### PR TITLE
Fixing compile-time warnings

### DIFF
--- a/src/openvic-simulation/Modifier.cpp
+++ b/src/openvic-simulation/Modifier.cpp
@@ -71,19 +71,14 @@ ModifierValue ModifierValue::operator-(ModifierValue const& right) const {
 	return ret -= right;
 }
 
-std::ostream& OpenVic::operator<<(std::ostream& stream, ModifierValue const& value) {
-	for (ModifierValue::effect_map_t::value_type const& effect : value.values) {
-		stream << effect.first << ": " << effect.second << "\n";
-	}
-	return stream;
-}
-
 Modifier::Modifier(const std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon)
 	: HasIdentifier { new_identifier }, ModifierValue { std::move(new_values) }, icon { new_icon } {}
 
 Modifier::icon_t Modifier::get_icon() const {
 	return icon;
 }
+
+ModifierInstance::ModifierInstance(Modifier const& modifier, Date expiry_date) : modifier { modifier }, expiry_date { expiry_date } {}
 
 Modifier const& ModifierInstance::get_modifier() const {
 	return modifier;
@@ -134,4 +129,13 @@ node_callback_t ModifierManager::expect_modifier_value(callback_t<ModifierValue&
 		ret &= callback(std::move(modifier));
 		return ret;
 	};
+}
+
+namespace OpenVic { //so the compiler shuts up
+	std::ostream& operator<<(std::ostream& stream, ModifierValue const& value) {
+		for (ModifierValue::effect_map_t::value_type const& effect : value.values) {
+			stream << effect.first << ": " << effect.second << "\n";
+		}
+		return stream;
+	}
 }

--- a/src/openvic-simulation/Modifier.hpp
+++ b/src/openvic-simulation/Modifier.hpp
@@ -76,6 +76,8 @@ namespace OpenVic {
 		Modifier const& modifier;
 		Date expiry_date;
 
+		ModifierInstance(Modifier const& modifier, Date expiry_date);
+
 	public:
 		Modifier const& get_modifier() const;
 		Date const& get_expiry_date() const;

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -177,6 +177,7 @@ namespace OpenVic {
 			for (identifier_index_map_t::value_type const& entry : identifier_index_map) {
 				identifiers.push_back(entry.first);
 			}
+			return identifiers;
 		}
 
 		NodeTools::node_callback_t expect_item_identifier(NodeTools::callback_t<T&> callback) {

--- a/src/openvic-simulation/types/Vector.cpp
+++ b/src/openvic-simulation/types/Vector.cpp
@@ -1,12 +1,6 @@
 #include "Vector.hpp"
 
-#include <ostream>
-#include <tuple>
-
 using namespace OpenVic;
-
-template<typename T>
-constexpr vec2_t<T>::vec2_t() = default;
 
 template<typename T>
 constexpr vec2_t<T>::vec2_t(T new_val) : x { new_val }, y { new_val } {}

--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -8,7 +8,7 @@ namespace OpenVic {
 	struct vec2_t {
 		T x, y;
 
-		constexpr vec2_t();
+		constexpr vec2_t() = default;
 		constexpr vec2_t(T new_val);
 		constexpr vec2_t(T new_x, T new_y);
 
@@ -21,14 +21,19 @@ namespace OpenVic {
 		constexpr T& operator[](size_t index);
 		constexpr T const& operator[](size_t index) const;
 
-		constexpr friend vec2_t operator+(vec2_t const& left, vec2_t const& right);
+		template <typename S>
+		constexpr friend vec2_t<S> operator+(vec2_t<S> const& left, vec2_t<S> const& right);
 		constexpr vec2_t& operator+=(vec2_t const& right);
 
-		constexpr friend vec2_t operator-(vec2_t const& arg);
-		constexpr friend vec2_t operator-(vec2_t const& left, vec2_t const& right);
+		template <typename S>
+		constexpr friend vec2_t<S> operator-(vec2_t<S> const& arg);
+
+		template <typename S>
+		constexpr friend vec2_t<S> operator-(vec2_t<S> const& left, vec2_t<S> const& right);
 		constexpr vec2_t& operator-=(vec2_t const& right);
 
-		constexpr friend std::ostream& operator<<(std::ostream& stream, vec2_t const& value);
+		template <typename S>
+		constexpr friend std::ostream& operator<<(std::ostream& stream, vec2_t<S> const& value);
 	};
 
 	using ivec2_t = vec2_t<int64_t>;


### PR DESCRIPTION
Only warnings left for me are the `#pragma once` things (which joe should already have fixed in his branch). When we merge Testing, we'll finally have a warn-free compilation. The built binary seems to work fine. 

Note: this applies to linux with `gcc`, haven't tested it on other systems/compilers.