### PR TITLE
Expose parse methods

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -126,7 +126,7 @@ static bool _v2script_parse(v2script::Parser& parser) {
 	return parser.simple_parse();
 }
 
-static v2script::Parser _parse_defines(fs::path const& path) {
+v2script::Parser Dataloader::parse_defines(fs::path const& path) {
 	return _run_ovdl_parser<v2script::Parser, &_v2script_parse>(path);
 }
 
@@ -134,20 +134,20 @@ static bool _csv_parse(csv::Windows1252Parser& parser) {
 	return parser.parse_csv();
 }
 
-static csv::Windows1252Parser _parse_csv(fs::path const& path) {
+csv::Windows1252Parser Dataloader::parse_csv(fs::path const& path) {
 	return _run_ovdl_parser<csv::Windows1252Parser, &_csv_parse>(path);
 }
 
 static callback_t<fs::path const&> _parse_defines_callback(node_callback_t callback) {
 	return [callback](fs::path const& path) -> bool {
-		return callback(_parse_defines(path).get_file_node());
+		return callback(Dataloader::parse_defines(path).get_file_node());
 	};
 }
 
 bool Dataloader::_load_pop_types(PopManager& pop_manager, fs::path const& pop_type_directory) const {
 	const bool ret = apply_to_files_in_dir(pop_type_directory, ".txt",
 		[&pop_manager](fs::path const& file) -> bool {
-			return pop_manager.load_pop_type_file(file.stem().string(), _parse_defines(file).get_file_node());
+			return pop_manager.load_pop_type_file(file.stem().string(), parse_defines(file).get_file_node());
 		}
 	);
 	pop_manager.lock_pop_types();
@@ -157,7 +157,7 @@ bool Dataloader::_load_pop_types(PopManager& pop_manager, fs::path const& pop_ty
 bool Dataloader::_load_units(GameManager& game_manager, fs::path const& units_directory) const {
 	const bool ret = apply_to_files_in_dir(units_directory, ".txt",
 		[&game_manager](fs::path const& file) -> bool {
-			return game_manager.get_unit_manager().load_unit_file(game_manager.get_good_manager(), _parse_defines(file).get_file_node());
+			return game_manager.get_unit_manager().load_unit_file(game_manager.get_good_manager(), parse_defines(file).get_file_node());
 		}
 	);
 	game_manager.get_unit_manager().lock_units();
@@ -181,7 +181,7 @@ bool Dataloader::_load_map_dir(GameManager& game_manager, fs::path const& map_di
 	static const std::string default_region_sea = "region_sea.txt";
 	static const std::string default_province_flag_sprite = "province_flag_sprites";
 
-	const v2script::Parser parser = _parse_defines(lookup_file(map_directory / defaults_filename));
+	const v2script::Parser parser = parse_defines(lookup_file(map_directory / defaults_filename));
 
 	std::vector<std::string_view> water_province_identifiers;
 
@@ -234,17 +234,17 @@ bool Dataloader::_load_map_dir(GameManager& game_manager, fs::path const& map_di
 		Logger::error("Failed to load map default file!");
 	}
 
-	if (!map.load_province_definitions(_parse_csv(lookup_file(map_directory / definitions)).get_lines())) {
+	if (!map.load_province_definitions(parse_csv(lookup_file(map_directory / definitions)).get_lines())) {
 		Logger::error("Failed to load province definitions file!");
 		ret = false;
 	}
 
-	if (!map.load_province_positions(game_manager.get_building_manager(), _parse_defines(lookup_file(map_directory / positions)).get_file_node())) {
+	if (!map.load_province_positions(game_manager.get_building_manager(), parse_defines(lookup_file(map_directory / positions)).get_file_node())) {
 		Logger::error("Failed to load province positions file!");
 		ret = false;
 	}
 
-	if (!map.load_region_file(_parse_defines(lookup_file(map_directory / region)).get_file_node())) {
+	if (!map.load_region_file(parse_defines(lookup_file(map_directory / region)).get_file_node())) {
 		Logger::error("Failed to load region file!");
 		ret = false;
 	}
@@ -255,7 +255,7 @@ bool Dataloader::_load_map_dir(GameManager& game_manager, fs::path const& map_di
 	}
 	map.lock_water_provinces();
 
-	if (!map.get_terrain_type_manager().load_terrain_types(game_manager.get_modifier_manager(), _parse_defines(lookup_file(map_directory / terrain_definition)).get_file_node())) {
+	if (!map.get_terrain_type_manager().load_terrain_types(game_manager.get_modifier_manager(), parse_defines(lookup_file(map_directory / terrain_definition)).get_file_node())) {
 		Logger::error("Failed to load terrain types!");
 		ret = false;
 	}
@@ -265,7 +265,7 @@ bool Dataloader::_load_map_dir(GameManager& game_manager, fs::path const& map_di
 		ret = false;
 	}
 
-	if (!map.generate_and_load_province_adjacencies(_parse_csv(lookup_file(map_directory / adjacencies)).get_lines())) {
+	if (!map.generate_and_load_province_adjacencies(parse_csv(lookup_file(map_directory / adjacencies)).get_lines())) {
 		Logger::error("Failed to generate and load province adjacencies!");
 		ret = false;
 	}
@@ -294,7 +294,7 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 		Logger::error("Failed to set up modifier effects!");
 		ret = false;
 	}
-	if (!game_manager.get_good_manager().load_goods_file(_parse_defines(lookup_file(goods_file)).get_file_node())) {
+	if (!game_manager.get_good_manager().load_goods_file(parse_defines(lookup_file(goods_file)).get_file_node())) {
 		Logger::error("Failed to load goods!");
 		ret = false;
 	}
@@ -302,34 +302,34 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 		Logger::error("Failed to load pop types!");
 		ret = false;
 	}
-	if (!game_manager.get_pop_manager().get_culture_manager().load_graphical_culture_type_file(_parse_defines(lookup_file(graphical_culture_type_file)).get_file_node())) {
+	if (!game_manager.get_pop_manager().get_culture_manager().load_graphical_culture_type_file(parse_defines(lookup_file(graphical_culture_type_file)).get_file_node())) {
 		Logger::error("Failed to load graphical culture types!");
 		ret = false;
 	}
-	if (!game_manager.get_pop_manager().get_culture_manager().load_culture_file(_parse_defines(lookup_file(culture_file)).get_file_node())) {
+	if (!game_manager.get_pop_manager().get_culture_manager().load_culture_file(parse_defines(lookup_file(culture_file)).get_file_node())) {
 		Logger::error("Failed to load cultures!");
 		ret = false;
 	}
-	if (!game_manager.get_pop_manager().get_religion_manager().load_religion_file(_parse_defines(lookup_file(religion_file)).get_file_node())) {
+	if (!game_manager.get_pop_manager().get_religion_manager().load_religion_file(parse_defines(lookup_file(religion_file)).get_file_node())) {
 		Logger::error("Failed to load religions!");
 		ret = false;
 	}
-	if (!game_manager.get_ideology_manager().load_ideology_file(_parse_defines(lookup_file(ideology_file)).get_file_node())) {
+	if (!game_manager.get_ideology_manager().load_ideology_file(parse_defines(lookup_file(ideology_file)).get_file_node())) {
 		Logger::error("Failed to load ideologies!");
 		ret = false;
 	}
-	if (!game_manager.get_government_type_manager().load_government_types_file(game_manager.get_ideology_manager(), _parse_defines(lookup_file(governments_file)).get_file_node())) {
+	if (!game_manager.get_government_type_manager().load_government_types_file(game_manager.get_ideology_manager(), parse_defines(lookup_file(governments_file)).get_file_node())) {
 		Logger::error("Failed to load government types!");
 		ret = false;
 	}
-	if (!game_manager.get_issue_manager().load_issues_file(_parse_defines(lookup_file(issues_file)).get_file_node())) {
+	if (!game_manager.get_issue_manager().load_issues_file(parse_defines(lookup_file(issues_file)).get_file_node())) {
 		Logger::error("Failed to load issues!");
 		ret = false;
 	}
 	if (!game_manager.get_production_type_manager().load_production_types_file(
 			game_manager.get_good_manager(),
 			game_manager.get_pop_manager(),
-			_parse_defines(lookup_file(production_types_file)).get_file_node())) {
+			parse_defines(lookup_file(production_types_file)).get_file_node())) {
 		Logger::error("Failed to load production types!");
 		ret = false;
 	}
@@ -337,7 +337,7 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 		game_manager.get_good_manager(),
 		game_manager.get_production_type_manager(),
 		game_manager.get_modifier_manager(),
-		_parse_defines(lookup_file(buildings_file)).get_file_node())) {
+		parse_defines(lookup_file(buildings_file)).get_file_node())) {
 		Logger::error("Failed to load buildings!");
 		ret = false;
 	}
@@ -385,7 +385,7 @@ static bool _load_localisation_file(Dataloader::localisation_callback_t callback
 bool Dataloader::load_localisation_files(localisation_callback_t callback, fs::path const& localisation_dir) {
 	return apply_to_files_in_dir(localisation_dir, ".csv",
 		[callback](fs::path path) -> bool {
-			return _load_localisation_file(callback, _parse_csv(path).get_lines());
+			return _load_localisation_file(callback, parse_csv(path).get_lines());
 		}
 	);
 }

--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -2,6 +2,9 @@
 
 #include <filesystem>
 
+#include <openvic-dataloader/csv/Parser.hpp>
+#include <openvic-dataloader/v2script/Parser.hpp>
+
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 
 namespace OpenVic {
@@ -23,6 +26,9 @@ namespace OpenVic {
 		bool _load_map_dir(GameManager& game_manager, fs::path const& map_directory) const;
 
 	public:
+		static ovdl::v2script::Parser parse_defines(fs::path const& path);
+		static ovdl::csv::Windows1252Parser parse_csv(fs::path const& path);
+
 		Dataloader() = default;
 
 		/* In reverse-load order, so base defines first and final loaded mod last */


### PR DESCRIPTION
Expose `Dataloader::parse_defines` 
Expose `Dataloader::parse_csv`

This is necessary in the case that a node refers to file like in countries.txt, any other solution would be less isolated and more complex.