### PR TITLE
Scaffolding for `positions.txt` + modifier loading

### DIFF
--- a/src/openvic-simulation/Modifier.hpp
+++ b/src/openvic-simulation/Modifier.hpp
@@ -25,6 +25,8 @@ namespace OpenVic {
 	};
 
 	struct ModifierValue {
+		friend struct ModifierManager;
+
 		using effect_map_t = std::map<ModifierEffect const*, fixed_point_t>;
 	private:
 		effect_map_t values;
@@ -57,6 +59,7 @@ namespace OpenVic {
 		using icon_t = uint8_t;
 
 	private:
+		/* A modifier can have no icon (zero). */
 		const icon_t icon;
 
 		Modifier(const std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon);
@@ -92,5 +95,7 @@ namespace OpenVic {
 
 		bool add_modifier(const std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
 		IDENTIFIER_REGISTRY_ACCESSORS(Modifier, modifier)
+
+		NodeTools::node_callback_t expect_modifier_value(NodeTools::callback_t<ModifierValue&&> callback) const;
 	};
 }

--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -4,6 +4,8 @@
 #include <functional>
 #include <vector>
 
+#include "openvic-simulation/dataloader/NodeTools.hpp"
+
 namespace OpenVic {
 	namespace fs = std::filesystem;
 
@@ -33,7 +35,7 @@ namespace OpenVic {
 		fs::path lookup_file(fs::path const& path) const;
 		path_vector_t lookup_files_in_dir(fs::path const& path, fs::path const& extension) const;
 		bool apply_to_files_in_dir(fs::path const& path, fs::path const& extension,
-			std::function<bool(fs::path const&)> callback) const;
+			NodeTools::callback_t<fs::path const&> callback) const;
 
 		bool load_defines(GameManager& game_manager) const;
 		bool load_pop_history(GameManager& game_manager, fs::path const& path) const;
@@ -46,7 +48,7 @@ namespace OpenVic {
 		};
 
 		/* Args: key, locale, localisation */
-		using localisation_callback_t = std::function<bool(std::string_view, locale_t, std::string_view)>;
+		using localisation_callback_t = NodeTools::callback_t<std::string_view, locale_t, std::string_view>;
 		bool load_localisation_files(localisation_callback_t callback, fs::path const& localisation_dir = "localisation");
 	};
 }

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -20,6 +20,7 @@ namespace OpenVic {
 		constexpr bool success_callback(ast::NodeCPtr) { return true; }
 
 		using key_value_callback_t = callback_t<std::string_view, ast::NodeCPtr>;
+		constexpr bool key_value_success_callback(std::string_view, ast::NodeCPtr) { return true; }
 
 		node_callback_t expect_identifier(callback_t<std::string_view> callback);
 		node_callback_t expect_string(callback_t<std::string_view> callback);

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -112,7 +112,9 @@ namespace OpenVic {
 		void update_state(Date const& today);
 		void tick(Date const& today);
 
+		NodeTools::node_callback_t expect_province_dictionary(NodeTools::callback_t<Province&, ast::NodeCPtr> callback);
 		bool load_province_definitions(std::vector<ovdl::csv::LineObject> const& lines);
+		bool load_province_positions(ast::NodeCPtr root);
 		bool load_region_file(ast::NodeCPtr root);
 	};
 }

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -34,6 +34,12 @@ Province::life_rating_t Province::get_life_rating() const {
 	return life_rating;
 }
 
+bool Province::load_positions(ast::NodeCPtr root) {
+	// TODO - implement province position loading
+	// (root is the dictionary after the province identifier)
+	return true;
+}
+
 bool Province::add_building(Building&& building) {
 	return buildings.add_item(std::move(building));
 }

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -43,6 +43,8 @@ namespace OpenVic {
 		bool get_has_region() const;
 		bool get_water() const;
 		life_rating_t get_life_rating() const;
+		bool load_positions(ast::NodeCPtr root);
+
 		bool add_building(Building&& building);
 		IDENTIFIER_REGISTRY_ACCESSORS(Building, building)
 		void reset_buildings();

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -1,5 +1,7 @@
 #include "Culture.hpp"
 
+#include <set>
+
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 
 using namespace OpenVic;
@@ -128,7 +130,7 @@ bool CultureManager::_load_culture_group(size_t& total_expected_cultures,
 		},
 		"unit", ZERO_OR_ONE, [this, &total_expected_cultures, &unit_graphical_culture_type](ast::NodeCPtr node) -> bool {
 			total_expected_cultures--;
-			return expect_graphical_culture_type(unit_graphical_culture_type)(node);
+			return expect_graphical_culture_type_identifier(unit_graphical_culture_type)(node);
 		},
 		"union", ZERO_OR_ONE, [&total_expected_cultures](ast::NodeCPtr) -> bool {
 			total_expected_cultures--;
@@ -207,7 +209,10 @@ bool CultureManager::load_culture_file(ast::NodeCPtr root) {
 			CultureGroup const* culture_group = get_culture_group_by_identifier(culture_group_key);
 			return expect_dictionary(
 				[this, culture_group](std::string_view key, ast::NodeCPtr value) -> bool {
-					if (key == "leader" || key == "unit" || key == "union" || key == "is_overseas") return true;
+					static const std::set<std::string, std::less<void>> reserved_keys = {
+						"leader", "unit", "union", "is_overseas"
+					};
+					if (reserved_keys.find(key) != reserved_keys.end()) return true;
 					return _load_culture(culture_group, key, value);
 				}
 			)(culture_group_value);

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -142,8 +142,8 @@ bool PopManager::load_pop_into_province(Province& province, const std::string_vi
 	Pop::pop_size_t size = 0;
 
 	bool ret = expect_dictionary_keys(
-		"culture", ONE_EXACTLY, culture_manager.expect_culture(culture),
-		"religion", ONE_EXACTLY, religion_manager.expect_religion(religion),
+		"culture", ONE_EXACTLY, culture_manager.expect_culture_identifier(culture),
+		"religion", ONE_EXACTLY, religion_manager.expect_religion_identifier(religion),
 		"size", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("pop size", size)),
 		"militancy", ZERO_OR_ONE, success_callback,
 		"rebel_type", ZERO_OR_ONE, success_callback

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -171,7 +171,7 @@ namespace OpenVic {
 			return items;
 		}
 
-		NodeTools::node_callback_t expect_item(T const*& ret) const {
+		NodeTools::node_callback_t expect_item_identifier(T const*& ret) const {
 			return NodeTools::expect_identifier(
 				[this, &ret](std::string_view identifier) -> bool {
 					ret = get_item_by_identifier(identifier);
@@ -193,8 +193,8 @@ namespace OpenVic {
 		return plural.size(); } \
 	std::vector<type> const& get_##plural() const { \
 		return plural.get_items(); } \
-	NodeTools::node_callback_t expect_##singular(type const*& ret) const { \
-		return plural.expect_item(ret); }
+	NodeTools::node_callback_t expect_##singular##_identifier(type const*& ret) const { \
+		return plural.expect_item_identifier(ret); }
 
 #define IDENTIFIER_REGISTRY_ACCESSORS(type, name) IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(type, name, name##s)
 }

--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -27,6 +27,7 @@ namespace OpenVic {
 		constexpr friend vec2_t operator-(vec2_t const& arg);
 		constexpr friend vec2_t operator-(vec2_t const& left, vec2_t const& right);
 		constexpr vec2_t& operator-=(vec2_t const& right);
+
 		constexpr friend std::ostream& operator<<(std::ostream& stream, vec2_t const& value);
 	};
 


### PR DESCRIPTION
- Basic `ModifierValue` parsing function.
- Added scaffolding for `positions.txt` loading, including turning the file in a `Node` tree, reading and looking up the province identifier keys, and passing the key's dictionary to `province.load_positions`.
- Added `expect_province_dictionary` to load defines of the form `province_a = { ... } province_b = { ... }`, currently used for loading pop history and `positions.txt`.
- Culture loading reserved keys are now looked up in a `std::set` rather than through `if (key == "reserved_key || ...)`.