### PR TITLE
Cleanup

### DIFF
--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -122,7 +122,7 @@ Date const& GameManager::get_today() const {
 	return today;
 }
 
-bool GameManager::expand_building(Province::index_t province_index, const std::string_view building_type_identifier) {
+bool GameManager::expand_building(Province::index_t province_index, std::string_view building_type_identifier) {
 	set_needs_update();
 	Province* province = map.get_province_by_index(province_index);
 	if (province == nullptr) {

--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -74,7 +74,7 @@ ModifierManager& GameManager::get_modifier_manager() {
 	return modifier_manager;
 }
 
-ModifierManager const& GameManager::get_modifier_manager() const{
+ModifierManager const& GameManager::get_modifier_manager() const {
 	return modifier_manager;
 }
 

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -2,14 +2,11 @@
 
 #include "openvic-simulation/GameAdvancementHook.hpp"
 #include "openvic-simulation/economy/Good.hpp"
+#include "openvic-simulation/economy/ProductionType.hpp"
 #include "openvic-simulation/map/Map.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
 #include "openvic-simulation/politics/Issue.hpp"
-#include "openvic-simulation/GameAdvancementHook.hpp"
-#include "openvic-simulation/economy/Good.hpp"
-#include "openvic-simulation/map/Map.hpp"
 #include "openvic-simulation/units/Unit.hpp"
-#include "openvic-simulation/economy/ProductionType.hpp"
 
 namespace OpenVic {
 	struct GameManager {

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -63,7 +63,7 @@ namespace OpenVic {
 		bool setup();
 
 		Date const& get_today() const;
-		bool expand_building(Province::index_t province_index, const std::string_view building_type_identifier);
+		bool expand_building(Province::index_t province_index, std::string_view building_type_identifier);
 
 		/* Hardcoded data for defining things for which parsing from files has
 		 * not been implemented, currently mapmodes and building types.

--- a/src/openvic-simulation/Modifier.cpp
+++ b/src/openvic-simulation/Modifier.cpp
@@ -3,7 +3,7 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-ModifierEffect::ModifierEffect(const std::string_view new_identifier, bool new_positive_good)
+ModifierEffect::ModifierEffect(std::string_view new_identifier, bool new_positive_good)
 	: HasIdentifier { new_identifier }, positive_good { new_positive_good } {}
 
 bool ModifierEffect::get_positive_good() const {
@@ -74,7 +74,7 @@ ModifierValue ModifierValue::operator-(ModifierValue const& right) const {
 	return ret -= right;
 }
 
-Modifier::Modifier(const std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon)
+Modifier::Modifier(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon)
 	: HasIdentifier { new_identifier }, ModifierValue { std::move(new_values) }, icon { new_icon } {}
 
 Modifier::icon_t Modifier::get_icon() const {
@@ -94,7 +94,7 @@ Date const& ModifierInstance::get_expiry_date() const {
 ModifierManager::ModifierManager()
 	: modifier_effects { "modifier effects"}, modifiers { "modifiers" } {}
 
-bool ModifierManager::add_modifier_effect(const std::string_view identifier, bool positive_good) {
+bool ModifierManager::add_modifier_effect(std::string_view identifier, bool positive_good) {
 	if (identifier.empty()) {
 		Logger::error("Invalid modifier effect identifier - empty!");
 		return false;
@@ -102,7 +102,7 @@ bool ModifierManager::add_modifier_effect(const std::string_view identifier, boo
 	return modifier_effects.add_item({ identifier, positive_good });
 }
 
-bool ModifierManager::add_modifier(const std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon) {
+bool ModifierManager::add_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon) {
 	if (identifier.empty()) {
 		Logger::error("Invalid modifier effect identifier - empty!");
 		return false;

--- a/src/openvic-simulation/Modifier.hpp
+++ b/src/openvic-simulation/Modifier.hpp
@@ -16,7 +16,7 @@ namespace OpenVic {
 
 		// TODO - format/precision, e.g. 80% vs 0.8 vs 0.800, 2 vs 2.0 vs 200%
 
-		ModifierEffect(const std::string_view new_identifier, bool new_positive_good);
+		ModifierEffect(std::string_view new_identifier, bool new_positive_good);
 
 	public:
 		ModifierEffect(ModifierEffect&&) = default;
@@ -65,7 +65,7 @@ namespace OpenVic {
 		/* A modifier can have no icon (zero). */
 		const icon_t icon;
 
-		Modifier(const std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon);
+		Modifier(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon);
 
 	public:
 		Modifier(Modifier&&) = default;
@@ -97,7 +97,7 @@ namespace OpenVic {
 		template<typename... Args>
 		NodeTools::node_callback_t _expect_modifier_value_and_keys(
 			NodeTools::callback_t<ModifierValue&&> modifier_callback, NodeTools::key_map_t&& key_map,
-			const std::string_view key, NodeTools::dictionary_entry_t::expected_count_t expected_count, NodeTools::node_callback_t callback,
+			std::string_view key, NodeTools::dictionary_entry_t::expected_count_t expected_count, NodeTools::node_callback_t callback,
 			Args... args) const {
 			NodeTools::add_key_map_entry(key_map, key, expected_count, callback);
 			return _expect_modifier_value_and_keys(modifier_callback, std::move(key_map), args...);
@@ -106,10 +106,10 @@ namespace OpenVic {
 	public:
 		ModifierManager();
 
-		bool add_modifier_effect(const std::string_view identifier, bool province_good);
+		bool add_modifier_effect(std::string_view identifier, bool province_good);
 		IDENTIFIER_REGISTRY_ACCESSORS(ModifierEffect, modifier_effect)
 
-		bool add_modifier(const std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
+		bool add_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
 		IDENTIFIER_REGISTRY_ACCESSORS(Modifier, modifier)
 
 		bool setup_modifier_effects();

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -1,5 +1,12 @@
 #include "Dataloader.hpp"
 
+#include <openvic-dataloader/csv/Parser.hpp>
+#include <openvic-dataloader/detail/CallbackOStream.hpp>
+#include <openvic-dataloader/v2script/Parser.hpp>
+
+#include "openvic-simulation/GameManager.hpp"
+#include "openvic-simulation/utility/Logger.hpp"
+
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 using namespace ovdl;

--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -1,15 +1,8 @@
 #pragma once
 
 #include <filesystem>
-#include <functional>
-#include <vector>
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"
-#include <openvic-dataloader/csv/Parser.hpp>
-#include <openvic-dataloader/detail/CallbackOStream.hpp>
-#include <openvic-dataloader/v2script/Parser.hpp>
-#include "openvic-simulation/GameManager.hpp"
-#include "openvic-simulation/utility/Logger.hpp"
 
 namespace OpenVic {
 	namespace fs = std::filesystem;

--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -242,7 +242,7 @@ node_callback_t NodeTools::expect_dictionary(key_value_callback_t callback) {
 	return expect_dictionary_and_length(default_length_callback, callback);
 }
 
-void NodeTools::add_key_map_entry(key_map_t& key_map, const std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback) {
+void NodeTools::add_key_map_entry(key_map_t& key_map, std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback) {
 	if (key_map.find(key) == key_map.end()) {
 		key_map.emplace(key, dictionary_entry_t { expected_count, callback });
 	} else {

--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -134,6 +134,10 @@ node_callback_t NodeTools::expect_colour(callback_t<colour_t> callback) {
 	};
 }
 
+node_callback_t NodeTools::expect_timespan(callback_t<Timespan> callback) {
+	return expect_int(callback);
+}
+
 node_callback_t NodeTools::expect_date(callback_t<Date> callback) {
 	return expect_identifier(
 		[callback](std::string_view identifier) -> bool {
@@ -234,6 +238,22 @@ node_callback_t NodeTools::expect_length(callback_t<size_t> callback) {
 	};
 }
 
+node_callback_t NodeTools::expect_key(std::string_view key, node_callback_t callback) {
+	return _expect_type<ast::AbstractListNode>(
+		[key, callback](ast::AbstractListNode const& list_node) -> bool {
+			std::vector<ast::NodeUPtr> const& list = list_node._statements;
+			for (ast::NodeUPtr const& sub_node : list_node._statements) {
+				ast::AssignNode const* assign_node = sub_node->cast_to<ast::AssignNode>();
+				if (assign_node != nullptr && assign_node->_name == key) {
+					return callback(&*assign_node->_initializer);
+				}
+			}
+			Logger::error("Failed to find expected key: ", key);
+			return false;
+		}
+	);
+}
+
 node_callback_t NodeTools::expect_dictionary_and_length(length_callback_t length_callback, key_value_callback_t callback) {
 	return expect_list_and_length(length_callback, expect_assign(callback));
 }
@@ -267,14 +287,15 @@ key_value_callback_t NodeTools::dictionary_keys_callback(key_map_t& key_map, boo
 	};
 }
 
-bool NodeTools::check_key_map_counts(key_map_t const& key_map) {
+bool NodeTools::check_key_map_counts(key_map_t& key_map) {
 	bool ret = true;
-	for (key_map_t::value_type const& key_entry : key_map) {
-		dictionary_entry_t const& entry = key_entry.second;
+	for (key_map_t::value_type& key_entry : key_map) {
+		dictionary_entry_t& entry = key_entry.second;
 		if (entry.must_appear() && entry.count < 1) {
 			Logger::error("Mandatory dictionary key not present: ", key_entry.first);
 			ret = false;
 		}
+		entry.count = 0;
 	}
 	return ret;
 }

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -30,6 +30,7 @@ namespace OpenVic {
 		node_callback_t expect_uint(callback_t<uint64_t> callback);
 		node_callback_t expect_fixed_point(callback_t<fixed_point_t> callback);
 		node_callback_t expect_colour(callback_t<colour_t> callback);
+		node_callback_t expect_timespan(callback_t<Timespan> callback);
 		node_callback_t expect_date(callback_t<Date> callback);
 		node_callback_t expect_ivec2(callback_t<ivec2_t> callback);
 		node_callback_t expect_fvec2(callback_t<fvec2_t> callback);
@@ -42,6 +43,8 @@ namespace OpenVic {
 		node_callback_t expect_list_of_length(size_t length, node_callback_t callback);
 		node_callback_t expect_list(node_callback_t callback);
 		node_callback_t expect_length(callback_t<size_t> callback);
+
+		node_callback_t expect_key(std::string_view key, node_callback_t callback);
 
 		node_callback_t expect_dictionary_and_length(length_callback_t length_callback, key_value_callback_t callback);
 		node_callback_t expect_dictionary(key_value_callback_t callback);
@@ -74,7 +77,7 @@ namespace OpenVic {
 
 		void add_key_map_entry(key_map_t& key_map, std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback);
 		key_value_callback_t dictionary_keys_callback(key_map_t& key_map, bool allow_other_keys);
-		bool check_key_map_counts(key_map_t const& key_map);
+		bool check_key_map_counts(key_map_t& key_map);
 
 		constexpr struct allow_other_keys_t {} ALLOW_OTHER_KEYS;
 
@@ -169,13 +172,13 @@ namespace OpenVic {
 
 		template<typename T>
 		requires(std::integral<T>)
-		callback_t<uint64_t> assign_variable_callback_uint(std::string_view name, T& var) {
-			return [&var, name](uint64_t val) -> bool {
+		callback_t<uint64_t> assign_variable_callback_uint(T& var) {
+			return [&var](uint64_t val) -> bool {
 				if (val <= static_cast<uint64_t>(std::numeric_limits<T>::max())) {
 					var = val;
 					return true;
 				}
-				Logger::error("Invalid ", name, ": ", val, " (valid range: [0, ",
+				Logger::error("Invalid uint: ", val, " (valid range: [0, ",
 					static_cast<uint64_t>(std::numeric_limits<T>::max()), "])");
 				return false;
 			};
@@ -183,13 +186,13 @@ namespace OpenVic {
 
 		template<typename T>
 		requires(std::signed_integral<T>)
-		callback_t<int64_t> assign_variable_callback_int(std::string_view name, T& var) {
-			return [&var, name](int64_t val) -> bool {
+		callback_t<int64_t> assign_variable_callback_int(T& var) {
+			return [&var](int64_t val) -> bool {
 				if (static_cast<int64_t>(std::numeric_limits<T>::lowest()) <= val && val <= static_cast<int64_t>(std::numeric_limits<T>::max())) {
 					var = val;
 					return true;
 				}
-				Logger::error("Invalid ", name, ": ", val, " (valid range: [",
+				Logger::error("Invalid int: ", val, " (valid range: [",
 					static_cast<int64_t>(std::numeric_limits<T>::lowest()), ", ",
 					static_cast<int64_t>(std::numeric_limits<T>::max()), "])");
 				return false;

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -72,7 +72,7 @@ namespace OpenVic {
 		using enum dictionary_entry_t::expected_count_t;
 		using key_map_t = std::map<std::string, dictionary_entry_t, std::less<void>>;
 
-		void add_key_map_entry(key_map_t& key_map, const std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback);
+		void add_key_map_entry(key_map_t& key_map, std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback);
 		key_value_callback_t dictionary_keys_callback(key_map_t& key_map, bool allow_other_keys);
 		bool check_key_map_counts(key_map_t const& key_map);
 
@@ -83,7 +83,7 @@ namespace OpenVic {
 		template<typename... Args>
 		node_callback_t _expect_dictionary_keys_and_length(length_callback_t length_callback,
 			bool allow_other_keys, key_map_t&& key_map,
-			const std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback,
+			std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback,
 			Args... args) {
 			add_key_map_entry(key_map, key, expected_count, callback);
 			return _expect_dictionary_keys_and_length(length_callback, allow_other_keys, std::move(key_map), args...);
@@ -91,7 +91,7 @@ namespace OpenVic {
 
 		template<typename... Args>
 		node_callback_t expect_dictionary_keys_and_length(length_callback_t length_callback,
-			const std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback,
+			std::string_view key, dictionary_entry_t::expected_count_t expected_count, node_callback_t callback,
 			Args... args) {
 			return _expect_dictionary_keys_and_length(length_callback, false, {}, key, expected_count, callback, args...);
 		}
@@ -169,7 +169,7 @@ namespace OpenVic {
 
 		template<typename T>
 		requires(std::integral<T>)
-		callback_t<uint64_t> assign_variable_callback_uint(const std::string_view name, T& var) {
+		callback_t<uint64_t> assign_variable_callback_uint(std::string_view name, T& var) {
 			return [&var, name](uint64_t val) -> bool {
 				if (val <= static_cast<uint64_t>(std::numeric_limits<T>::max())) {
 					var = val;
@@ -183,7 +183,7 @@ namespace OpenVic {
 
 		template<typename T>
 		requires(std::signed_integral<T>)
-		callback_t<int64_t> assign_variable_callback_int(const std::string_view name, T& var) {
+		callback_t<int64_t> assign_variable_callback_int(std::string_view name, T& var) {
 			return [&var, name](int64_t val) -> bool {
 				if (static_cast<int64_t>(std::numeric_limits<T>::lowest()) <= val && val <= static_cast<int64_t>(std::numeric_limits<T>::max())) {
 					var = val;

--- a/src/openvic-simulation/economy/Good.cpp
+++ b/src/openvic-simulation/economy/Good.cpp
@@ -5,9 +5,9 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-GoodCategory::GoodCategory(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+GoodCategory::GoodCategory(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
-Good::Good(const std::string_view new_identifier, colour_t new_colour, GoodCategory const& new_category, price_t new_base_price,
+Good::Good(std::string_view new_identifier, colour_t new_colour, GoodCategory const& new_category, price_t new_base_price,
 	bool new_available_from_start, bool new_tradeable, bool new_money, bool new_overseas_penalty)
 	: HasIdentifierAndColour { new_identifier, new_colour, true, false },
 	  category { new_category },
@@ -58,7 +58,7 @@ void Good::reset_to_defaults() {
 
 GoodManager::GoodManager() : good_categories { "good categories" }, goods { "goods" } {}
 
-bool GoodManager::add_good_category(const std::string_view identifier) {
+bool GoodManager::add_good_category(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid good category identifier - empty!");
 		return false;
@@ -66,7 +66,7 @@ bool GoodManager::add_good_category(const std::string_view identifier) {
 	return good_categories.add_item({ identifier });
 }
 
-bool GoodManager::add_good(const std::string_view identifier, colour_t colour, GoodCategory const* category,
+bool GoodManager::add_good(std::string_view identifier, colour_t colour, GoodCategory const* category,
 	Good::price_t base_price, bool available_from_start, bool tradeable, bool money, bool overseas_penalty) {
 	if (identifier.empty()) {
 		Logger::error("Invalid good identifier - empty!");

--- a/src/openvic-simulation/economy/Good.hpp
+++ b/src/openvic-simulation/economy/Good.hpp
@@ -9,7 +9,7 @@ namespace OpenVic {
 		friend struct GoodManager;
 
 	private:
-		GoodCategory(const std::string_view new_identifier);
+		GoodCategory(std::string_view new_identifier);
 
 	public:
 		GoodCategory(GoodCategory&&) = default;
@@ -40,7 +40,7 @@ namespace OpenVic {
 		const bool available_from_start, tradeable, money, overseas_penalty;
 		bool available;
 
-		Good(const std::string_view new_identifier, colour_t new_colour, GoodCategory const& new_category, price_t new_base_price,
+		Good(std::string_view new_identifier, colour_t new_colour, GoodCategory const& new_category, price_t new_base_price,
 			bool new_available_from_start, bool new_tradeable, bool new_money, bool new_overseas_penalty);
 
 	public:
@@ -65,10 +65,10 @@ namespace OpenVic {
 	public:
 		GoodManager();
 
-		bool add_good_category(const std::string_view identifier);
+		bool add_good_category(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(GoodCategory, good_category, good_categories)
 
-		bool add_good(const std::string_view identifier, colour_t colour, GoodCategory const* category, Good::price_t base_price,
+		bool add_good(std::string_view identifier, colour_t colour, GoodCategory const* category, Good::price_t base_price,
 			bool available_from_start, bool tradeable, bool money, bool overseas_penalty);
 		IDENTIFIER_REGISTRY_ACCESSORS(Good, good)
 

--- a/src/openvic-simulation/economy/ProductionType.hpp
+++ b/src/openvic-simulation/economy/ProductionType.hpp
@@ -5,9 +5,9 @@
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 
-#define PRODUCTION_TYPE_ARGS(enum_type, output) \
-	std::string_view identifier, EmployedPop owner, std::vector<EmployedPop> employees, enum_type type, \
-	Pop::pop_size_t workforce, std::map<Good const*, fixed_point_t> input_goods, output output_goods, \
+#define PRODUCTION_TYPE_ARGS \
+	std::string_view identifier, EmployedPop owner, std::vector<EmployedPop> employees, ProductionType::type_t type, \
+	Pop::pop_size_t workforce, std::map<Good const*, fixed_point_t> input_goods, Good const* output_goods, \
 	fixed_point_t value, std::vector<Bonus> bonuses, std::map<Good const*, fixed_point_t> efficiency, \
 	bool coastal, bool farm, bool mine
 
@@ -69,7 +69,7 @@ namespace OpenVic {
 		const bool farm;
 		const bool mine;
 
-		ProductionType(PRODUCTION_TYPE_ARGS(type_t, Good const*));
+		ProductionType(PRODUCTION_TYPE_ARGS);
 
 	public:
 		ProductionType(ProductionType&&) = default;
@@ -80,7 +80,7 @@ namespace OpenVic {
 		Pop::pop_size_t get_workforce() const;
 
 		std::map<Good const*, fixed_point_t> const& get_input_goods();
-		const Good* get_output_goods() const;
+		Good const* get_output_goods() const;
 		fixed_point_t get_value() const;
 		std::vector<Bonus> const& get_bonuses();
 
@@ -103,7 +103,7 @@ namespace OpenVic {
 	public:
 		ProductionTypeManager();
 
-		bool add_production_type(PRODUCTION_TYPE_ARGS(std::string_view, std::string_view), GoodManager& good_manager);
+		bool add_production_type(PRODUCTION_TYPE_ARGS, GoodManager& good_manager);
 		IDENTIFIER_REGISTRY_ACCESSORS(ProductionType, production_type)
 
 		bool load_production_types_file(GoodManager& good_manager, PopManager& pop_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/map/Building.cpp
+++ b/src/openvic-simulation/map/Building.cpp
@@ -105,7 +105,7 @@ bool Building::spawned_railway_track() const {
 	return spawn_railway_track;
 }
 
-BuildingType::BuildingType(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+BuildingType::BuildingType(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
 BuildingInstance::BuildingInstance(Building const& building) : HasIdentifier { building.get_identifier() }, building { building } {}
 
@@ -176,7 +176,7 @@ void BuildingInstance::tick(Date const& today) {
 
 BuildingManager::BuildingManager() : building_types { "building types" }, buildings { "buildings" } {}
 
-bool BuildingManager::add_building_type(const std::string_view identifier) {
+bool BuildingManager::add_building_type(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid building type identifier - empty!");
 		return false;

--- a/src/openvic-simulation/map/Building.hpp
+++ b/src/openvic-simulation/map/Building.hpp
@@ -103,7 +103,7 @@ namespace OpenVic {
 		friend struct BuildingManager;
 
 	private:
-		BuildingType(const std::string_view new_identifier);
+		BuildingType(std::string_view new_identifier);
 
 	public:
 		BuildingType(BuildingType&&) = default;
@@ -161,7 +161,7 @@ namespace OpenVic {
 	public:
 		BuildingManager();
 
-		bool add_building_type(const std::string_view identifier);
+		bool add_building_type(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(BuildingType, building_type)
 
 		bool add_building(std::string_view identifier, ARGS);

--- a/src/openvic-simulation/map/Building.hpp
+++ b/src/openvic-simulation/map/Building.hpp
@@ -7,10 +7,10 @@
 #include "openvic-simulation/economy/ProductionType.hpp"
 #include "openvic-simulation/Modifier.hpp"
 
-#define ARGS BuildingType const& type, std::string_view on_completion, fixed_point_t completion_size, level_t max_level, \
-				std::map<const Good*, fixed_point_t> goods_cost, fixed_point_t cost, Timespan build_time, bool visibility, bool on_map, bool default_enabled, \
+#define ARGS std::string_view on_completion, fixed_point_t completion_size, level_t max_level, \
+				std::map<Good const*, fixed_point_t> goods_cost, fixed_point_t cost, Timespan build_time, bool visibility, bool on_map, bool default_enabled, \
 				ProductionType const* production_type, bool pop_build_factory, bool strategic_factory, bool advanced_factory, level_t fort_level, \
-				uint64_t naval_capacity, std::vector<uint64_t> colonial_points, bool in_province, bool one_per_state, fixed_point_t colonial_range, \
+				uint64_t naval_capacity, std::vector<fixed_point_t> colonial_points, bool in_province, bool one_per_state, fixed_point_t colonial_range, \
 				fixed_point_t infrastructure, fixed_point_t movement_cost, fixed_point_t local_ship_build, bool spawn_railway_track, bool sail, bool steam, \
 				bool capital, bool port, ModifierValue&& modifiers
 
@@ -27,19 +27,19 @@ namespace OpenVic {
 	struct Building : HasIdentifier, ModifierValue {
 		friend struct BuildingManager;
 
-		using level_t = uint8_t;
+		using level_t = int8_t;
 
 	private:
 		BuildingType const& type;
-		const std::string_view on_completion; //probably sound played on completion
+		const std::string on_completion; //probably sound played on completion
 		const fixed_point_t completion_size;
 		const level_t max_level;
-		const std::map<const Good*, fixed_point_t> goods_cost;
+		const std::map<Good const*, fixed_point_t> goods_cost;
 		const fixed_point_t cost;
 		const Timespan build_time; //time
 		const bool visibility;
 		const bool on_map; //onmap
-		
+
 		const bool default_enabled;
 		ProductionType const* production_type;
 		const bool pop_build_factory;
@@ -49,7 +49,7 @@ namespace OpenVic {
 		const level_t fort_level; //probably the step-per-level
 
 		const uint64_t naval_capacity;
-		const std::vector<uint64_t> colonial_points;
+		const std::vector<fixed_point_t> colonial_points;
 		const bool in_province; //province
 		const bool one_per_state;
 		const fixed_point_t colonial_range;
@@ -64,16 +64,16 @@ namespace OpenVic {
 		const bool capital; //only in naval base
 		const bool port; //only in naval base
 
-		Building(std::string_view identifier, ARGS);
+		Building(std::string_view identifier, BuildingType const& type, ARGS);
 
 	public:
 		Building(Building&&) = default;
 
 		BuildingType const& get_type() const;
-		std::string_view get_on_completion() const;
+		std::string const& get_on_completion() const;
 		fixed_point_t get_completion_size() const;
 		level_t get_max_level() const;
-		std::map<const Good*, fixed_point_t> const& get_goods_cost() const;
+		std::map<Good const*, fixed_point_t> const& get_goods_cost() const;
 		fixed_point_t get_cost() const;
 		Timespan get_build_time() const;
 		bool has_visibility() const;
@@ -84,15 +84,15 @@ namespace OpenVic {
 		bool is_pop_built_factory() const;
 		bool is_strategic_factory() const;
 		bool is_advanced_factory() const;
-		
+
 		level_t get_fort_level() const;
 
 		uint64_t get_naval_capacity() const;
-		std::vector<uint64_t> const& get_colonial_points() const;
+		std::vector<fixed_point_t> const& get_colonial_points() const;
 		bool is_in_province() const;
 		bool is_one_per_state() const;
 		fixed_point_t get_colonial_range() const;
-		
+
 		fixed_point_t get_infrastructure() const;
 		fixed_point_t get_movement_cost() const;
 		fixed_point_t get_local_ship_build() const;
@@ -119,7 +119,7 @@ namespace OpenVic {
 	struct BuildingInstance : HasIdentifier { //used in the actual game
 		friend struct BuildingManager;
 		using level_t = Building::level_t;
-	
+
 	private:
 		Building const& building;
 
@@ -164,7 +164,7 @@ namespace OpenVic {
 		bool add_building_type(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(BuildingType, building_type)
 
-		bool add_building(std::string_view identifier, ARGS);
+		bool add_building(std::string_view identifier, BuildingType const* type, ARGS);
 		IDENTIFIER_REGISTRY_ACCESSORS(Building, building)
 
 		bool load_buildings_file(GoodManager const& good_manager, ProductionTypeManager const& production_type_manager, ModifierManager const& modifier_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -10,7 +10,7 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-Mapmode::Mapmode(const std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func)
+Mapmode::Mapmode(std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func)
 	: HasIdentifier { new_identifier },
 	  index { new_index },
 	  colour_func { new_colour_func } {
@@ -32,7 +32,7 @@ Map::Map() : provinces { "provinces" },
 			 regions { "regions" },
 			 mapmodes { "mapmodes" } {}
 
-bool Map::add_province(const std::string_view identifier, colour_t colour) {
+bool Map::add_province(std::string_view identifier, colour_t colour) {
 	if (provinces.size() >= max_provinces) {
 		Logger::error("The map's province list is full - maximum number of provinces is ", max_provinces, " (this can be at most ", Province::MAX_INDEX, ")");
 		return false;
@@ -55,7 +55,7 @@ bool Map::add_province(const std::string_view identifier, colour_t colour) {
 	return provinces.add_item(std::move(new_province));
 }
 
-bool Map::set_water_province(const std::string_view identifier) {
+bool Map::set_water_province(std::string_view identifier) {
 	if (water_provinces.is_locked()) {
 		Logger::error("The map's water provinces have already been locked!");
 		return false;
@@ -91,7 +91,7 @@ void Map::lock_water_provinces() {
 	Logger::info("Locked water provinces after registering ", water_provinces.size());
 }
 
-bool Map::add_region(const std::string_view identifier, std::vector<std::string_view> const& province_identifiers) {
+bool Map::add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers) {
 	if (identifier.empty()) {
 		Logger::error("Invalid region identifier - empty!");
 		return false;
@@ -203,7 +203,7 @@ TerrainTypeManager const& Map::get_terrain_type_manager() const {
 	return terrain_type_manager;
 }
 
-bool Map::add_mapmode(const std::string_view identifier, Mapmode::colour_func_t colour_func) {
+bool Map::add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func) {
 	if (identifier.empty()) {
 		Logger::error("Invalid mapmode identifier - empty!");
 		return false;

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -21,7 +21,7 @@ namespace OpenVic {
 		const index_t index;
 		const colour_func_t colour_func;
 
-		Mapmode(const std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func);
+		Mapmode(std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func);
 
 	public:
 		static const Mapmode ERROR_MAPMODE;
@@ -69,11 +69,11 @@ namespace OpenVic {
 	public:
 		Map();
 
-		bool add_province(const std::string_view identifier, colour_t colour);
+		bool add_province(std::string_view identifier, colour_t colour);
 		IDENTIFIER_REGISTRY_ACCESSORS(Province, province)
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(Province, province)
 
-		bool set_water_province(const std::string_view identifier);
+		bool set_water_province(std::string_view identifier);
 		bool set_water_province_list(std::vector<std::string_view> const& list);
 		void lock_water_provinces();
 
@@ -92,11 +92,11 @@ namespace OpenVic {
 		TerrainTypeManager& get_terrain_type_manager();
 		TerrainTypeManager const& get_terrain_type_manager() const;
 
-		bool add_region(const std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
+		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
 		IDENTIFIER_REGISTRY_ACCESSORS(Region, region)
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(Region, region)
 
-		bool add_mapmode(const std::string_view identifier, Mapmode::colour_func_t colour_func);
+		bool add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func);
 		IDENTIFIER_REGISTRY_ACCESSORS(Mapmode, mapmode)
 		Mapmode const* get_mapmode_by_index(size_t index) const;
 		static constexpr size_t MAPMODE_COLOUR_SIZE = 4;

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -3,7 +3,7 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-Province::Province(const std::string_view new_identifier, colour_t new_colour, index_t new_index)
+Province::Province(std::string_view new_identifier, colour_t new_colour, index_t new_index)
 	: HasIdentifierAndColour { new_identifier, new_colour, false, false },
 	  index { new_index }, buildings { "buildings", false } {
 	assert(index != NULL_INDEX);
@@ -47,7 +47,7 @@ void Province::reset_buildings() {
 	buildings.reset();
 }
 
-bool Province::expand_building(const std::string_view building_type_identifier) {
+bool Province::expand_building(std::string_view building_type_identifier) {
 	BuildingInstance* building = buildings.get_item_by_identifier(building_type_identifier);
 	if (building == nullptr) return false;
 	return building->expand();

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -60,7 +60,7 @@ namespace OpenVic {
 
 		void _set_terrain_type(TerrainType const* type);
 
-		Province(const std::string_view new_identifier, colour_t new_colour, index_t new_index);
+		Province(std::string_view new_identifier, colour_t new_colour, index_t new_index);
 
 	public:
 		Province(Province&&) = default;
@@ -76,7 +76,7 @@ namespace OpenVic {
 		bool add_building(BuildingInstance&& building_instance);
 		IDENTIFIER_REGISTRY_ACCESSORS(BuildingInstance, building)
 		void reset_buildings();
-		bool expand_building(const std::string_view building_type_identifier);
+		bool expand_building(std::string_view building_type_identifier);
 		Good const* get_rgo() const;
 		std::string to_string() const;
 

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -63,7 +63,7 @@ ProvinceSet::provinces_t const& ProvinceSet::get_provinces() const {
 	return provinces;
 }
 
-Region::Region(const std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta)
+Region::Region(std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta)
 	: HasIdentifier { new_identifier }, ProvinceSet { std::move(new_provinces) }, meta { new_meta } {
 	lock();
 }

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -38,7 +38,7 @@ namespace OpenVic {
 		 */
 		const bool meta;
 
-		Region(const std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta);
+		Region(std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta);
 
 	public:
 		Region(Region&&) = default;

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -117,7 +117,7 @@ bool TerrainTypeManager::_load_terrain_type_mapping(std::string_view mapping_key
 				return false;
 			}
 		)),
-		"priority", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint("terrain type mapping priority", priority)),
+		"priority", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint(priority)),
 		"has_texture", ZERO_OR_ONE, expect_bool(assign_variable_callback(has_texture))
 	)(mapping_value);
 	if (has_texture) {
@@ -153,7 +153,7 @@ bool TerrainTypeManager::load_terrain_types(ModifierManager const& modifier_mana
 			if (key == "terrain") {
 				if (!terrain) {
 					terrain = true;
-					return expect_uint(assign_variable_callback_uint("terrain texture limit", terrain_texture_limit))(value);
+					return expect_uint(assign_variable_callback_uint(terrain_texture_limit))(value);
 				} else {
 					Logger::error("Duplicate terrain key!");
 					return false;

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -5,14 +5,14 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-TerrainType::TerrainType(const std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values, bool new_is_water)
+TerrainType::TerrainType(std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values, bool new_is_water)
 	: HasIdentifierAndColour { new_identifier, new_colour, true, false }, ModifierValue { std::move(new_values) }, is_water { new_is_water } {}
 
 bool TerrainType::get_is_water() const {
 	return is_water;
 }
 
-TerrainTypeMapping::TerrainTypeMapping(const std::string_view new_identifier, TerrainType const& new_type,
+TerrainTypeMapping::TerrainTypeMapping(std::string_view new_identifier, TerrainType const& new_type,
 	std::vector<index_t>&& new_terrain_indicies, index_t new_priority, bool new_has_texture)
 	: HasIdentifier { new_identifier }, type { new_type }, terrain_indicies { std::move(new_terrain_indicies) },
 	  priority { new_priority }, has_texture { new_has_texture } {}
@@ -35,7 +35,7 @@ bool TerrainTypeMapping::get_has_texture() const {
 
 TerrainTypeManager::TerrainTypeManager() : terrain_types { "terrain types" }, terrain_type_mappings { "terrain type mappings" } {}
 
-bool TerrainTypeManager::add_terrain_type(const std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water) {
+bool TerrainTypeManager::add_terrain_type(std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water) {
 	if (identifier.empty()) {
 		Logger::error("Invalid terrain type identifier - empty!");
 		return false;
@@ -47,7 +47,7 @@ bool TerrainTypeManager::add_terrain_type(const std::string_view identifier, col
 	return terrain_types.add_item({ identifier, colour, std::move(values), is_water });
 }
 
-bool TerrainTypeManager::add_terrain_type_mapping(const std::string_view identifier, TerrainType const* type,
+bool TerrainTypeManager::add_terrain_type_mapping(std::string_view identifier, TerrainType const* type,
 	std::vector<TerrainTypeMapping::index_t>&& terrain_indicies, TerrainTypeMapping::index_t priority, bool has_texture) {
 	if (!terrain_types.is_locked()) {
 		Logger::error("Cannot register terrain type mappings until terrain types are locked!");

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -11,7 +11,7 @@ namespace OpenVic {
 	private:
 		const bool is_water;
 
-		TerrainType(const std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values, bool new_is_water);
+		TerrainType(std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values, bool new_is_water);
 
 	public:
 		TerrainType(TerrainType&&) = default;
@@ -30,7 +30,7 @@ namespace OpenVic {
 		const index_t priority;
 		const bool has_texture;
 
-		TerrainTypeMapping(const std::string_view new_identifier, TerrainType const& new_type, std::vector<index_t>&& new_terrain_indicies, index_t new_priority, bool new_has_texture);
+		TerrainTypeMapping(std::string_view new_identifier, TerrainType const& new_type, std::vector<index_t>&& new_terrain_indicies, index_t new_priority, bool new_has_texture);
 
 	public:
 		TerrainTypeMapping(TerrainTypeMapping&&) = default;
@@ -56,10 +56,10 @@ namespace OpenVic {
 	public:
 		TerrainTypeManager();
 
-		bool add_terrain_type(const std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water);
+		bool add_terrain_type(std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water);
 		IDENTIFIER_REGISTRY_ACCESSORS(TerrainType, terrain_type)
 
-		bool add_terrain_type_mapping(const std::string_view identifier, TerrainType const* type,
+		bool add_terrain_type_mapping(std::string_view identifier, TerrainType const* type,
 			std::vector<TerrainTypeMapping::index_t>&& terrain_indicies, TerrainTypeMapping::index_t priority, bool has_texture);
 		IDENTIFIER_REGISTRY_ACCESSORS(TerrainTypeMapping, terrain_type_mapping)
 

--- a/src/openvic-simulation/politics/Ideology.cpp
+++ b/src/openvic-simulation/politics/Ideology.cpp
@@ -3,9 +3,9 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-IdeologyGroup::IdeologyGroup(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+IdeologyGroup::IdeologyGroup(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
-Ideology::Ideology(const std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised, bool new_can_reduce_militancy, Date new_spawn_date)
+Ideology::Ideology(std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised, bool new_can_reduce_militancy, Date new_spawn_date)
 	: HasIdentifierAndColour { new_identifier, new_colour, true, false }, group { new_group }, uncivilised { new_uncivilised },
 	can_reduce_militancy { new_can_reduce_militancy }, spawn_date { new_spawn_date } {}
 
@@ -27,7 +27,7 @@ Date const& Ideology::get_spawn_date() const {
 
 IdeologyManager::IdeologyManager() : ideology_groups { "ideology groups" }, ideologies { "ideologies" } {}
 
-bool IdeologyManager::add_ideology_group(const std::string_view identifier) {
+bool IdeologyManager::add_ideology_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid ideology group identifier - empty!");
 		return false;
@@ -36,7 +36,7 @@ bool IdeologyManager::add_ideology_group(const std::string_view identifier) {
 	return ideology_groups.add_item({ identifier });
 }
 
-bool IdeologyManager::add_ideology(const std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised, bool can_reduce_militancy, Date spawn_date) {
+bool IdeologyManager::add_ideology(std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised, bool can_reduce_militancy, Date spawn_date) {
 	if (identifier.empty()) {
 		Logger::error("Invalid ideology identifier - empty!");
 		return false;

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -9,7 +9,7 @@ namespace OpenVic {
 		friend struct IdeologyManager;
 
 	private:
-		IdeologyGroup(const std::string_view new_identifier);
+		IdeologyGroup(std::string_view new_identifier);
 
 	public:
 		IdeologyGroup(IdeologyGroup&&) = default;
@@ -25,7 +25,7 @@ namespace OpenVic {
 
 		//TODO - willingness to repeal/pass reforms (and its modifiers)
 
-		Ideology(const std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised, bool new_can_reduce_militancy, Date new_spawn_date);
+		Ideology(std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised, bool new_can_reduce_militancy, Date new_spawn_date);
 
 	public:
 		Ideology(Ideology&&) = default;
@@ -44,10 +44,10 @@ namespace OpenVic {
 	public:
 		IdeologyManager();
 
-		bool add_ideology_group(const std::string_view identifier);
+		bool add_ideology_group(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(IdeologyGroup, ideology_group)
 
-		bool add_ideology(const std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised, bool can_reduce_militancy, Date spawn_date);
+		bool add_ideology(std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised, bool can_reduce_militancy, Date spawn_date);
 		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(Ideology, ideology, ideologies)
 
 		bool load_ideology_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -3,19 +3,19 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-IssueGroup::IssueGroup(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+IssueGroup::IssueGroup(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
-Issue::Issue(const std::string_view identifier, IssueGroup const& group)
+Issue::Issue(std::string_view identifier, IssueGroup const& group)
 	: HasIdentifier { identifier }, group { group } {}
 
 IssueGroup const& Issue::get_group() const {
 	return group;
 }
 
-ReformType::ReformType(const std::string_view new_identifier, bool uncivilised)
+ReformType::ReformType(std::string_view new_identifier, bool uncivilised)
 	: HasIdentifier { new_identifier }, uncivilised { uncivilised } {}
 
-ReformGroup::ReformGroup(const std::string_view identifier, ReformType const& type, bool ordered, bool administrative)
+ReformGroup::ReformGroup(std::string_view identifier, ReformType const& type, bool ordered, bool administrative)
 	: IssueGroup { identifier }, type { type }, ordered { ordered }, administrative { administrative } {}
 
 ReformType const& ReformGroup::get_type() const {
@@ -30,7 +30,7 @@ bool ReformGroup::is_administrative() const {
 	return administrative;
 }
 
-Reform::Reform(const std::string_view identifier, ReformGroup const& group, size_t ordinal)
+Reform::Reform(std::string_view identifier, ReformGroup const& group, size_t ordinal)
 	: Issue { identifier, group }, ordinal { ordinal }, reform_group { group } {}
 
 ReformGroup const& Reform::get_reform_group() const {
@@ -48,7 +48,7 @@ size_t Reform::get_ordinal() const {
 IssueManager::IssueManager() : issue_groups { "issue groups" }, issues { "issues" },
 	reform_types { "reform types" }, reform_groups { "reform groups" }, reforms { "reforms" }  {}
 
-bool IssueManager::add_issue_group(const std::string_view identifier) {
+bool IssueManager::add_issue_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue group identifier - empty!");
 		return false;
@@ -57,7 +57,7 @@ bool IssueManager::add_issue_group(const std::string_view identifier) {
 	return issue_groups.add_item({ identifier });
 }
 
-bool IssueManager::add_issue(const std::string_view identifier, IssueGroup const* group) {
+bool IssueManager::add_issue(std::string_view identifier, IssueGroup const* group) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue identifier - empty!");
 		return false;
@@ -71,7 +71,7 @@ bool IssueManager::add_issue(const std::string_view identifier, IssueGroup const
 	return issues.add_item({ identifier, *group });
 }
 
-bool IssueManager::add_reform_type(const std::string_view identifier, bool uncivilised) {
+bool IssueManager::add_reform_type(std::string_view identifier, bool uncivilised) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue type identifier - empty!");
 		return false;
@@ -80,7 +80,7 @@ bool IssueManager::add_reform_type(const std::string_view identifier, bool unciv
 	return reform_types.add_item({ identifier, uncivilised });
 }
 
-bool IssueManager::add_reform_group(const std::string_view identifier, ReformType const* type, bool ordered, bool administrative) {
+bool IssueManager::add_reform_group(std::string_view identifier, ReformType const* type, bool ordered, bool administrative) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue group identifier - empty!");
 		return false;
@@ -94,7 +94,7 @@ bool IssueManager::add_reform_group(const std::string_view identifier, ReformTyp
 	return reform_groups.add_item({ identifier, *type, ordered, administrative });
 }
 
-bool IssueManager::add_reform(const std::string_view identifier, ReformGroup const* group, size_t ordinal) {
+bool IssueManager::add_reform(std::string_view identifier, ReformGroup const* group, size_t ordinal) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue identifier - empty!");
 		return false;
@@ -108,19 +108,19 @@ bool IssueManager::add_reform(const std::string_view identifier, ReformGroup con
 	return reforms.add_item({ identifier, *group, ordinal });
 }
 
-bool IssueManager::_load_issue_group(size_t& expected_issues, const std::string_view identifier, ast::NodeCPtr node) {
+bool IssueManager::_load_issue_group(size_t& expected_issues, std::string_view identifier, ast::NodeCPtr node) {
 	return expect_length([&expected_issues](size_t size) -> size_t {
 		expected_issues += size;
 		return size;
 	})(node) & add_issue_group(identifier);
 }
 
-bool IssueManager::_load_issue(const std::string_view identifier, IssueGroup const* group, ast::NodeCPtr node) {
+bool IssueManager::_load_issue(std::string_view identifier, IssueGroup const* group, ast::NodeCPtr node) {
 	//TODO: policy modifiers, policy rule changes
 	return add_issue(identifier, group);
 }
 
-bool IssueManager::_load_reform_group(size_t& expected_reforms, const std::string_view identifier, ReformType const* type, ast::NodeCPtr node) {
+bool IssueManager::_load_reform_group(size_t& expected_reforms, std::string_view identifier, ReformType const* type, ast::NodeCPtr node) {
 	bool ordered = false, administrative = false;
 	bool ret = expect_dictionary_keys_and_length(
 		[&expected_reforms](size_t size) -> size_t {
@@ -134,7 +134,7 @@ bool IssueManager::_load_reform_group(size_t& expected_reforms, const std::strin
 	return ret;
 }
 
-bool IssueManager::_load_reform(size_t& ordinal, const std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node) {
+bool IssueManager::_load_reform(size_t& ordinal, std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node) {
 	//TODO: conditions to allow, policy modifiers, policy rule changes
 	return add_reform(identifier, group, ordinal);
 }

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -14,7 +14,7 @@ namespace OpenVic {
 		friend struct IssueManager;
 
 	protected:
-		IssueGroup(const std::string_view identifier);
+		IssueGroup(std::string_view identifier);
 
 	public:
 		IssueGroup(IssueGroup&&) = default;
@@ -30,7 +30,7 @@ namespace OpenVic {
 		//TODO: policy modifiers, policy rule changes
 
 	protected:
-		Issue(const std::string_view identifier, IssueGroup const& group);
+		Issue(std::string_view identifier, IssueGroup const& group);
 
 	public:
 		Issue(Issue&&) = default;
@@ -45,7 +45,7 @@ namespace OpenVic {
 		bool uncivilised; //whether this group is available to non-westernised countries
 		//in vanilla education, military and economic reforms are hardcoded to true and the rest to false
 
-		ReformType(const std::string_view new_identifier, bool uncivilised);
+		ReformType(std::string_view new_identifier, bool uncivilised);
 
 	public:
 		ReformType(ReformType&&) = default;
@@ -60,7 +60,7 @@ namespace OpenVic {
 		const bool ordered; //next_step_only
 		const bool administrative;
 
-		ReformGroup(const std::string_view identifier, ReformType const& type, bool ordered, bool administrative);
+		ReformGroup(std::string_view identifier, ReformType const& type, bool ordered, bool administrative);
 
 	public:
 		ReformGroup(ReformGroup&&) = default;
@@ -77,7 +77,7 @@ namespace OpenVic {
 		ReformGroup const& reform_group; //stores an already casted reference
 		const size_t ordinal; //assigned by the parser to allow policy sorting
 
-		Reform(const std::string_view new_identifier, ReformGroup const& group, size_t ordinal);
+		Reform(std::string_view new_identifier, ReformGroup const& group, size_t ordinal);
 
 		//TODO: conditions to allow,
 
@@ -97,28 +97,28 @@ namespace OpenVic {
 		IdentifierRegistry<ReformGroup> reform_groups;
 		IdentifierRegistry<Reform> reforms;
 
-		bool _load_issue_group(size_t& expected_issues, const std::string_view identifier, ast::NodeCPtr node);
-		bool _load_issue(const std::string_view identifier, IssueGroup const* group, ast::NodeCPtr node);
-		bool _load_reform_group(size_t& expected_reforms, const std::string_view identifier, ReformType const* type,
+		bool _load_issue_group(size_t& expected_issues, std::string_view identifier, ast::NodeCPtr node);
+		bool _load_issue(std::string_view identifier, IssueGroup const* group, ast::NodeCPtr node);
+		bool _load_reform_group(size_t& expected_reforms, std::string_view identifier, ReformType const* type,
 			ast::NodeCPtr node);
-		bool _load_reform(size_t& ordinal, const std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node);
+		bool _load_reform(size_t& ordinal, std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node);
 
 	public:
 		IssueManager();
 
-		bool add_issue_group(const std::string_view identifier);
+		bool add_issue_group(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(IssueGroup, issue_group)
 
-		bool add_issue(const std::string_view identifier, IssueGroup const* group);
+		bool add_issue(std::string_view identifier, IssueGroup const* group);
 		IDENTIFIER_REGISTRY_ACCESSORS(Issue, issue)
 
-		bool add_reform_type(const std::string_view identifier, bool uncivilised);
+		bool add_reform_type(std::string_view identifier, bool uncivilised);
 		IDENTIFIER_REGISTRY_ACCESSORS(ReformType, reform_type)
 
-		bool add_reform_group(const std::string_view identifier, ReformType const* type, bool ordered, bool administrative);
+		bool add_reform_group(std::string_view identifier, ReformType const* type, bool ordered, bool administrative);
 		IDENTIFIER_REGISTRY_ACCESSORS(ReformGroup, reform_group)
 
-		bool add_reform(const std::string_view identifier, ReformGroup const* group, size_t ordinal);
+		bool add_reform(std::string_view identifier, ReformGroup const* group, size_t ordinal);
 		IDENTIFIER_REGISTRY_ACCESSORS(Reform, reform)
 
 		bool load_issues_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -7,9 +7,9 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-GraphicalCultureType::GraphicalCultureType(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+GraphicalCultureType::GraphicalCultureType(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
-CultureGroup::CultureGroup(const std::string_view new_identifier, const std::string_view new_leader,
+CultureGroup::CultureGroup(std::string_view new_identifier, std::string_view new_leader,
 	GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas)
 	: HasIdentifier { new_identifier }, leader { new_leader },
 	  unit_graphical_culture_type { new_unit_graphical_culture_type },
@@ -27,7 +27,7 @@ bool CultureGroup::get_is_overseas() const {
 	return is_overseas;
 }
 
-Culture::Culture(const std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group,
+Culture::Culture(std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group,
 	std::vector<std::string> const& new_first_names, std::vector<std::string> const& new_last_names)
 	: HasIdentifierAndColour { new_identifier, new_colour, true, false },
 	  group { new_group },
@@ -51,7 +51,7 @@ CultureManager::CultureManager()
 	  culture_groups { "culture groups" },
 	  cultures { "cultures" } {}
 
-bool CultureManager::add_graphical_culture_type(const std::string_view identifier) {
+bool CultureManager::add_graphical_culture_type(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid culture group identifier - empty!");
 		return false;
@@ -59,7 +59,7 @@ bool CultureManager::add_graphical_culture_type(const std::string_view identifie
 	return graphical_culture_types.add_item({ identifier });
 }
 
-bool CultureManager::add_culture_group(const std::string_view identifier, const std::string_view leader, GraphicalCultureType const* graphical_culture_type, bool is_overseas) {
+bool CultureManager::add_culture_group(std::string_view identifier, std::string_view leader, GraphicalCultureType const* graphical_culture_type, bool is_overseas) {
 	if (!graphical_culture_types.is_locked()) {
 		Logger::error("Cannot register culture groups until graphical culture types are locked!");
 		return false;
@@ -79,7 +79,7 @@ bool CultureManager::add_culture_group(const std::string_view identifier, const 
 	return culture_groups.add_item({ identifier, leader, *graphical_culture_type, is_overseas });
 }
 
-bool CultureManager::add_culture(const std::string_view identifier, colour_t colour, CultureGroup const* group, std::vector<std::string> const& first_names, std::vector<std::string> const& last_names) {
+bool CultureManager::add_culture(std::string_view identifier, colour_t colour, CultureGroup const* group, std::vector<std::string> const& first_names, std::vector<std::string> const& last_names) {
 	if (!culture_groups.is_locked()) {
 		Logger::error("Cannot register cultures until culture groups are locked!");
 		return false;
@@ -112,7 +112,7 @@ bool CultureManager::load_graphical_culture_type_file(ast::NodeCPtr root) {
 
 bool CultureManager::_load_culture_group(size_t& total_expected_cultures,
 	GraphicalCultureType const* default_unit_graphical_culture_type,
-	const std::string_view culture_group_key, ast::NodeCPtr culture_group_node) {
+	std::string_view culture_group_key, ast::NodeCPtr culture_group_node) {
 
 	std::string_view leader;
 	GraphicalCultureType const* unit_graphical_culture_type = default_unit_graphical_culture_type;
@@ -134,7 +134,7 @@ bool CultureManager::_load_culture_group(size_t& total_expected_cultures,
 }
 
 bool CultureManager::_load_culture(CultureGroup const* culture_group,
-	const std::string_view culture_key, ast::NodeCPtr culture_node) {
+	std::string_view culture_key, ast::NodeCPtr culture_node) {
 
 	colour_t colour = NULL_COLOUR;
 	std::vector<std::string> first_names, last_names;

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -10,7 +10,7 @@ namespace OpenVic {
 		friend struct CultureManager;
 
 	private:
-		GraphicalCultureType(const std::string_view new_identifier);
+		GraphicalCultureType(std::string_view new_identifier);
 
 	public:
 		GraphicalCultureType(GraphicalCultureType&&) = default;
@@ -26,7 +26,7 @@ namespace OpenVic {
 
 		// TODO - union tag
 
-		CultureGroup(const std::string_view new_identifier, const std::string_view new_leader, GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas);
+		CultureGroup(std::string_view new_identifier, std::string_view new_leader, GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas);
 
 	public:
 		CultureGroup(CultureGroup&&) = default;
@@ -45,7 +45,7 @@ namespace OpenVic {
 
 		// TODO - radicalism, primary tag
 
-		Culture(const std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group, std::vector<std::string> const& new_first_names, std::vector<std::string> const& new_last_names);
+		Culture(std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group, std::vector<std::string> const& new_first_names, std::vector<std::string> const& new_last_names);
 
 	public:
 		Culture(Culture&&) = default;
@@ -62,19 +62,19 @@ namespace OpenVic {
 		IdentifierRegistry<Culture> cultures;
 
 		bool _load_culture_group(size_t& total_expected_cultures, GraphicalCultureType const* default_unit_graphical_culture_type,
-			const std::string_view culture_group_key, ast::NodeCPtr culture_group_node);
-		bool _load_culture(CultureGroup const* culture_group, const std::string_view culture_key, ast::NodeCPtr node);
+			std::string_view culture_group_key, ast::NodeCPtr culture_group_node);
+		bool _load_culture(CultureGroup const* culture_group, std::string_view culture_key, ast::NodeCPtr node);
 
 	public:
 		CultureManager();
 
-		bool add_graphical_culture_type(const std::string_view identifier);
+		bool add_graphical_culture_type(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(GraphicalCultureType, graphical_culture_type)
 
-		bool add_culture_group(const std::string_view identifier, const std::string_view leader, GraphicalCultureType const* new_graphical_culture_type, bool is_overseas);
+		bool add_culture_group(std::string_view identifier, std::string_view leader, GraphicalCultureType const* new_graphical_culture_type, bool is_overseas);
 		IDENTIFIER_REGISTRY_ACCESSORS(CultureGroup, culture_group)
 
-		bool add_culture(const std::string_view identifier, colour_t colour, CultureGroup const* group, std::vector<std::string> const& first_names, std::vector<std::string> const& last_names);
+		bool add_culture(std::string_view identifier, colour_t colour, CultureGroup const* group, std::vector<std::string> const& first_names, std::vector<std::string> const& last_names);
 		IDENTIFIER_REGISTRY_ACCESSORS(Culture, culture)
 
 		bool load_graphical_culture_type_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -49,7 +49,7 @@ Pop::pop_size_t Pop::get_pop_daily_change() const {
 	return Pop::get_num_promoted() - (Pop::get_num_demoted() + Pop::get_num_migrated());
 }
 
-PopType::PopType(const std::string_view new_identifier, colour_t new_colour,
+PopType::PopType(std::string_view new_identifier, colour_t new_colour,
 	strata_t new_strata, sprite_t new_sprite,
 	Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
 	bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan, bool new_is_slave)
@@ -117,7 +117,7 @@ ReligionManager const& PopManager::get_religion_manager() const {
 	return religion_manager;
 }
 
-bool PopManager::add_pop_type(const std::string_view identifier, colour_t colour, PopType::strata_t strata, PopType::sprite_t sprite,
+bool PopManager::add_pop_type(std::string_view identifier, colour_t colour, PopType::strata_t strata, PopType::sprite_t sprite,
 	Pop::pop_size_t max_size, Pop::pop_size_t merge_max_size, bool state_capital_only, bool demote_migrant, bool is_artisan, bool is_slave) {
 	if (identifier.empty()) {
 		Logger::error("Invalid pop type identifier - empty!");
@@ -145,7 +145,7 @@ bool PopManager::add_pop_type(const std::string_view identifier, colour_t colour
 /* REQUIREMENTS:
  * POP-3, POP-4, POP-5, POP-6, POP-7, POP-8, POP-9, POP-10, POP-11, POP-12, POP-13, POP-14
  */
-bool PopManager::load_pop_type_file(const std::string_view filestem, ast::NodeCPtr root) {
+bool PopManager::load_pop_type_file(std::string_view filestem, ast::NodeCPtr root) {
 	colour_t colour = NULL_COLOUR;
 	PopType::strata_t strata = PopType::strata_t::POOR;
 	PopType::sprite_t sprite = 0;
@@ -210,7 +210,7 @@ bool PopManager::load_pop_type_file(const std::string_view filestem, ast::NodeCP
 	return ret;
 }
 
-bool PopManager::load_pop_into_province(Province& province, const std::string_view pop_type_identifier, ast::NodeCPtr pop_node) const {
+bool PopManager::load_pop_into_province(Province& province, std::string_view pop_type_identifier, ast::NodeCPtr pop_node) const {
 	PopType const* type = get_pop_type_by_identifier(pop_type_identifier);
 	Culture const* culture = nullptr;
 	Religion const* religion = nullptr;

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -152,11 +152,11 @@ bool PopManager::load_pop_type_file(std::string_view filestem, ast::NodeCPtr roo
 	bool state_capital_only = false, is_artisan = false, is_slave = false, demote_migrant = false;
 	Pop::pop_size_t max_size = 0, merge_max_size = 0;
 	bool ret = expect_dictionary_keys(
-		"sprite", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("poptype sprite", sprite)),
+		"sprite", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(sprite)),
 		"color", ONE_EXACTLY, expect_colour(assign_variable_callback(colour)),
 		"is_artisan", ZERO_OR_ONE, expect_bool(assign_variable_callback(is_artisan)),
-		"max_size", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint("poptype max_size", max_size)),
-		"merge_max_size", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint("poptype merge_max_size", merge_max_size)),
+		"max_size", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint(max_size)),
+		"merge_max_size", ZERO_OR_ONE, expect_uint(assign_variable_callback_uint(merge_max_size)),
 		"strata", ONE_EXACTLY, expect_identifier(
 			[&strata](std::string_view identifier) -> bool {
 				using strata_map_t = std::map<std::string, PopType::strata_t, std::less<void>>;
@@ -218,7 +218,7 @@ bool PopManager::load_pop_into_province(Province& province, std::string_view pop
 	bool ret = expect_dictionary_keys(
 		"culture", ONE_EXACTLY, culture_manager.expect_culture_identifier(assign_variable_callback_pointer(culture)),
 		"religion", ONE_EXACTLY, religion_manager.expect_religion_identifier(assign_variable_callback_pointer(religion)),
-		"size", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("pop size", size)),
+		"size", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(size)),
 		"militancy", ZERO_OR_ONE, success_callback,
 		"rebel_type", ZERO_OR_ONE, success_callback
 	)(pop_node);

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -60,7 +60,7 @@ namespace OpenVic {
 
 		// TODO - rebel composition, life/everyday/luxury needs, country and province migration targets, promote_to targets, ideologies and issues
 
-		PopType(const std::string_view new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
+		PopType(std::string_view new_identifier, colour_t new_colour, strata_t new_strata, sprite_t new_sprite, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
 			bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan, bool new_is_slave);
 
 	public:
@@ -93,12 +93,12 @@ namespace OpenVic {
 		ReligionManager& get_religion_manager();
 		ReligionManager const& get_religion_manager() const;
 
-		bool add_pop_type(const std::string_view identifier, colour_t new_colour, PopType::strata_t strata, PopType::sprite_t sprite,
+		bool add_pop_type(std::string_view identifier, colour_t new_colour, PopType::strata_t strata, PopType::sprite_t sprite,
 			Pop::pop_size_t max_size, Pop::pop_size_t merge_max_size, bool state_capital_only, bool demote_migrant,
 			bool is_artisan, bool is_slave);
 		IDENTIFIER_REGISTRY_ACCESSORS(PopType, pop_type)
 
-		bool load_pop_type_file(const std::string_view filestem, ast::NodeCPtr root);
-		bool load_pop_into_province(Province& province, const std::string_view pop_type_identifier, ast::NodeCPtr pop_node) const;
+		bool load_pop_type_file(std::string_view filestem, ast::NodeCPtr root);
+		bool load_pop_into_province(Province& province, std::string_view pop_type_identifier, ast::NodeCPtr pop_node) const;
 	};
 }

--- a/src/openvic-simulation/pop/Religion.cpp
+++ b/src/openvic-simulation/pop/Religion.cpp
@@ -5,9 +5,9 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-ReligionGroup::ReligionGroup(const std::string_view new_identifier) : HasIdentifier { new_identifier } {}
+ReligionGroup::ReligionGroup(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
-Religion::Religion(const std::string_view new_identifier, colour_t new_colour,
+Religion::Religion(std::string_view new_identifier, colour_t new_colour,
 	ReligionGroup const& new_group, icon_t new_icon, bool new_pagan)
 	: HasIdentifierAndColour { new_identifier, new_colour, true, false },
 	  group { new_group },
@@ -32,7 +32,7 @@ ReligionManager::ReligionManager()
 	: religion_groups { "religion groups" },
 	  religions { "religions" } {}
 
-bool ReligionManager::add_religion_group(const std::string_view identifier) {
+bool ReligionManager::add_religion_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid religion group identifier - empty!");
 		return false;
@@ -40,7 +40,7 @@ bool ReligionManager::add_religion_group(const std::string_view identifier) {
 	return religion_groups.add_item({ identifier });
 }
 
-bool ReligionManager::add_religion(const std::string_view identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan) {
+bool ReligionManager::add_religion(std::string_view identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan) {
 	if (!religion_groups.is_locked()) {
 		Logger::error("Cannot register religions until religion groups are locked!");
 		return false;

--- a/src/openvic-simulation/pop/Religion.cpp
+++ b/src/openvic-simulation/pop/Religion.cpp
@@ -91,7 +91,7 @@ bool ReligionManager::load_religion_file(ast::NodeCPtr root) {
 					bool pagan = false;
 
 					bool ret = expect_dictionary_keys(
-						"icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("religion icon", icon)),
+						"icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(icon)),
 						"color", ONE_EXACTLY, expect_colour(assign_variable_callback(colour)),
 						"pagan", ZERO_OR_ONE, expect_bool(assign_variable_callback(pagan))
 					)(value);

--- a/src/openvic-simulation/pop/Religion.hpp
+++ b/src/openvic-simulation/pop/Religion.hpp
@@ -11,7 +11,7 @@ namespace OpenVic {
 		friend struct ReligionManager;
 
 	private:
-		ReligionGroup(const std::string_view new_identifier);
+		ReligionGroup(std::string_view new_identifier);
 
 	public:
 		ReligionGroup(ReligionGroup&&) = default;
@@ -27,7 +27,7 @@ namespace OpenVic {
 		const icon_t icon;
 		const bool pagan;
 
-		Religion(const std::string_view new_identifier, colour_t new_colour, ReligionGroup const& new_group, icon_t new_icon, bool new_pagan);
+		Religion(std::string_view new_identifier, colour_t new_colour, ReligionGroup const& new_group, icon_t new_icon, bool new_pagan);
 
 	public:
 		Religion(Religion&&) = default;
@@ -45,10 +45,10 @@ namespace OpenVic {
 	public:
 		ReligionManager();
 
-		bool add_religion_group(const std::string_view identifier);
+		bool add_religion_group(std::string_view identifier);
 		IDENTIFIER_REGISTRY_ACCESSORS(ReligionGroup, religion_group)
 
-		bool add_religion(const std::string_view identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan);
+		bool add_religion(std::string_view identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan);
 		IDENTIFIER_REGISTRY_ACCESSORS(Religion, religion)
 
 		bool load_religion_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/types/Date.cpp
+++ b/src/openvic-simulation/types/Date.cpp
@@ -257,6 +257,6 @@ Date Date::from_string(char const* str, size_t length, bool* successful) {
 	return from_string(str, str + length, successful);
 }
 
-Date Date::from_string(const std::string_view str, bool* successful) {
+Date Date::from_string(std::string_view str, bool* successful) {
 	return from_string(str.data(), str.length(), successful);
 }

--- a/src/openvic-simulation/types/Date.hpp
+++ b/src/openvic-simulation/types/Date.hpp
@@ -90,7 +90,7 @@ namespace OpenVic {
 		// Parsed from string of the form YYYY.MM.DD
 		static Date from_string(char const* str, char const* end, bool* successful = nullptr);
 		static Date from_string(char const* str, size_t length, bool* successful = nullptr);
-		static Date from_string(const std::string_view str, bool* successful = nullptr);
+		static Date from_string(std::string_view str, bool* successful = nullptr);
 	};
 	std::ostream& operator<<(std::ostream& out, Date const& date);
 }

--- a/src/openvic-simulation/types/IdentifierRegistry.cpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.cpp
@@ -4,7 +4,7 @@
 
 using namespace OpenVic;
 
-HasIdentifier::HasIdentifier(const std::string_view new_identifier)
+HasIdentifier::HasIdentifier(std::string_view new_identifier)
 	: identifier { new_identifier } {
 	assert(!identifier.empty());
 }
@@ -31,7 +31,7 @@ std::string HasColour::colour_to_hex_string() const {
 	return OpenVic::colour_to_hex_string(colour);
 }
 
-HasIdentifierAndColour::HasIdentifierAndColour(const std::string_view new_identifier,
+HasIdentifierAndColour::HasIdentifierAndColour(std::string_view new_identifier,
 	const colour_t new_colour, bool can_be_null, bool can_have_alpha)
 	: HasIdentifier { new_identifier },
 	  HasColour { new_colour, can_be_null, can_have_alpha } {}

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -16,7 +16,7 @@ namespace OpenVic {
 		const std::string identifier;
 
 	protected:
-		HasIdentifier(const std::string_view new_identifier);
+		HasIdentifier(std::string_view new_identifier);
 
 	public:
 		HasIdentifier(HasIdentifier const&) = delete;
@@ -55,7 +55,7 @@ namespace OpenVic {
 	 */
 	class HasIdentifierAndColour : public HasIdentifier, public HasColour {
 	protected:
-		HasIdentifierAndColour(const std::string_view new_identifier, const colour_t new_colour, bool can_be_null, bool can_have_alpha);
+		HasIdentifierAndColour(std::string_view new_identifier, const colour_t new_colour, bool can_be_null, bool can_have_alpha);
 
 	public:
 		HasIdentifierAndColour(HasIdentifierAndColour const&) = delete;
@@ -86,7 +86,7 @@ namespace OpenVic {
 		identifier_index_map_t identifier_index_map;
 
 	public:
-		IdentifierRegistry(const std::string_view new_name, bool new_log_lock = true)
+		IdentifierRegistry(std::string_view new_name, bool new_log_lock = true)
 			: name { new_name }, log_lock { new_log_lock } {}
 
 		std::string const& get_name() const {
@@ -143,13 +143,13 @@ namespace OpenVic {
 			}
 		}
 
-		T* get_item_by_identifier(const std::string_view identifier) {
+		T* get_item_by_identifier(std::string_view identifier) {
 			const identifier_index_map_t::const_iterator it = identifier_index_map.find(identifier);
 			if (it != identifier_index_map.end()) return &items[it->second];
 			return nullptr;
 		}
 
-		T const* get_item_by_identifier(const std::string_view identifier) const {
+		T const* get_item_by_identifier(std::string_view identifier) const {
 			const identifier_index_map_t::const_iterator it = identifier_index_map.find(identifier);
 			if (it != identifier_index_map.end()) return &items[it->second];
 			return nullptr;
@@ -242,7 +242,7 @@ namespace OpenVic {
 #define IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(type, singular, plural) \
 	void lock_##plural() { plural.lock(); } \
 	bool plural##_are_locked() const { return plural.is_locked(); } \
-	type const* get_##singular##_by_identifier(const std::string_view identifier) const { \
+	type const* get_##singular##_by_identifier(std::string_view identifier) const { \
 		return plural.get_item_by_identifier(identifier); } \
 	size_t get_##singular##_count() const { \
 		return plural.size(); } \
@@ -258,7 +258,7 @@ namespace OpenVic {
 		return plural.expect_item_decimal_map(callback); }
 
 #define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_PLURAL(type, singular, plural) \
-	type* get_##singular##_by_identifier(const std::string_view identifier) { \
+	type* get_##singular##_by_identifier(std::string_view identifier) { \
 		return plural.get_item_by_identifier(identifier); } \
 	NodeTools::node_callback_t expect_##singular##_identifier(NodeTools::callback_t<type&> callback) { \
 		return plural.expect_item_identifier(callback); } \

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -155,12 +155,20 @@ namespace OpenVic {
 			return nullptr;
 		}
 
+		bool has_identifier(std::string_view identifier) const {
+			return get_item_by_identifier(identifier) != nullptr;
+		}
+
 		T* get_item_by_index(size_t index) {
 			return index < items.size() ? &items[index] : nullptr;
 		}
 
 		T const* get_item_by_index(size_t index) const {
 			return index < items.size() ? &items[index] : nullptr;
+		}
+
+		bool has_index(size_t index) const {
+			return get_item_by_index(index) != nullptr;
 		}
 
 		std::vector<T>& get_items() {
@@ -244,6 +252,8 @@ namespace OpenVic {
 	bool plural##_are_locked() const { return plural.is_locked(); } \
 	type const* get_##singular##_by_identifier(std::string_view identifier) const { \
 		return plural.get_item_by_identifier(identifier); } \
+	bool has_##singular##_identifier(std::string_view identifier) const { \
+		return plural.has_identifier(identifier); } \
 	size_t get_##singular##_count() const { \
 		return plural.size(); } \
 	std::vector<type> const& get_##plural() const { \

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -329,7 +329,7 @@ namespace OpenVic {
 			return parse(str, str + length, successful);
 		}
 
-		static fixed_point_t parse(const std::string_view str, bool* successful = nullptr) {
+		static fixed_point_t parse(std::string_view str, bool* successful = nullptr) {
 			return parse(str.data(), str.length(), successful);
 		}
 

--- a/src/openvic-simulation/units/Unit.cpp
+++ b/src/openvic-simulation/units/Unit.cpp
@@ -1,6 +1,6 @@
 #include "Unit.hpp"
 
-#define UNIT_ARGS icon, sprite, active, type, floating_flag, priority, max_strength, \
+#define UNIT_ARGS icon, sprite, active, unit_type, floating_flag, priority, max_strength, \
 					default_organisation, maximum_speed, weighted_value, build_time, build_cost, supply_consumption, \
 					supply_cost
 #define LAND_ARGS reconnaissance, attack, defence, discipline, support, maneuver, siege
@@ -10,8 +10,8 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-Unit::Unit(std::string_view identifier, std::string_view category, UNIT_PARAMS) : HasIdentifier { identifier },
-	icon { icon }, category { category }, sprite { sprite }, active { active }, type { type },
+Unit::Unit(std::string_view identifier, type_t type, UNIT_PARAMS) : HasIdentifier { identifier },
+	icon { icon }, type { type }, sprite { sprite }, active { active }, unit_type { unit_type },
 	floating_flag { floating_flag }, priority { priority }, max_strength { max_strength },
 	default_organisation { default_organisation }, maximum_speed { maximum_speed }, weighted_value { weighted_value },
 	build_time { build_time }, build_cost { build_cost }, supply_consumption { supply_consumption }, supply_cost { supply_cost } {}
@@ -20,7 +20,11 @@ Unit::icon_t Unit::get_icon() const {
 	return icon;
 }
 
-Unit::sprite_t Unit::get_sprite() const {
+Unit::type_t Unit::get_type() const {
+	return type;
+}
+
+std::string const& Unit::get_sprite() const {
 	return sprite;
 }
 
@@ -28,8 +32,8 @@ bool Unit::is_active() const {
 	return active;
 }
 
-std::string_view Unit::get_type() const {
-	return type;
+std::string const& Unit::get_unit_type() const {
+	return unit_type;
 }
 
 bool Unit::has_floating_flag() const {
@@ -60,7 +64,7 @@ fixed_point_t Unit::get_weighted_value() const {
 	return weighted_value;
 }
 
-std::map<const Good*, fixed_point_t> const& Unit::get_build_cost() const {
+std::map<Good const*, fixed_point_t> const& Unit::get_build_cost() const {
 	return build_cost;
 }
 
@@ -68,11 +72,11 @@ fixed_point_t Unit::get_supply_consumption() const {
 	return supply_consumption;
 }
 
-std::map<const Good*, fixed_point_t> const& Unit::get_supply_cost() const {
+std::map<Good const*, fixed_point_t> const& Unit::get_supply_cost() const {
 	return supply_cost;
 }
 
-LandUnit::LandUnit(std::string_view identifier, UNIT_PARAMS, LAND_PARAMS) : Unit { identifier, "land", UNIT_ARGS },
+LandUnit::LandUnit(std::string_view identifier, UNIT_PARAMS, LAND_PARAMS) : Unit { identifier, type_t::LAND, UNIT_ARGS },
 	reconnaissance { reconnaissance }, attack { attack }, defence { defence }, discipline { discipline }, support { support },
 	maneuver { maneuver }, siege { siege } {}
 
@@ -104,7 +108,7 @@ fixed_point_t LandUnit::get_siege() const {
 	return siege;
 }
 
-NavalUnit::NavalUnit(std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS) : Unit { identifier, "naval", UNIT_ARGS },
+NavalUnit::NavalUnit(std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS) : Unit { identifier, type_t::NAVAL, UNIT_ARGS },
 	naval_icon { naval_icon }, sail { sail }, transport { transport }, capital { capital }, move_sound { move_sound },
 	select_sound { select_sound }, colonial_points { colonial_points }, build_overseas { build_overseas },
 	min_port_level { min_port_level }, limit_per_port { limit_per_port }, supply_consumption_score { supply_consumption_score },
@@ -122,11 +126,11 @@ bool NavalUnit::is_transport() const {
 	return transport;
 }
 
-NavalUnit::sound_t NavalUnit::get_move_sound() const {
+std::string const& NavalUnit::get_move_sound() const {
 	return move_sound;
 }
 
-NavalUnit::sound_t NavalUnit::get_select_sound() const {
+std::string const& NavalUnit::get_select_sound() const {
 	return select_sound;
 }
 
@@ -183,7 +187,7 @@ bool UnitManager::_check_shared_parameters(std::string_view identifier, UNIT_PAR
 		return false;
 	}
 
-	if (type.empty()) {
+	if (unit_type.empty()) {
 		Logger::error("Invalid unit type - empty!");
 		return false;
 	}
@@ -212,38 +216,36 @@ bool UnitManager::add_naval_unit(std::string_view identifier, UNIT_PARAMS, NAVY_
 }
 
 bool UnitManager::load_unit_file(GoodManager const& good_manager, ast::NodeCPtr root) {
-	return NodeTools::expect_dictionary([this, &good_manager](std::string_view key, ast::NodeCPtr value) -> bool {
-		Unit::icon_t icon;
-		std::string_view category, type;
-		Unit::sprite_t sprite;
-		bool active = true, floating_flag;
-		uint32_t priority, build_time_days;
-		fixed_point_t maximum_speed, max_strength, default_organisation, weighted_value, supply_consumption;
-		std::map<const Good*, fixed_point_t> build_cost, supply_cost;
+	return expect_dictionary([this, &good_manager](std::string_view key, ast::NodeCPtr value) -> bool {
+		Unit::icon_t icon = 0;
+		std::string_view type, unit_type, sprite;
+		bool active = true, floating_flag = false;
+		uint32_t priority = 0;
+		Timespan build_time;
+		fixed_point_t maximum_speed = 0, max_strength = 0, default_organisation = 0, weighted_value = 0, supply_consumption = 0;
+		std::map<Good const*, fixed_point_t> build_cost, supply_cost;
 
 		//shared
 		bool ret = expect_dictionary_keys(ALLOW_OTHER_KEYS,
-			"icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("unit icon", icon)),
-			"type", ONE_EXACTLY, expect_identifier(assign_variable_callback(category)),
+			"icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(icon)),
+			"type", ONE_EXACTLY, expect_identifier(assign_variable_callback(type)),
 			"sprite", ONE_EXACTLY, expect_identifier(assign_variable_callback(sprite)),
 			"active", ZERO_OR_ONE, expect_bool(assign_variable_callback(active)),
-			"unit_type", ONE_EXACTLY, expect_identifier(assign_variable_callback(type)),
+			"unit_type", ONE_EXACTLY, expect_identifier(assign_variable_callback(unit_type)),
 			"floating_flag", ONE_EXACTLY, expect_bool(assign_variable_callback(floating_flag)),
-			"priority", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("unit priority", priority)),
+			"priority", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(priority)),
 			"max_strength", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(max_strength)),
 			"default_organisation", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(default_organisation)),
 			"maximum_speed", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(maximum_speed)),
 			"weighted_value", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(weighted_value)),
-			"build_time", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("unit build time", build_time_days)),
-			"build_cost", ONE_EXACTLY, good_manager.expect_good_decimal_map(assign_variable_callback(build_cost)),
-			"supply_consumption", ONE_EXACTLY, expect_fixed_point(move_variable_callback(supply_consumption)),
+			"build_time", ONE_EXACTLY, expect_timespan(assign_variable_callback(build_time)),
+			"build_cost", ONE_EXACTLY, good_manager.expect_good_decimal_map(move_variable_callback(build_cost)),
+			"supply_consumption", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(supply_consumption)),
 			"supply_cost", ONE_EXACTLY, good_manager.expect_good_decimal_map(move_variable_callback(supply_cost))
 		)(value);
 
-		Timespan build_time = { build_time_days };
-
-		if (category == "land") {
-			fixed_point_t reconnaissance, attack, defence, discipline, support, maneuver, siege;
+		if (type == "land") {
+			fixed_point_t reconnaissance = 0, attack = 0, defence = 0, discipline = 0, support = 0, maneuver = 0, siege = 0;
 
 			ret &= expect_dictionary_keys(ALLOW_OTHER_KEYS,
 				"reconnaissance", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(reconnaissance)),
@@ -258,16 +260,16 @@ bool UnitManager::load_unit_file(GoodManager const& good_manager, ast::NodeCPtr 
 			ret &= add_land_unit(key, UNIT_ARGS, LAND_ARGS);
 
 			return ret;
-		} else if (category == "naval") {
-			Unit::icon_t naval_icon;
+		} else if (type == "naval") {
+			Unit::icon_t naval_icon = 0;
 			bool sail = false, transport = false, capital = false, build_overseas = false;
-			Unit::sound_t move_sound, select_sound; //TODO defaults for both
-			uint32_t min_port_level;
-			int32_t limit_per_port;
-			fixed_point_t fire_range, evasion, supply_consumption_score, hull, gun_power, colonial_points = 0, torpedo_attack = 0;
+			std::string_view move_sound, select_sound; //TODO defaults for both
+			uint32_t min_port_level = 0;
+			int32_t limit_per_port = 0;
+			fixed_point_t fire_range = 0, evasion = 0, supply_consumption_score = 0, hull = 0, gun_power = 0, colonial_points = 0, torpedo_attack = 0;
 
 			ret &= expect_dictionary_keys(ALLOW_OTHER_KEYS,
-				"naval_icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("unit naval icon", naval_icon)),
+				"naval_icon", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(naval_icon)),
 				"sail", ZERO_OR_ONE, expect_bool(assign_variable_callback(sail)),
 				"transport", ZERO_OR_ONE, expect_bool(assign_variable_callback(transport)),
 				"capital", ZERO_OR_ONE, expect_bool(assign_variable_callback(capital)),
@@ -275,8 +277,8 @@ bool UnitManager::load_unit_file(GoodManager const& good_manager, ast::NodeCPtr 
 				"select_sound", ZERO_OR_ONE, expect_identifier(assign_variable_callback(select_sound)),
 				"colonial_points", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(colonial_points)),
 				"can_build_overseas", ZERO_OR_ONE, expect_bool(assign_variable_callback(build_overseas)),
-				"min_port_level", ONE_EXACTLY, expect_uint(assign_variable_callback_uint("unit min port level", min_port_level)),
-				"limit_per_port", ONE_EXACTLY, expect_int(assign_variable_callback_int("unit limit per port", limit_per_port)),
+				"min_port_level", ONE_EXACTLY, expect_uint(assign_variable_callback_uint(min_port_level)),
+				"limit_per_port", ONE_EXACTLY, expect_int(assign_variable_callback_int(limit_per_port)),
 				"supply_consumption_score", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(supply_consumption_score)),
 				"hull", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(hull)),
 				"gun_power", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(gun_power)),
@@ -288,6 +290,9 @@ bool UnitManager::load_unit_file(GoodManager const& good_manager, ast::NodeCPtr 
 			ret &= add_naval_unit(key, UNIT_ARGS, NAVY_ARGS);
 
 			return ret;
-		} else return false;
+		} else {
+			Logger::error("Invalid type for unit ", key, ": ", type);
+			return false;
+		}
 	})(root);
 }

--- a/src/openvic-simulation/units/Unit.cpp
+++ b/src/openvic-simulation/units/Unit.cpp
@@ -172,7 +172,7 @@ fixed_point_t NavalUnit::get_torpedo_attack() const {
 
 UnitManager::UnitManager() : units { "units" } {}
 
-bool UnitManager::_check_shared_parameters(const std::string_view identifier, UNIT_PARAMS) {
+bool UnitManager::_check_shared_parameters(std::string_view identifier, UNIT_PARAMS) {
 	if (identifier.empty()) {
 		Logger::error("Invalid religion identifier - empty!");
 		return false;
@@ -193,7 +193,7 @@ bool UnitManager::_check_shared_parameters(const std::string_view identifier, UN
 	return true;
 }
 
-bool UnitManager::add_land_unit(const std::string_view identifier, UNIT_PARAMS, LAND_PARAMS) {
+bool UnitManager::add_land_unit(std::string_view identifier, UNIT_PARAMS, LAND_PARAMS) {
 	if (!_check_shared_parameters(identifier, UNIT_ARGS)) {
 		return false;
 	}
@@ -201,7 +201,7 @@ bool UnitManager::add_land_unit(const std::string_view identifier, UNIT_PARAMS, 
 	return units.add_item(LandUnit { identifier, UNIT_ARGS, LAND_ARGS });
 }
 
-bool UnitManager::add_naval_unit(const std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS) {
+bool UnitManager::add_naval_unit(std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS) {
 	if (!_check_shared_parameters(identifier, UNIT_ARGS)) {
 		return false;
 	}

--- a/src/openvic-simulation/units/Unit.hpp
+++ b/src/openvic-simulation/units/Unit.hpp
@@ -147,13 +147,13 @@ namespace OpenVic {
 	private:
 		IdentifierRegistry<Unit> units;
 
-		bool _check_shared_parameters(const std::string_view identifier, UNIT_PARAMS);
+		bool _check_shared_parameters(std::string_view identifier, UNIT_PARAMS);
 
 	public:
 		UnitManager();
 
-		bool add_land_unit(const std::string_view identifier, UNIT_PARAMS, LAND_PARAMS);
-		bool add_naval_unit(const std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS);
+		bool add_land_unit(std::string_view identifier, UNIT_PARAMS, LAND_PARAMS);
+		bool add_naval_unit(std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS);
 		IDENTIFIER_REGISTRY_ACCESSORS(Unit, unit)
 
 		bool load_unit_file(GoodManager const& good_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/units/Unit.hpp
+++ b/src/openvic-simulation/units/Unit.hpp
@@ -9,30 +9,32 @@
 #include "openvic-simulation/economy/Good.hpp"
 #include "openvic-simulation/types/Date.hpp"
 
-#define UNIT_PARAMS Unit::icon_t icon, Unit::sprite_t sprite, bool active, std::string_view type, \
+#define UNIT_PARAMS Unit::icon_t icon, std::string_view sprite, bool active, std::string_view unit_type, \
 					bool floating_flag, uint32_t priority, fixed_point_t max_strength, fixed_point_t default_organisation, \
 					fixed_point_t maximum_speed, fixed_point_t weighted_value, Timespan build_time, \
-					std::map<const Good*, fixed_point_t> build_cost, fixed_point_t supply_consumption, \
-					std::map<const Good*, fixed_point_t> supply_cost
+					std::map<Good const*, fixed_point_t> build_cost, fixed_point_t supply_consumption, \
+					std::map<Good const*, fixed_point_t> supply_cost
 #define LAND_PARAMS fixed_point_t reconnaissance, fixed_point_t attack, fixed_point_t defence, fixed_point_t discipline, \
 					fixed_point_t support, fixed_point_t maneuver, fixed_point_t siege
-#define NAVY_PARAMS Unit::icon_t naval_icon, bool sail, bool transport, bool capital, Unit::sound_t move_sound, \
-					Unit::sound_t select_sound, fixed_point_t colonial_points, bool build_overseas, uint32_t min_port_level, \
+#define NAVY_PARAMS Unit::icon_t naval_icon, bool sail, bool transport, bool capital, std::string_view move_sound, \
+					std::string_view select_sound, fixed_point_t colonial_points, bool build_overseas, uint32_t min_port_level, \
 					int32_t limit_per_port, fixed_point_t supply_consumption_score, fixed_point_t hull, fixed_point_t gun_power, \
 					fixed_point_t fire_range, fixed_point_t evasion, fixed_point_t torpedo_attack
 
 namespace OpenVic {
 	struct Unit : HasIdentifier {
 		using icon_t = uint32_t;
-		using sprite_t = std::string_view;
-		using sound_t = std::string_view;
+
+		enum struct type_t {
+			LAND, NAVAL
+		};
 
 	private:
-		const std::string_view category;
+		const type_t type;
 		const icon_t icon;
-		const sprite_t sprite;
+		const std::string sprite;
 		const bool active;
-		const std::string_view type;
+		const std::string unit_type;
 		const bool floating_flag;
 
 		const uint32_t priority;
@@ -42,21 +44,21 @@ namespace OpenVic {
 		const fixed_point_t weighted_value;
 
 		const Timespan build_time;
-		const std::map<const Good*, fixed_point_t> build_cost;
+		const std::map<Good const*, fixed_point_t> build_cost;
 		const fixed_point_t supply_consumption;
-		const std::map<const Good*, fixed_point_t> supply_cost;
+		const std::map<Good const*, fixed_point_t> supply_cost;
 
 	protected:
-		Unit(std::string_view identifier, std::string_view category, UNIT_PARAMS);
+		Unit(std::string_view identifier, type_t type, UNIT_PARAMS);
 
 	public:
 		Unit(Unit&&) = default;
 
 		icon_t get_icon() const;
-		std::string_view get_category() const;
-		sprite_t get_sprite() const;
+		type_t get_type() const;
+		std::string const& get_sprite() const;
 		bool is_active() const;
-		std::string_view get_type() const;
+		std::string const& get_unit_type() const;
 		bool has_floating_flag() const;
 
 		uint32_t get_priority() const;
@@ -66,9 +68,9 @@ namespace OpenVic {
 		fixed_point_t get_weighted_value() const;
 
 		Timespan get_build_time() const;
-		std::map<const Good*, fixed_point_t> const& get_build_cost() const;
+		std::map<Good const*, fixed_point_t> const& get_build_cost() const;
 		fixed_point_t get_supply_consumption() const;
-		std::map<const Good*, fixed_point_t> const& get_supply_cost() const;
+		std::map<Good const*, fixed_point_t> const& get_supply_cost() const;
 	};
 
 	struct LandUnit : Unit {
@@ -105,8 +107,8 @@ namespace OpenVic {
 		const bool sail;
 		const bool transport;
 		const bool capital;
-		const sound_t move_sound;
-		const sound_t select_sound;
+		const std::string move_sound;
+		const std::string select_sound;
 		const fixed_point_t colonial_points;
 		const bool build_overseas;
 		const uint32_t min_port_level;
@@ -128,8 +130,8 @@ namespace OpenVic {
 		bool can_sail() const;
 		bool is_transport() const;
 		bool is_capital() const;
-		sound_t get_move_sound() const;
-		sound_t get_select_sound() const;
+		std::string const& get_move_sound() const;
+		std::string const& get_select_sound() const;
 		fixed_point_t get_colonial_points() const;
 		bool can_build_overseas() const;
 		uint32_t get_min_port_level() const;

--- a/src/openvic-simulation/utility/StringUtils.hpp
+++ b/src/openvic-simulation/utility/StringUtils.hpp
@@ -85,7 +85,7 @@ namespace OpenVic::StringUtils {
 		return string_to_uint64(str, str + length, successful, base);
 	}
 
-	inline uint64_t string_to_uint64(const std::string_view str, bool* successful = nullptr, int base = 10) {
+	inline uint64_t string_to_uint64(std::string_view str, bool* successful = nullptr, int base = 10) {
 		return string_to_uint64(str.data(), str.length(), successful, base);
 	}
 
@@ -121,7 +121,7 @@ namespace OpenVic::StringUtils {
 		return string_to_int64(str, str + length, successful, base);
 	}
 
-	inline int64_t string_to_int64(const std::string_view str, bool* successful = nullptr, int base = 10) {
+	inline int64_t string_to_int64(std::string_view str, bool* successful = nullptr, int base = 10) {
 		return string_to_int64(str.data(), str.length(), successful, base);
 	}
 }


### PR DESCRIPTION
- Add default values for primitive types used in dataloading.
- Changed some `std::string_view`s to `std::string` - data structs need their own copy of the string, rather than just referencing the Node's string which is destroyed after loading finishes.
- Changed some callbacks to use `expect_***_identifier` rather than manually looking up an identifier and checking the resulting pointer.
- Moved `BuildingType` loading to before `Building` loading so that the `BuidlingType` pointers are stable/safe.