### PR TITLE
Pops and other bits

### DIFF
--- a/src/openvic/GameManager.cpp
+++ b/src/openvic/GameManager.cpp
@@ -36,7 +36,7 @@ return_t GameManager::setup() {
 	clock.reset();
 	today = { 1836 };
 	good_manager.reset_to_defaults();
-	return_t ret = map.setup(good_manager, building_manager);
+	return_t ret = map.setup(good_manager, building_manager, pop_manager);
 	set_needs_update();
 	return ret;
 }

--- a/src/openvic/GameManager.hpp
+++ b/src/openvic/GameManager.hpp
@@ -11,6 +11,7 @@ namespace OpenVic {
 		Map map;
 		BuildingManager building_manager;
 		GoodManager good_manager;
+		PopManager pop_manager;
 		GameAdvancementHook clock;
 
 	private:

--- a/src/openvic/Types.hpp
+++ b/src/openvic/Types.hpp
@@ -64,7 +64,7 @@ namespace OpenVic {
 		const colour_t colour;
 
 	protected:
-		HasColour(colour_t const new_colour, bool can_be_null = false);
+		HasColour(colour_t const new_colour, bool can_be_null);
 
 	public:
 		HasColour(HasColour const&) = delete;

--- a/src/openvic/economy/Good.cpp
+++ b/src/openvic/economy/Good.cpp
@@ -50,8 +50,12 @@ return_t GoodManager::add_good(std::string const& identifier, std::string const&
 		Logger::error("Invalid good identifier - empty!");
 		return FAILURE;
 	}
+	if (colour > MAX_COLOUR_RGB) {
+		Logger::error("Invalid good colour for ", identifier, ": ", Good::colour_to_hex_string(colour));
+		return FAILURE;
+	}
 	if (category.empty()) {
-		Logger::error("Invalid good category - empty!");
+		Logger::error("Invalid good category for ", identifier, ": empty!");
 		return FAILURE;
 	}
 	if (base_price <= NULL_PRICE) {

--- a/src/openvic/map/Building.cpp
+++ b/src/openvic/map/Building.cpp
@@ -100,11 +100,11 @@ return_t BuildingManager::add_building_type(std::string const& identifier, Build
 		return FAILURE;
 	}
 	if (max_level < 0) {
-		Logger::error("Invalid building type max level: ", max_level);
+		Logger::error("Invalid building type max level for ", identifier, ": ", max_level);
 		return FAILURE;
 	}
 	if (build_time < 0) {
-		Logger::error("Invalid building type build time: ", build_time);
+		Logger::error("Invalid building type build time for ", identifier, ": ", build_time);
 		return FAILURE;
 	}
 	return building_types.add_item({ identifier, max_level, build_time });

--- a/src/openvic/map/Building.cpp
+++ b/src/openvic/map/Building.cpp
@@ -127,7 +127,7 @@ return_t BuildingManager::generate_province_buildings(Province& province) const 
 	if (province.is_water()) return SUCCESS;
 	return_t ret = SUCCESS;
 	for (BuildingType const& type : building_types.get_items())
-		if (province.add_building(type) != SUCCESS) ret = FAILURE;
+		if (province.add_building({ type }) != SUCCESS) ret = FAILURE;
 	province.lock_buildings();
 	return ret;
 }

--- a/src/openvic/map/Building.hpp
+++ b/src/openvic/map/Building.hpp
@@ -6,7 +6,8 @@
 #include "../Types.hpp"
 
 namespace OpenVic {
-	struct Province;
+
+	struct BuildingManager;
 	struct BuildingType;
 
 	/* REQUIREMENTS:
@@ -15,7 +16,7 @@ namespace OpenVic {
 	 * MAP-13, MAP-78, MAP-79
 	 */
 	struct Building : HasIdentifier {
-		friend struct Province;
+		friend struct BuildingManager;
 
 		using level_t = int8_t;
 
@@ -52,8 +53,6 @@ namespace OpenVic {
 		void tick(Date const& today);
 	};
 
-	struct BuildingManager;
-
 	struct BuildingType : HasIdentifier {
 		friend struct BuildingManager;
 
@@ -69,6 +68,8 @@ namespace OpenVic {
 		Building::level_t get_max_level() const;
 		Timespan get_build_time() const;
 	};
+
+	struct Province;
 
 	struct BuildingManager {
 	private:

--- a/src/openvic/map/Map.cpp
+++ b/src/openvic/map/Map.cpp
@@ -39,7 +39,7 @@ return_t Map::add_province(std::string const& identifier, colour_t colour) {
 		return FAILURE;
 	}
 	if (colour == NULL_COLOUR || colour > MAX_COLOUR_RGB) {
-		Logger::error("Invalid province colour: ", Province::colour_to_hex_string(colour));
+		Logger::error("Invalid province colour for ", identifier, ": ", Province::colour_to_hex_string(colour));
 		return FAILURE;
 	}
 	Province new_province { static_cast<index_t>(provinces.get_item_count() + 1), identifier, colour };
@@ -91,26 +91,26 @@ return_t Map::add_region(std::string const& identifier, std::vector<std::string>
 		Province* province = get_province_by_identifier(province_identifier);
 		if (province != nullptr) {
 			if (new_region.contains_province(province)) {
-				Logger::error("Duplicate province identifier ", province_identifier);
+				Logger::error("Duplicate province identifier ", province_identifier, " in region ", identifier);
 				ret = FAILURE;
 			} else {
 				size_t other_region_index = reinterpret_cast<size_t>(province->get_region());
 				if (other_region_index != 0) {
 					other_region_index--;
 					if (other_region_index < regions.get_item_count())
-						Logger::error("Province ", province_identifier, " is already part of ", regions.get_item_by_index(other_region_index)->get_identifier());
+						Logger::error("Cannot add province ", province_identifier, " to region ", identifier, " - it is already part of ", regions.get_item_by_index(other_region_index)->get_identifier());
 					else
-						Logger::error("Province ", province_identifier, " is already part of an unknown region with index ", other_region_index);
+						Logger::error("Cannot add province ", province_identifier, " to region ", identifier, " - it is already part of an unknown region with index ", other_region_index);
 					ret = FAILURE;
 				} else new_region.provinces.push_back(province);
 			}
 		} else {
-			Logger::error("Invalid province identifier ", province_identifier);
+			Logger::error("Invalid province identifier ", province_identifier, " for region ", identifier);
 			ret = FAILURE;
 		}
 	}
 	if (!new_region.get_province_count()) {
-		Logger::error("No valid provinces in region's list");
+		Logger::error("No valid provinces in list for ", identifier);
 		return FAILURE;
 	}
 

--- a/src/openvic/map/Map.hpp
+++ b/src/openvic/map/Map.hpp
@@ -54,6 +54,8 @@ namespace OpenVic {
 		colour_index_map_t colour_index_map;
 		index_t selected_province = NULL_INDEX;
 
+		Pop::pop_size_t highest_province_population, total_map_population;
+
 		index_t get_index_from_colour(colour_t colour) const;
 
 	public:
@@ -93,7 +95,12 @@ namespace OpenVic {
 		static constexpr size_t MAPMODE_COLOUR_SIZE = 4;
 		return_t generate_mapmode_colours(Mapmode::index_t index, uint8_t* target) const;
 
-		return_t setup(GoodManager const& good_manager, BuildingManager const& building_manager);
+		return_t setup(GoodManager const& good_manager, BuildingManager const& building_manager, PopManager const& pop_manager);
+
+		void update_highest_province_population();
+		Pop::pop_size_t get_highest_province_population() const;
+		void update_total_map_population();
+		Pop::pop_size_t get_total_map_population() const;
 
 		void update_state(Date const& today);
 		void tick(Date const& today);

--- a/src/openvic/map/Province.cpp
+++ b/src/openvic/map/Province.cpp
@@ -30,8 +30,8 @@ Province::life_rating_t Province::get_life_rating() const {
 	return life_rating;
 }
 
-return_t Province::add_building(BuildingType const& type) {
-	return buildings.add_item({ type });
+return_t Province::add_building(Building&& building) {
+	return buildings.add_item(std::move(building));
 }
 
 void Province::lock_buildings() {
@@ -66,9 +66,28 @@ std::string Province::to_string() const {
 	return stream.str();
 }
 
+void Province::add_pop(Pop&& pop) {
+	pops.push_back(std::move(pop));
+}
+
+/* REQUIREMENTS:
+ * MAP-65
+ */
+void Province::update_total_population() {
+	total_population = 0;
+	for (Pop const& pop : pops) {
+		total_population += pop.get_size();
+	}
+}
+
+Pop::pop_size_t Province::get_total_population() const {
+	return total_population;
+}
+
 void Province::update_state(Date const& today) {
 	for (Building& building : buildings.get_items())
 		building.update_state(today);
+	update_total_population();
 }
 
 void Province::tick(Date const& today) {

--- a/src/openvic/map/Province.cpp
+++ b/src/openvic/map/Province.cpp
@@ -8,7 +8,7 @@ using namespace OpenVic;
 
 Province::Province(index_t new_index, std::string const& new_identifier, colour_t new_colour)
 	: HasIdentifier { new_identifier },
-	  HasColour { new_colour },
+	  HasColour { new_colour, false },
 	  index { new_index },
 	  buildings { "buildings" } {
 	assert(index != NULL_INDEX);

--- a/src/openvic/map/Province.hpp
+++ b/src/openvic/map/Province.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../pop/Pop.hpp"
 #include "Building.hpp"
 
 namespace OpenVic {
@@ -24,6 +25,9 @@ namespace OpenVic {
 		// TODO - change this into a factory-like structure
 		Good const* rgo = nullptr;
 
+		std::vector<Pop> pops;
+		Pop::pop_size_t total_population;
+
 		Province(index_t new_index, std::string const& new_identifier, colour_t new_colour);
 
 	public:
@@ -33,7 +37,7 @@ namespace OpenVic {
 		Region* get_region() const;
 		bool is_water() const;
 		life_rating_t get_life_rating() const;
-		return_t add_building(BuildingType const& type);
+		return_t add_building(Building&& building);
 		void lock_buildings();
 		void reset_buildings();
 		Building const* get_building_by_identifier(std::string const& identifier) const;
@@ -41,6 +45,10 @@ namespace OpenVic {
 		return_t expand_building(std::string const& building_type_identifier);
 		Good const* get_rgo() const;
 		std::string to_string() const;
+
+		void add_pop(Pop&& pop);
+		void update_total_population();
+		Pop::pop_size_t get_total_population() const;
 
 		void update_state(Date const& today);
 		void tick(Date const& today);

--- a/src/openvic/pop/Culture.cpp
+++ b/src/openvic/pop/Culture.cpp
@@ -49,7 +49,7 @@ GraphicalCultureType const* CultureManager::get_graphical_culture_type_by_identi
 	return graphical_culture_types.get_item_by_identifier(identifier);
 }
 
-return_t CultureManager::add_culture_group(std::string const& identifier, GraphicalCultureType const& graphical_culture_type) {
+return_t CultureManager::add_culture_group(std::string const& identifier, GraphicalCultureType const* graphical_culture_type) {
 	if (!graphical_culture_types.is_locked()) {
 		Logger::error("Cannot register culture groups until graphical culture types are locked!");
 		return FAILURE;
@@ -58,7 +58,11 @@ return_t CultureManager::add_culture_group(std::string const& identifier, Graphi
 		Logger::error("Invalid culture group identifier - empty!");
 		return FAILURE;
 	}
-	return culture_groups.add_item({ identifier, graphical_culture_type });
+	if (graphical_culture_type == nullptr) {
+		Logger::error("Null graphical culture type for ", identifier);
+		return FAILURE;
+	}
+	return culture_groups.add_item({ identifier, *graphical_culture_type });
 }
 
 void CultureManager::lock_culture_groups() {
@@ -69,7 +73,7 @@ CultureGroup const* CultureManager::get_culture_group_by_identifier(std::string 
 	return culture_groups.get_item_by_identifier(identifier);
 }
 
-return_t CultureManager::add_culture(CultureGroup const* group, std::string const& identifier, colour_t colour, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names) {
+return_t CultureManager::add_culture(std::string const& identifier, colour_t colour, CultureGroup const* group, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names) {
 	if (!culture_groups.is_locked()) {
 		Logger::error("Cannot register cultures until culture groups are locked!");
 		return FAILURE;

--- a/src/openvic/pop/Culture.cpp
+++ b/src/openvic/pop/Culture.cpp
@@ -1,0 +1,99 @@
+#include "Culture.hpp"
+
+#include <cassert>
+
+using namespace OpenVic;
+
+GraphicalCultureType::GraphicalCultureType(std::string const& new_identifier) : HasIdentifier { new_identifier } {}
+
+CultureGroup::CultureGroup(std::string const& new_identifier,
+	GraphicalCultureType const& new_unit_graphical_culture_type)
+	: HasIdentifier { new_identifier },
+	  unit_graphical_culture_type { new_unit_graphical_culture_type } {}
+
+GraphicalCultureType const& CultureGroup::get_unit_graphical_culture_type() const {
+	return unit_graphical_culture_type;
+}
+
+Culture::Culture(CultureGroup const& new_group, std::string const& new_identifier,
+	colour_t new_colour, name_list_t const& new_first_names, name_list_t const& new_last_names)
+	: group { new_group },
+	  HasIdentifier { new_identifier },
+	  HasColour { new_colour, true },
+	  first_names { new_first_names },
+	  last_names { new_last_names } {
+}
+
+CultureGroup const& Culture::get_group() const {
+	return group;
+}
+
+CultureManager::CultureManager()
+	: graphical_culture_types { "graphical culture types" },
+	  culture_groups { "culture groups" },
+	  cultures { "cultures" } {}
+
+return_t CultureManager::add_graphical_culture_type(std::string const& identifier) {
+	if (identifier.empty()) {
+		Logger::error("Invalid culture group identifier - empty!");
+		return FAILURE;
+	}
+	return graphical_culture_types.add_item({ identifier });
+}
+
+void CultureManager::lock_graphical_culture_types() {
+	graphical_culture_types.lock();
+}
+
+GraphicalCultureType const* CultureManager::get_graphical_culture_type_by_identifier(std::string const& identifier) const {
+	return graphical_culture_types.get_item_by_identifier(identifier);
+}
+
+return_t CultureManager::add_culture_group(std::string const& identifier, GraphicalCultureType const& graphical_culture_type) {
+	if (!graphical_culture_types.is_locked()) {
+		Logger::error("Cannot register culture groups until graphical culture types are locked!");
+		return FAILURE;
+	}
+	if (identifier.empty()) {
+		Logger::error("Invalid culture group identifier - empty!");
+		return FAILURE;
+	}
+	return culture_groups.add_item({ identifier, graphical_culture_type });
+}
+
+void CultureManager::lock_culture_groups() {
+	culture_groups.lock();
+}
+
+CultureGroup const* CultureManager::get_culture_group_by_identifier(std::string const& identifier) const {
+	return culture_groups.get_item_by_identifier(identifier);
+}
+
+return_t CultureManager::add_culture(CultureGroup const* group, std::string const& identifier, colour_t colour, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names) {
+	if (!culture_groups.is_locked()) {
+		Logger::error("Cannot register cultures until culture groups are locked!");
+		return FAILURE;
+	}
+	if (identifier.empty()) {
+		Logger::error("Invalid culture identifier - empty!");
+		return FAILURE;
+	}
+	if (group == nullptr) {
+		Logger::error("Null culture group for ", identifier);
+		return FAILURE;
+	}
+	if (colour > MAX_COLOUR_RGB) {
+		Logger::error("Invalid culture colour for ", identifier, ": ", Culture::colour_to_hex_string(colour));
+		return FAILURE;
+	}
+	// TODO - name list sanatisation?
+	return cultures.add_item({ *group, identifier, colour, first_names, last_names });
+}
+
+void CultureManager::lock_cultures() {
+	cultures.lock();
+}
+
+Culture const* CultureManager::get_culture_by_identifier(std::string const& identifier) const {
+	return cultures.get_item_by_identifier(identifier);
+}

--- a/src/openvic/pop/Culture.hpp
+++ b/src/openvic/pop/Culture.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "../Types.hpp"
+
+namespace OpenVic {
+
+	struct CultureManager;
+
+	struct GraphicalCultureType : HasIdentifier {
+		friend struct CultureManager;
+
+	private:
+		GraphicalCultureType(std::string const& new_identifier);
+
+	public:
+		GraphicalCultureType(GraphicalCultureType&&) = default;
+	};
+
+	struct CultureGroup : HasIdentifier {
+		friend struct CultureManager;
+
+	private:
+		GraphicalCultureType const& unit_graphical_culture_type;
+
+		// TODO - leader type, union tag
+
+		CultureGroup(std::string const& new_identifier, GraphicalCultureType const& new_unit_graphical_culture_type);
+
+	public:
+		CultureGroup(CultureGroup&&) = default;
+
+		GraphicalCultureType const& get_unit_graphical_culture_type() const;
+	};
+
+	struct Culture : HasIdentifier, HasColour {
+		friend struct CultureManager;
+
+		using name_list_t = std::vector<std::string>;
+
+	private:
+		CultureGroup const& group;
+		const name_list_t first_names, last_names;
+
+		// TODO - radicalism, primary tag
+
+		Culture(CultureGroup const& new_group, std::string const& new_identifier, colour_t new_colour, name_list_t const& new_first_names, name_list_t const& new_last_names);
+
+	public:
+		Culture(Culture&&) = default;
+
+		CultureGroup const& get_group() const;
+	};
+
+	struct CultureManager {
+	private:
+		IdentifierRegistry<GraphicalCultureType> graphical_culture_types;
+		IdentifierRegistry<CultureGroup> culture_groups;
+		IdentifierRegistry<Culture> cultures;
+
+	public:
+		CultureManager();
+
+		return_t add_graphical_culture_type(std::string const& identifier);
+		void lock_graphical_culture_types();
+		GraphicalCultureType const* get_graphical_culture_type_by_identifier(std::string const& identifier) const;
+		return_t add_culture_group(std::string const& identifier, GraphicalCultureType const& new_graphical_culture_type);
+		void lock_culture_groups();
+		CultureGroup const* get_culture_group_by_identifier(std::string const& identifier) const;
+		return_t add_culture(CultureGroup const* group, std::string const& identifier, colour_t colour, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names);
+		void lock_cultures();
+		Culture const* get_culture_by_identifier(std::string const& identifier) const;
+	};
+}

--- a/src/openvic/pop/Culture.hpp
+++ b/src/openvic/pop/Culture.hpp
@@ -63,10 +63,10 @@ namespace OpenVic {
 		return_t add_graphical_culture_type(std::string const& identifier);
 		void lock_graphical_culture_types();
 		GraphicalCultureType const* get_graphical_culture_type_by_identifier(std::string const& identifier) const;
-		return_t add_culture_group(std::string const& identifier, GraphicalCultureType const& new_graphical_culture_type);
+		return_t add_culture_group(std::string const& identifier, GraphicalCultureType const* new_graphical_culture_type);
 		void lock_culture_groups();
 		CultureGroup const* get_culture_group_by_identifier(std::string const& identifier) const;
-		return_t add_culture(CultureGroup const* group, std::string const& identifier, colour_t colour, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names);
+		return_t add_culture(std::string const& identifier, colour_t colour, CultureGroup const* group, Culture::name_list_t const& first_names, Culture::name_list_t const& last_names);
 		void lock_cultures();
 		Culture const* get_culture_by_identifier(std::string const& identifier) const;
 	};

--- a/src/openvic/pop/Pop.cpp
+++ b/src/openvic/pop/Pop.cpp
@@ -1,0 +1,99 @@
+#include "Pop.hpp"
+
+#include <cassert>
+
+#include "../utility/Logger.hpp"
+
+using namespace OpenVic;
+
+Pop::Pop(PopType const& new_type, Religion const& new_religion)
+	: type { new_type }, religion { new_religion }, size { 1 } {
+	assert(size > 0);
+}
+
+PopType const& Pop::get_type() const {
+	return type;
+}
+
+Religion const& Pop::get_religion() const {
+	return religion;
+}
+
+Pop::pop_size_t Pop::get_size() const {
+	return size;
+}
+
+PopType::PopType(std::string const& new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite,
+	Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
+	bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan)
+	: HasIdentifier { new_identifier },
+	  HasColour { new_colour, true },
+	  strata { new_strata },
+	  sprite { new_sprite },
+	  max_size { new_max_size },
+	  merge_max_size { new_merge_max_size },
+	  state_capital_only { new_state_capital_only },
+	  demote_migrant { new_demote_migrant },
+	  is_artisan { new_is_artisan } {
+	assert(sprite > 0);
+	assert(max_size > 0);
+	assert(merge_max_size > 0);
+}
+
+PopType::sprite_t PopType::get_sprite() const {
+	return sprite;
+}
+
+Pop::pop_size_t PopType::get_max_size() const {
+	return max_size;
+}
+
+Pop::pop_size_t PopType::get_merge_max_size() const {
+	return merge_max_size;
+}
+
+bool PopType::get_state_capital_only() const {
+	return state_capital_only;
+}
+
+bool PopType::get_demote_migrant() const {
+	return demote_migrant;
+}
+
+bool PopType::get_is_artisan() const {
+	return is_artisan;
+}
+
+PopTypeManager::PopTypeManager() : pop_types { "pop types" } {}
+
+return_t PopTypeManager::add_pop_type(std::string const& identifier, colour_t colour, PopType::strata_t strata, PopType::sprite_t sprite, Pop::pop_size_t max_size, Pop::pop_size_t merge_max_size, bool state_capital_only, bool demote_migrant, bool is_artisan) {
+	if (identifier.empty()) {
+		Logger::error("Invalid pop type identifier - empty!");
+		return FAILURE;
+	}
+	if (colour > MAX_COLOUR_RGB) {
+		Logger::error("Invalid pop type colour for ", identifier, ": ", PopType::colour_to_hex_string(colour));
+		return FAILURE;
+	}
+	if (sprite <= 0) {
+		Logger::error("Invalid pop type sprite index for ", identifier, ": ", sprite);
+		return FAILURE;
+	}
+	if (max_size <= 0) {
+		Logger::error("Invalid pop type max size for ", identifier, ": ", max_size);
+		return FAILURE;
+	}
+	if (merge_max_size <= 0) {
+		Logger::error("Invalid pop type merge max size for ", identifier, ": ", merge_max_size);
+		return FAILURE;
+	}
+	return pop_types.add_item({ identifier, colour, strata, sprite, max_size, merge_max_size, state_capital_only, demote_migrant, is_artisan });
+}
+
+void PopTypeManager::lock_pop_types() {
+	pop_types.lock();
+}
+
+PopType const* PopTypeManager::get_pop_type_by_identifier(std::string const& identifier) const {
+	return pop_types.get_item_by_identifier(identifier);
+}

--- a/src/openvic/pop/Pop.cpp
+++ b/src/openvic/pop/Pop.cpp
@@ -6,13 +6,20 @@
 
 using namespace OpenVic;
 
-Pop::Pop(PopType const& new_type, Religion const& new_religion)
-	: type { new_type }, religion { new_religion }, size { 1 } {
+Pop::Pop(PopType const& new_type, Culture const& new_culture, Religion const& new_religion)
+	: type { new_type },
+	  culture { new_culture },
+	  religion { new_religion },
+	  size { 1 } {
 	assert(size > 0);
 }
 
 PopType const& Pop::get_type() const {
 	return type;
+}
+
+Culture const& Pop::get_culture() const {
+	return culture;
 }
 
 Religion const& Pop::get_religion() const {
@@ -23,7 +30,8 @@ Pop::pop_size_t Pop::get_size() const {
 	return size;
 }
 
-PopType::PopType(std::string const& new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite,
+PopType::PopType(std::string const& new_identifier, colour_t new_colour,
+	strata_t new_strata, sprite_t new_sprite,
 	Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
 	bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan)
 	: HasIdentifier { new_identifier },

--- a/src/openvic/pop/Pop.hpp
+++ b/src/openvic/pop/Pop.hpp
@@ -1,17 +1,19 @@
 #pragma once
 
 #include "../Types.hpp"
+#include "Culture.hpp"
+#include "Religion.hpp"
 
 namespace OpenVic {
 
+	struct PopManager;
 	struct PopType;
-	struct Culture;
-	struct Religion;
 
 	/* REQUIREMENTS:
-	 * POP-18, POP-19, POP-21
+	 * POP-18, POP-19, POP-20, POP-21
 	 */
 	struct Pop {
+		friend struct PopManager;
 
 		using pop_size_t = uint32_t;
 
@@ -21,7 +23,7 @@ namespace OpenVic {
 		Religion const& religion;
 		pop_size_t size;
 
-		Pop(PopType const& new_type, Culture const& new_culture, Religion const& new_religion);
+		Pop(PopType const& new_type, Culture const& new_culture, Religion const& new_religion, pop_size_t new_size);
 
 	public:
 		Pop(Pop const&) = delete;
@@ -35,13 +37,11 @@ namespace OpenVic {
 		pop_size_t get_size() const;
 	};
 
-	struct PopTypeManager;
-
 	/* REQUIREMENTS:
 	 * POP-26
 	 */
 	struct PopType : HasIdentifier, HasColour {
-		friend struct PopTypeManager;
+		friend struct PopManager;
 
 		using sprite_t = uint8_t;
 
@@ -53,11 +53,12 @@ namespace OpenVic {
 		} strata;
 		const sprite_t sprite;
 		const Pop::pop_size_t max_size, merge_max_size;
-		const bool state_capital_only, demote_migrant, is_artisan;
+		const bool state_capital_only, demote_migrant, is_artisan, is_slave;
 
 		// TODO - rebel composition, life/everyday/luxury needs, country and province migration targets, promote_to targets, ideologies and issues
 
-		PopType(std::string const& new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size, bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan);
+		PopType(std::string const& new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
+			bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan, bool new_is_slave);
 
 	public:
 		PopType(PopType&&) = default;
@@ -68,17 +69,26 @@ namespace OpenVic {
 		bool get_state_capital_only() const;
 		bool get_demote_migrant() const;
 		bool get_is_artisan() const;
+		bool get_is_slave() const;
 	};
 
-	struct PopTypeManager {
+	struct Province;
+
+	struct PopManager {
 	private:
 		IdentifierRegistry<PopType> pop_types;
+		CultureManager culture_manager;
+		ReligionManager religion_manager;
 
 	public:
-		PopTypeManager();
+		PopManager();
 
-		return_t add_pop_type(std::string const& identifier, colour_t new_colour, PopType::strata_t new_strata, PopType::sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size, bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan);
+		return_t add_pop_type(std::string const& identifier, colour_t new_colour, PopType::strata_t strata, PopType::sprite_t sprite,
+			Pop::pop_size_t max_size, Pop::pop_size_t merge_max_size, bool state_capital_only, bool demote_migrant,
+			bool is_artisan, bool is_slave);
 		void lock_pop_types();
 		PopType const* get_pop_type_by_identifier(std::string const& identifier) const;
+
+		void generate_test_pops(Province& province) const;
 	};
 }

--- a/src/openvic/pop/Pop.hpp
+++ b/src/openvic/pop/Pop.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "../Types.hpp"
+
+namespace OpenVic {
+
+	struct PopType;
+	struct Religion;
+
+	/* REQUIREMENTS:
+	 * POP-18, POP-19, POP-21
+	 */
+	struct Pop {
+
+		using pop_size_t = uint32_t;
+
+	private:
+		PopType const& type;
+		Religion const& religion;
+		pop_size_t size;
+
+		Pop(PopType const& new_type, Religion const& new_religion);
+
+	public:
+		Pop(Pop const&) = delete;
+		Pop(Pop&&) = default;
+		Pop& operator=(Pop const&) = delete;
+		Pop& operator=(Pop&&) = delete;
+
+		PopType const& get_type() const;
+		Religion const& get_religion() const;
+		pop_size_t get_size() const;
+	};
+
+	struct PopTypeManager;
+
+	/* REQUIREMENTS:
+	 * POP-26
+	 */
+	struct PopType : HasIdentifier, HasColour {
+		friend struct PopTypeManager;
+
+		using sprite_t = uint8_t;
+
+	private:
+		const enum class strata_t {
+			POOR,
+			MIDDLE,
+			RICH
+		} strata;
+		const sprite_t sprite;
+		const Pop::pop_size_t max_size, merge_max_size;
+		const bool state_capital_only, demote_migrant, is_artisan;
+
+		// TODO - rebel composition, life/everyday/luxury needs, country and province migration targets, promote_to targets, ideologies and issues
+
+		PopType(std::string const& new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size, bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan);
+
+	public:
+		PopType(PopType&&) = default;
+
+		sprite_t get_sprite() const;
+		Pop::pop_size_t get_max_size() const;
+		Pop::pop_size_t get_merge_max_size() const;
+		bool get_state_capital_only() const;
+		bool get_demote_migrant() const;
+		bool get_is_artisan() const;
+	};
+
+	struct PopTypeManager {
+	private:
+		IdentifierRegistry<PopType> pop_types;
+
+	public:
+		PopTypeManager();
+
+		return_t add_pop_type(std::string const& identifier, colour_t new_colour, PopType::strata_t new_strata, PopType::sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size, bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan);
+		void lock_pop_types();
+		PopType const* get_pop_type_by_identifier(std::string const& identifier) const;
+	};
+}

--- a/src/openvic/pop/Pop.hpp
+++ b/src/openvic/pop/Pop.hpp
@@ -5,6 +5,7 @@
 namespace OpenVic {
 
 	struct PopType;
+	struct Culture;
 	struct Religion;
 
 	/* REQUIREMENTS:
@@ -16,10 +17,11 @@ namespace OpenVic {
 
 	private:
 		PopType const& type;
+		Culture const& culture;
 		Religion const& religion;
 		pop_size_t size;
 
-		Pop(PopType const& new_type, Religion const& new_religion);
+		Pop(PopType const& new_type, Culture const& new_culture, Religion const& new_religion);
 
 	public:
 		Pop(Pop const&) = delete;
@@ -28,6 +30,7 @@ namespace OpenVic {
 		Pop& operator=(Pop&&) = delete;
 
 		PopType const& get_type() const;
+		Culture const& get_culture() const;
 		Religion const& get_religion() const;
 		pop_size_t get_size() const;
 	};

--- a/src/openvic/pop/Religion.cpp
+++ b/src/openvic/pop/Religion.cpp
@@ -48,7 +48,7 @@ ReligionGroup const* ReligionManager::get_religion_group_by_identifier(std::stri
 	return religion_groups.get_item_by_identifier(identifier);
 }
 
-return_t ReligionManager::add_religion(ReligionGroup const* group, std::string const& identifier, colour_t colour, Religion::icon_t icon, bool pagan) {
+return_t ReligionManager::add_religion(std::string const& identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan) {
 	if (!religion_groups.is_locked()) {
 		Logger::error("Cannot register religions until religion groups are locked!");
 		return FAILURE;

--- a/src/openvic/pop/Religion.cpp
+++ b/src/openvic/pop/Religion.cpp
@@ -34,7 +34,7 @@ ReligionManager::ReligionManager()
 
 return_t ReligionManager::add_religion_group(std::string const& identifier) {
 	if (identifier.empty()) {
-		Logger::error("Invalid relgion group identifier - empty!");
+		Logger::error("Invalid religion group identifier - empty!");
 		return FAILURE;
 	}
 	return religion_groups.add_item({ identifier });
@@ -72,7 +72,7 @@ return_t ReligionManager::add_religion(ReligionGroup const* group, std::string c
 	return religions.add_item({ *group, identifier, colour, icon, pagan });
 }
 
-void ReligionManager::lock_religion() {
+void ReligionManager::lock_religions() {
 	religions.lock();
 }
 

--- a/src/openvic/pop/Religion.cpp
+++ b/src/openvic/pop/Religion.cpp
@@ -1,0 +1,81 @@
+#include "Religion.hpp"
+
+#include <cassert>
+
+using namespace OpenVic;
+
+ReligionGroup::ReligionGroup(std::string const& new_identifier) : HasIdentifier { new_identifier } {}
+
+Religion::Religion(ReligionGroup const& new_group, std::string const& new_identifier,
+	colour_t new_colour, icon_t new_icon, bool new_pagan)
+	: group { new_group },
+	  HasIdentifier { new_identifier },
+	  HasColour { new_colour, true },
+	  icon { new_icon },
+	  pagan { new_pagan } {
+	assert(icon > 0);
+}
+
+ReligionGroup const& Religion::get_group() const {
+	return group;
+}
+
+Religion::icon_t Religion::get_icon() const {
+	return icon;
+}
+
+bool Religion::get_pagan() const {
+	return pagan;
+}
+
+ReligionManager::ReligionManager()
+	: religion_groups { "religion groups" },
+	  religions { "religions" } {}
+
+return_t ReligionManager::add_religion_group(std::string const& identifier) {
+	if (identifier.empty()) {
+		Logger::error("Invalid relgion group identifier - empty!");
+		return FAILURE;
+	}
+	return religion_groups.add_item({ identifier });
+}
+
+void ReligionManager::lock_religion_groups() {
+	religion_groups.lock();
+}
+
+ReligionGroup const* ReligionManager::get_religion_group_by_identifier(std::string const& identifier) const {
+	return religion_groups.get_item_by_identifier(identifier);
+}
+
+return_t ReligionManager::add_religion(ReligionGroup const* group, std::string const& identifier, colour_t colour, Religion::icon_t icon, bool pagan) {
+	if (!religion_groups.is_locked()) {
+		Logger::error("Cannot register religions until religion groups are locked!");
+		return FAILURE;
+	}
+	if (identifier.empty()) {
+		Logger::error("Invalid religion identifier - empty!");
+		return FAILURE;
+	}
+	if (group == nullptr) {
+		Logger::error("Null religion group for ", identifier);
+		return FAILURE;
+	}
+	if (colour > MAX_COLOUR_RGB) {
+		Logger::error("Invalid religion colour for ", identifier, ": ", Religion::colour_to_hex_string(colour));
+		return FAILURE;
+	}
+	if (icon <= 0) {
+		Logger::error("Invalid religion icon for ", identifier, ": ", icon);
+		return FAILURE;
+	}
+	return religions.add_item({ *group, identifier, colour, icon, pagan });
+}
+
+void ReligionManager::lock_religion() {
+	religions.lock();
+}
+
+Religion const* ReligionManager::get_religion_by_identifier(std::string const& identifier) const {
+	return religions.get_item_by_identifier(identifier);
+}

--- a/src/openvic/pop/Religion.hpp
+++ b/src/openvic/pop/Religion.hpp
@@ -47,7 +47,7 @@ namespace OpenVic {
 		return_t add_religion_group(std::string const& identifier);
 		void lock_religion_groups();
 		ReligionGroup const* get_religion_group_by_identifier(std::string const& identifier) const;
-		return_t add_religion(ReligionGroup const* group, std::string const& identifier, colour_t colour, Religion::icon_t icon, bool pagan);
+		return_t add_religion(std::string const& identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan);
 		void lock_religions();
 		Religion const* get_religion_by_identifier(std::string const& identifier) const;
 	};

--- a/src/openvic/pop/Religion.hpp
+++ b/src/openvic/pop/Religion.hpp
@@ -48,7 +48,7 @@ namespace OpenVic {
 		void lock_religion_groups();
 		ReligionGroup const* get_religion_group_by_identifier(std::string const& identifier) const;
 		return_t add_religion(ReligionGroup const* group, std::string const& identifier, colour_t colour, Religion::icon_t icon, bool pagan);
-		void lock_religion();
+		void lock_religions();
 		Religion const* get_religion_by_identifier(std::string const& identifier) const;
 	};
 }

--- a/src/openvic/pop/Religion.hpp
+++ b/src/openvic/pop/Religion.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../Types.hpp"
+
+namespace OpenVic {
+
+	struct ReligionManager;
+
+	struct ReligionGroup : HasIdentifier {
+		friend struct ReligionManager;
+
+	private:
+		ReligionGroup(std::string const& new_identifier);
+
+	public:
+		ReligionGroup(ReligionGroup&&) = default;
+	};
+
+	struct Religion : HasIdentifier, HasColour {
+		friend struct ReligionManager;
+
+		using icon_t = uint8_t;
+
+	private:
+		ReligionGroup const& group;
+		const icon_t icon;
+		const bool pagan;
+
+		Religion(ReligionGroup const& new_group, std::string const& new_identifier, colour_t new_colour, icon_t new_icon, bool new_pagan);
+
+	public:
+		Religion(Religion&&) = default;
+
+		ReligionGroup const& get_group() const;
+		icon_t get_icon() const;
+		bool get_pagan() const;
+	};
+
+	struct ReligionManager {
+	private:
+		IdentifierRegistry<ReligionGroup> religion_groups;
+		IdentifierRegistry<Religion> religions;
+
+	public:
+		ReligionManager();
+
+		return_t add_religion_group(std::string const& identifier);
+		void lock_religion_groups();
+		ReligionGroup const* get_religion_group_by_identifier(std::string const& identifier) const;
+		return_t add_religion(ReligionGroup const* group, std::string const& identifier, colour_t colour, Religion::icon_t icon, bool pagan);
+		void lock_religion();
+		Religion const* get_religion_by_identifier(std::string const& identifier) const;
+	};
+}


### PR DESCRIPTION
Data structures and managers for:
- Pop, PopType
- Religion, ReligionGroup
- Culture, Culture Group, GraphicalCultureType

Provinces have an internal Pop list, currently filled with hardcoded test Pops. Provinces keep track of their total population, and the map keeps track of its total population and the highest individual province population (which will be used in the Population Density mapmode).

Requirements implemented:
- POP-18, POP-19, POP-20, POP-21, POP-26
- MAP-65