### PR TITLE
Accumulated changes

### DIFF
--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -170,12 +170,12 @@ bool GameManager::load_hardcoded_defines() {
 				BuildingInstance const* railroad = province.get_building_by_identifier("railroad");
 				if (railroad != nullptr) {
 					colour_t val = fraction_to_colour_byte(railroad->get_level(),
-						railroad->get_building().get_max_level() + 1, 0.5f, 1.0f);
+						railroad->get_building_type().get_max_level() + 1, 0.5f, 1.0f);
 					switch (railroad->get_expansion_state()) {
-					case ExpansionState::CannotExpand:
+					case BuildingInstance::ExpansionState::CannotExpand:
 						val <<= 16;
 						break;
-					case ExpansionState::CanExpand:
+					case BuildingInstance::ExpansionState::CanExpand:
 						break;
 					default:
 						val <<= 8;

--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -61,14 +61,58 @@ bool GameManager::expand_building(Province::index_t province_index, std::string_
 	return province->expand_building(building_type_identifier);
 }
 
-static constexpr colour_t LOW_ALPHA_VALUE = float_to_alpha_value(0.4f);
-static constexpr colour_t HIGH_ALPHA_VALUE = float_to_alpha_value(0.7f);
+static constexpr colour_t ALPHA_VALUE = float_to_alpha_value(0.5f);
 
-static colour_t default_colour(Province const& province) {
-	/* Nice looking colours to blend with the terrain textures */
-	static constexpr colour_t LAND_COLOUR = 0x0D7017;
-	static constexpr colour_t WATER_COLOUR = 0x4287F5;
-	return LOW_ALPHA_VALUE | (province.get_water() ? WATER_COLOUR : LAND_COLOUR);
+static constexpr Mapmode::base_stripe_t combine_base_stripe(colour_t base, colour_t stripe) {
+	return (static_cast<Mapmode::base_stripe_t>(stripe) << (sizeof(colour_t) * 8)) | base;
+}
+
+static constexpr Mapmode::base_stripe_t make_solid_base_stripe(colour_t colour) {
+	return combine_base_stripe(colour, colour);
+}
+
+static constexpr auto make_solid_base_stripe_func(auto func) {
+	return [func](Map const& map, Province const& province) -> Mapmode::base_stripe_t {
+		return make_solid_base_stripe(func(map, province));
+	};
+}
+
+template<std::derived_from<HasColour> T>
+static constexpr Mapmode::base_stripe_t get_colour_mapmode(T const* item) {
+	return item != nullptr ? make_solid_base_stripe(ALPHA_VALUE | item->get_colour()) : NULL_COLOUR;
+}
+
+template<std::derived_from<HasColour> T>
+static constexpr auto get_colour_mapmode(T const*(Province::*get_item)() const) {
+	return [get_item](Map const& map, Province const& province) -> Mapmode::base_stripe_t {
+		T const* item = (province.*get_item)();
+		return item != nullptr ? make_solid_base_stripe(ALPHA_VALUE | item->get_colour()) : NULL_COLOUR;
+	};
+}
+
+template<std::derived_from<HasColour> T>
+static constexpr Mapmode::base_stripe_t shaded_mapmode(fixed_point_map_t<T const*> const& map) {
+	const std::pair<fixed_point_map_const_iterator_t<T const*>, fixed_point_map_const_iterator_t<T const*>> largest =
+		get_largest_two_items(map);
+	if (largest.first != map.end()) {
+		const colour_t base_colour = ALPHA_VALUE | largest.first->first->get_colour();
+		if (largest.second != map.end()) {
+			/* If second largest is at least a third... */
+			if (largest.second->second * 3 >= get_total(map)) {
+				const colour_t stripe_colour = ALPHA_VALUE | largest.second->first->get_colour();
+				return combine_base_stripe(base_colour, stripe_colour);
+			}
+		}
+		return make_solid_base_stripe(base_colour);
+	}
+	return NULL_COLOUR;
+}
+
+template<std::derived_from<HasColour> T>
+static constexpr auto shaded_mapmode(fixed_point_map_t<T const*> const&(Province::*get_map)() const) {
+	return [get_map](Map const& map, Province const& province) -> Mapmode::base_stripe_t {
+		return shaded_mapmode((province.*get_map)());
+	};
 }
 
 bool GameManager::load_hardcoded_defines() {
@@ -78,48 +122,39 @@ bool GameManager::load_hardcoded_defines() {
 	const std::vector<mapmode_t> mapmodes {
 		{
 			"mapmode_terrain",
-			[](Map const&, Province const& province) -> colour_t {
-				return default_colour(province);
+			[](Map const&, Province const& province) -> Mapmode::base_stripe_t {
+				return NULL_COLOUR;
 			}
+		},
+		{
+			"mapmode_political", get_colour_mapmode(&Province::get_owner)
 		},
 		{
 			"mapmode_province",
-			[](Map const&, Province const& province) -> colour_t {
-				return HIGH_ALPHA_VALUE | province.get_colour();
-			}
+			make_solid_base_stripe_func([](Map const&, Province const& province) -> colour_t {
+				return ALPHA_VALUE | province.get_colour();
+			})
 		},
 		{
-			"mapmode_region",
-			[](Map const&, Province const& province) -> colour_t {
-				Region const* region = province.get_region();
-				return region != nullptr ? HIGH_ALPHA_VALUE | region->get_colour() : default_colour(province);
-			}
+			"mapmode_region", get_colour_mapmode(&Province::get_region)
 		},
 		{
 			"mapmode_index",
-			[](Map const& map, Province const& province) -> colour_t {
+			make_solid_base_stripe_func([](Map const& map, Province const& province) -> colour_t {
 				const colour_t f = fraction_to_colour_byte(province.get_index(), map.get_province_count() + 1);
-				return HIGH_ALPHA_VALUE | (f << 16) | (f << 8) | f;
-			}
+				return ALPHA_VALUE | (f << 16) | (f << 8) | f;
+			})
 		},
 		{
-			"mapmode_terrain_type",
-			[](Map const& map, Province const& province) -> colour_t {
-				TerrainType const* terrarin_type = province.get_terrain_type();
-				return terrarin_type != nullptr ? HIGH_ALPHA_VALUE | terrarin_type->get_colour() : default_colour(province);
-			}
+			"mapmode_terrain_type", get_colour_mapmode(&Province::get_terrain_type)
 		},
 		{
-			"mapmode_rgo",
-			[](Map const& map, Province const& province) -> colour_t {
-				Good const* rgo = province.get_rgo();
-				return rgo != nullptr ? HIGH_ALPHA_VALUE | rgo->get_colour() : default_colour(province);
-			}
+			"mapmode_rgo", get_colour_mapmode(&Province::get_rgo)
 		},
 		{
 			"mapmode_infrastructure",
-			[](Map const& map, Province const& province) -> colour_t {
-				BuildingInstance const* railroad = province.get_building_by_identifier("building_railroad");
+			make_solid_base_stripe_func([](Map const& map, Province const& province) -> colour_t {
+				BuildingInstance const* railroad = province.get_building_by_identifier("railroad");
 				if (railroad != nullptr) {
 					colour_t val = fraction_to_colour_byte(railroad->get_current_level(),
 						railroad->get_building().get_max_level() + 1, 0.5f, 1.0f);
@@ -133,32 +168,30 @@ bool GameManager::load_hardcoded_defines() {
 						val <<= 8;
 						break;
 					}
-					return HIGH_ALPHA_VALUE | val;
+					return ALPHA_VALUE | val;
 				}
-				return default_colour(province);
-			}
+				return NULL_COLOUR;
+			})
 		},
 		{
 			"mapmode_population",
-			[](Map const& map, Province const& province) -> colour_t {
-				return HIGH_ALPHA_VALUE | (fraction_to_colour_byte(province.get_total_population(), map.get_highest_province_population() + 1, 0.1f, 1.0f) << 8);
-			}
+			make_solid_base_stripe_func([](Map const& map, Province const& province) -> colour_t {
+				// TODO - explore non-linear scaling to have more variation among non-massive provinces
+				// TODO - when selecting a province, only show the population of provinces controlled (or owned?)
+				// by the same country, relative to the most populous province in that set of provinces
+				return ALPHA_VALUE | (fraction_to_colour_byte(
+					province.get_total_population(), map.get_highest_province_population() + 1, 0.1f, 1.0f
+				) << 8);
+			})
 		},
 		{
-			"mapmode_culture",
-			[](Map const& map, Province const& province) -> colour_t {
-				HasIdentifierAndColour const* largest = get_largest_item(province.get_culture_distribution()).first;
-				return largest != nullptr ? HIGH_ALPHA_VALUE | largest->get_colour() : default_colour(province);
-			}
+			"mapmode_culture", shaded_mapmode(&Province::get_culture_distribution)
 		},
 		{
-			"mapmode_religion",
-			[](Map const& map, Province const& province) -> colour_t {
-				HasIdentifierAndColour const* largest = get_largest_item(province.get_religion_distribution()).first;
-				return largest != nullptr ? HIGH_ALPHA_VALUE | largest->get_colour() : default_colour(province);
-			}
+			"mapmode_religion", shaded_mapmode(&Province::get_religion_distribution)
 		}
 	};
+
 	for (mapmode_t const& mapmode : mapmodes) {
 		ret &= map.add_mapmode(mapmode.first, mapmode.second);
 	}

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -29,7 +29,8 @@ namespace OpenVic {
 		GameAdvancementHook clock;
 
 		time_t session_start; /* SS-54, as well as allowing time-tracking */
-		Date today;
+		Bookmark const* PROPERTY(bookmark);
+		Date PROPERTY(today);
 		state_updated_func_t state_updated;
 		bool needs_update;
 
@@ -52,9 +53,9 @@ namespace OpenVic {
 		REF_GETTERS(ui_manager)
 		REF_GETTERS(clock)
 
-		bool setup();
+		bool reset();
+		bool load_bookmark(Bookmark const* new_bookmark);
 
-		Date get_today() const;
 		bool expand_building(Province::index_t province_index, std::string_view building_type_identifier);
 
 		/* Hardcoded data for defining things for which parsing from files has

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "openvic-simulation/GameAdvancementHook.hpp"
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/country/Country.hpp"
 #include "openvic-simulation/economy/EconomyManager.hpp"
 #include "openvic-simulation/history/HistoryManager.hpp"

--- a/src/openvic-simulation/Modifier.hpp
+++ b/src/openvic-simulation/Modifier.hpp
@@ -36,7 +36,7 @@ namespace OpenVic {
 	struct ModifierValue {
 		friend struct ModifierManager;
 
-		using effect_map_t = decimal_map_t<ModifierEffect const*>;
+		using effect_map_t = fixed_point_map_t<ModifierEffect const*>;
 
 	private:
 		effect_map_t values;

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -3,77 +3,77 @@
 using namespace OpenVic;
 
 bool CountryInstance::add_accepted_culture(Culture const* new_accepted_culture) {
-    if(std::find(accepted_cultures.begin(), accepted_cultures.end(), new_accepted_culture) != accepted_cultures.end()) {
-        Logger::warning("Attempted to add accepted culture ", new_accepted_culture->get_identifier(), " to country ", base_country->get_identifier(), ": already present!");
-        return false;
-    }
-    accepted_cultures.push_back(new_accepted_culture);
-    return true;
+	if(std::find(accepted_cultures.begin(), accepted_cultures.end(), new_accepted_culture) != accepted_cultures.end()) {
+		Logger::warning("Attempted to add accepted culture ", new_accepted_culture->get_identifier(), " to country ", base_country->get_identifier(), ": already present!");
+		return false;
+	}
+	accepted_cultures.push_back(new_accepted_culture);
+	return true;
 }
 
 bool CountryInstance::remove_accepted_culture(Culture const* culture_to_remove) {
-    auto existing_entry = std::find(accepted_cultures.begin(), accepted_cultures.end(), culture_to_remove);
-    if (existing_entry == accepted_cultures.end()) {
-        Logger::warning("Attempted to remove accepted culture ", culture_to_remove->get_identifier(), " from country ", base_country->get_identifier(), ": not present!");
-        return false;
-    }
-    accepted_cultures.erase(existing_entry);
-    return true;
+	auto existing_entry = std::find(accepted_cultures.begin(), accepted_cultures.end(), culture_to_remove);
+	if (existing_entry == accepted_cultures.end()) {
+		Logger::warning("Attempted to remove accepted culture ", culture_to_remove->get_identifier(), " from country ", base_country->get_identifier(), ": not present!");
+		return false;
+	}
+	accepted_cultures.erase(existing_entry);
+	return true;
 }
 
 void CountryInstance::add_to_upper_house(Ideology const* party, fixed_point_t popularity) {
-    upper_house[party] = popularity;
+	upper_house[party] = popularity;
 }
 
 bool CountryInstance::remove_from_upper_house(Ideology const* party) {
-    return upper_house.erase(party) == 1;
+	return upper_house.erase(party) == 1;
 }
 
 bool CountryInstance::add_reform(Reform const* new_reform) {
-    if (std::find(reforms.begin(), reforms.end(), new_reform) != reforms.end()) {
-        Logger::warning("Attempted to add reform ", new_reform->get_identifier(), " to country ", base_country->get_identifier(), ": already present!");
-        return false;
-    }
-    reforms.push_back(new_reform);
-    return true;
+	if (std::find(reforms.begin(), reforms.end(), new_reform) != reforms.end()) {
+		Logger::warning("Attempted to add reform ", new_reform->get_identifier(), " to country ", base_country->get_identifier(), ": already present!");
+		return false;
+	}
+	reforms.push_back(new_reform);
+	return true;
 }
 
 bool CountryInstance::remove_reform(Reform const* reform_to_remove) {
-    auto existing_entry = std::find(reforms.begin(), reforms.end(), reform_to_remove);
-    if (existing_entry == reforms.end()) {
-        Logger::warning("Attempted to remove reform ", reform_to_remove->get_identifier(), " from country ", base_country->get_identifier(), ": not present!");
-        return false;
-    }
-    reforms.erase(existing_entry);
-    return true;
+	auto existing_entry = std::find(reforms.begin(), reforms.end(), reform_to_remove);
+	if (existing_entry == reforms.end()) {
+		Logger::warning("Attempted to remove reform ", reform_to_remove->get_identifier(), " from country ", base_country->get_identifier(), ": not present!");
+		return false;
+	}
+	reforms.erase(existing_entry);
+	return true;
 }
 
-void CountryInstance::apply_history_to_country(CountryHistoryMap const& history, Date date) {
-    auto entries = history.get_entries_up_to(date);
+bool CountryInstance::apply_history_to_country(CountryHistoryMap const& history, Date date) {
+	accepted_cultures.clear();
+	upper_house.clear();
+	reforms.clear();
 
-    accepted_cultures.clear();
-    upper_house.clear();
-    reforms.clear();
-
-    for (CountryHistoryEntry const* entry : entries) {
-        if (entry->get_primary_culture()) primary_culture = *entry->get_primary_culture();
-        for (const auto culture : entry->get_accepted_cultures()) {
-            add_accepted_culture(culture);
-        }
-        if (entry->get_religion()) religion = *entry->get_religion();
-        if (entry->get_ruling_party()) ruling_party = *entry->get_ruling_party();
-        if (entry->get_last_election()) last_election = *entry->get_last_election();
-        for (const auto& party : entry->get_upper_house()) {
-            add_to_upper_house(party.first, party.second);
-        }
-        if (entry->get_capital()) capital = *entry->get_capital();
-        if (entry->get_government_type()) government_type = *entry->get_government_type();
-        if (entry->get_plurality()) plurality = *entry->get_plurality();
-        if (entry->get_national_value()) national_value = *entry->get_national_value();
-        if (entry->get_civilised()) civilised = *entry->get_civilised();
-        if (entry->get_prestige()) prestige = *entry->get_prestige();
-        for (const auto reform : entry->get_reforms()) {
-            add_reform(reform);
-        }
-    }
+	bool ret = true;
+	for (CountryHistoryEntry const* entry : history.get_entries_up_to(date)) {
+		if (entry->get_primary_culture()) primary_culture = *entry->get_primary_culture();
+		for (Culture const* culture : entry->get_accepted_cultures()) {
+			ret &= add_accepted_culture(culture);
+		}
+		if (entry->get_religion()) religion = *entry->get_religion();
+		if (entry->get_ruling_party()) ruling_party = *entry->get_ruling_party();
+		if (entry->get_last_election()) last_election = *entry->get_last_election();
+		for (auto const& [ideology, popularity] : entry->get_upper_house()) {
+			add_to_upper_house(ideology, popularity);
+		}
+		if (entry->get_capital()) capital = *entry->get_capital();
+		if (entry->get_government_type()) government_type = *entry->get_government_type();
+		if (entry->get_plurality()) plurality = *entry->get_plurality();
+		if (entry->get_national_value()) national_value = *entry->get_national_value();
+		if (entry->get_civilised()) civilised = *entry->get_civilised();
+		if (entry->get_prestige()) prestige = *entry->get_prestige();
+		for (Reform const* reform : entry->get_reforms()) {
+			ret &= add_reform(reform);
+		}
+	}
+	return ret;
 }

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -49,7 +49,7 @@ bool CountryInstance::remove_reform(Reform const* reform_to_remove) {
 }
 
 void CountryInstance::apply_history_to_country(CountryHistoryMap const& history, Date date) {
-    auto entries = history.get_entries(date);
+    auto entries = history.get_entries_up_to(date);
 
     accepted_cultures.clear();
     upper_house.clear();

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -6,34 +6,34 @@
 #include "openvic-simulation/utility/Getters.hpp"
 
 namespace OpenVic {
-    /* Representation of an existing country that is currently in-game. */
-    struct CountryInstance {
-    private:
-        Country const* PROPERTY_RW(base_country);
-        Culture const* PROPERTY_RW(primary_culture);
-        std::vector<Culture const*> PROPERTY(accepted_cultures);
-        Religion const* PROPERTY_RW(religion);
-        CountryParty const* PROPERTY_RW(ruling_party);
-        Date PROPERTY_RW(last_election);
-        fixed_point_map_t<Ideology const*> PROPERTY(upper_house);
-        Province const* PROPERTY_RW(capital);
-        GovernmentType const* PROPERTY_RW(government_type);
-        fixed_point_t PROPERTY_RW(plurality);
-        NationalValue const* PROPERTY_RW(national_value);
-        bool PROPERTY_RW(civilised);
-        fixed_point_t PROPERTY_RW(prestige);
-        std::vector<Reform const*> PROPERTY(reforms); // TODO: should be map of reform groups to active reforms: must set defaults & validate applied history
-        // TODO: Military units + OOBs; will probably need an extensible deployment class
+	/* Representation of an existing country that is currently in-game. */
+	struct CountryInstance {
+	private:
+		Country const* PROPERTY_RW(base_country);
+		Culture const* PROPERTY_RW(primary_culture);
+		std::vector<Culture const*> PROPERTY(accepted_cultures);
+		Religion const* PROPERTY_RW(religion);
+		CountryParty const* PROPERTY_RW(ruling_party);
+		Date PROPERTY_RW(last_election);
+		fixed_point_map_t<Ideology const*> PROPERTY(upper_house);
+		Province const* PROPERTY_RW(capital);
+		GovernmentType const* PROPERTY_RW(government_type);
+		fixed_point_t PROPERTY_RW(plurality);
+		NationalValue const* PROPERTY_RW(national_value);
+		bool PROPERTY_RW(civilised);
+		fixed_point_t PROPERTY_RW(prestige);
+		std::vector<Reform const*> PROPERTY(reforms); // TODO: should be map of reform groups to active reforms: must set defaults & validate applied history
+		// TODO: Military units + OOBs; will probably need an extensible deployment class
 
-    public:
-        bool add_accepted_culture(Culture const* new_accepted_culture);
-        bool remove_accepted_culture(Culture const* culture_to_remove);
-        /* Add or modify a party in the upper house. */
-        void add_to_upper_house(Ideology const* party, fixed_point_t popularity);
-        bool remove_from_upper_house(Ideology const* party);
-        bool add_reform(Reform const* new_reform);
-        bool remove_reform(Reform const* reform_to_remove);
+	public:
+		bool add_accepted_culture(Culture const* new_accepted_culture);
+		bool remove_accepted_culture(Culture const* culture_to_remove);
+		/* Add or modify a party in the upper house. */
+		void add_to_upper_house(Ideology const* party, fixed_point_t popularity);
+		bool remove_from_upper_house(Ideology const* party);
+		bool add_reform(Reform const* new_reform);
+		bool remove_reform(Reform const* reform_to_remove);
 
-        void apply_history_to_country(CountryHistoryMap const& history, Date date); 
-    };
+		bool apply_history_to_country(CountryHistoryMap const& history, Date date);
+	};
 } // namespace OpenVic

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -15,7 +15,7 @@ namespace OpenVic {
         Religion const* PROPERTY_RW(religion);
         CountryParty const* PROPERTY_RW(ruling_party);
         Date PROPERTY_RW(last_election);
-        decimal_map_t<Ideology const*> PROPERTY(upper_house);
+        fixed_point_map_t<Ideology const*> PROPERTY(upper_house);
         Province const* PROPERTY_RW(capital);
         GovernmentType const* PROPERTY_RW(government_type);
         fixed_point_t PROPERTY_RW(plurality);

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -849,6 +849,10 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 	static const std::string religion_file = "common/religion.txt";
 	static const std::string leader_traits_file = "common/traits.txt";
 	static const std::string cb_types_file = "common/cb_types.txt";
+	static const std::string crime_modifiers_file = "common/crime.txt";
+	static const std::string event_modifiers_file = "common/event_modifiers.txt";
+	static const std::string static_modifiers_file = "common/static_modifiers.txt";
+	static const std::string triggered_modifiers_file = "common/triggered_modifiers.txt";
 
 	bool ret = true;
 
@@ -858,6 +862,30 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 	}
 	if (!game_manager.get_modifier_manager().setup_modifier_effects()) {
 		Logger::error("Failed to set up modifier effects!");
+		ret = false;
+	}
+	if (!game_manager.get_modifier_manager().load_crime_modifiers(
+		parse_defines(lookup_file(crime_modifiers_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load crime modifiers!");
+		ret = false;
+	}
+	if (!game_manager.get_modifier_manager().load_event_modifiers(
+		parse_defines(lookup_file(event_modifiers_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load event modifiers!");
+		ret = false;
+	}
+	if (!game_manager.get_modifier_manager().load_static_modifiers(
+		parse_defines(lookup_file(static_modifiers_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load static modifiers!");
+		ret = false;
+	}
+	if (!game_manager.get_modifier_manager().load_triggered_modifiers(
+		parse_defines(lookup_file(triggered_modifiers_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load triggered modifiers!");
 		ret = false;
 	}
 	if (!game_manager.get_define_manager().load_defines_file(parse_lua_defines(lookup_file(defines_file)).get_file_node())) {

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -959,7 +959,9 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 		Logger::error("Failed to load wargoals!");
 		ret = false;
 	}
-	if (!game_manager.get_history_manager().load_bookmark_file(parse_defines(lookup_file(bookmark_file)).get_file_node())) {
+	if (!game_manager.get_history_manager().get_bookmark_manager().load_bookmark_file(
+		parse_defines(lookup_file(bookmark_file)).get_file_node()
+	)) {
 		Logger::error("Failed to load bookmarks!");
 		ret = false;
 	}

--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -206,7 +206,11 @@ node_callback_t NodeTools::expect_fvec2(callback_t<fvec2_t> callback) {
 
 node_callback_t NodeTools::expect_assign(key_value_callback_t callback) {
 	return _expect_type<ast::AssignNode>([callback](ast::AssignNode const& assign_node) -> bool {
-		return callback(assign_node._name, assign_node._initializer.get());
+		const bool ret = callback(assign_node._name, assign_node._initializer.get());
+		if (!ret) {
+			Logger::error("Callback failed for assign node with key: ", assign_node._name);
+		}
+		return ret;
 	});
 }
 

--- a/src/openvic-simulation/economy/Building.hpp
+++ b/src/openvic-simulation/economy/Building.hpp
@@ -18,7 +18,16 @@
 namespace OpenVic {
 
 	struct BuildingManager;
-	struct BuildingType;
+
+	struct BuildingType : HasIdentifier {
+		friend struct BuildingManager;
+
+	private:
+		BuildingType(std::string_view new_identifier);
+
+	public:
+		BuildingType(BuildingType&&) = default;
+	};
 
 	/* REQUIREMENTS:
 	 * MAP-11, MAP-72, MAP-73
@@ -31,81 +40,43 @@ namespace OpenVic {
 		using level_t = int16_t;
 
 	private:
-		BuildingType const& type;
-		const ModifierValue modifier;
-		const std::string on_completion; // probably sound played on completion
-		const fixed_point_t completion_size;
-		const level_t max_level;
-		const Good::good_map_t goods_cost;
-		const fixed_point_t cost;
-		const Timespan build_time; // time
-		const bool visibility;
-		const bool on_map; // onmap
+		BuildingType const& PROPERTY(type);
+		ModifierValue PROPERTY(modifier);
+		std::string PROPERTY(on_completion); // probably sound played on completion
+		fixed_point_t PROPERTY(completion_size);
+		level_t PROPERTY(max_level);
+		Good::good_map_t PROPERTY(goods_cost);
+		fixed_point_t PROPERTY(cost);
+		Timespan PROPERTY(build_time); // time
+		bool PROPERTY(visibility);
+		bool PROPERTY(on_map); // onmap
 
-		const bool default_enabled;
-		ProductionType const* production_type;
-		const bool pop_build_factory;
-		const bool strategic_factory;
-		const bool advanced_factory;
+		bool PROPERTY(default_enabled);
+		ProductionType const* PROPERTY(production_type);
+		bool PROPERTY(pop_build_factory);
+		bool PROPERTY(strategic_factory);
+		bool PROPERTY(advanced_factory);
 
-		const level_t fort_level; // probably the step-per-level
+		level_t PROPERTY(fort_level); // probably the step-per-level
 
-		const uint64_t naval_capacity;
-		const std::vector<fixed_point_t> colonial_points;
-		const bool in_province; // province
-		const bool one_per_state;
-		const fixed_point_t colonial_range;
+		uint64_t PROPERTY(naval_capacity);
+		std::vector<fixed_point_t> PROPERTY(colonial_points);
+		bool PROPERTY(in_province); // province
+		bool PROPERTY(one_per_state);
+		fixed_point_t PROPERTY(colonial_range);
 
-		const fixed_point_t infrastructure;
-		const bool spawn_railway_track;
+		fixed_point_t PROPERTY(infrastructure);
+		bool PROPERTY(spawn_railway_track);
 
-		const bool sail; // only in clipper shipyard
-		const bool steam; // only in steamer shipyard
-		const bool capital; // only in naval base
-		const bool port; // only in naval base
+		bool PROPERTY(sail); // only in clipper shipyard
+		bool PROPERTY(steam); // only in steamer shipyard
+		bool PROPERTY(capital); // only in naval base
+		bool PROPERTY(port); // only in naval base
 
 		Building(std::string_view identifier, BuildingType const& type, ARGS);
 
 	public:
 		Building(Building&&) = default;
-
-		BuildingType const& get_type() const;
-		ModifierValue const& get_modifier() const;
-		std::string_view get_on_completion() const;
-		fixed_point_t get_completion_size() const;
-		level_t get_max_level() const;
-		Good::good_map_t const& get_goods_cost() const;
-		fixed_point_t get_cost() const;
-		Timespan get_build_time() const;
-		bool has_visibility() const;
-		bool is_on_map() const;
-
-		bool is_default_enabled() const;
-		ProductionType const* get_production_type() const;
-		bool is_pop_built_factory() const;
-		bool is_strategic_factory() const;
-		bool is_advanced_factory() const;
-
-		level_t get_fort_level() const;
-
-		uint64_t get_naval_capacity() const;
-		std::vector<fixed_point_t> const& get_colonial_points() const;
-		bool is_in_province() const;
-		bool is_one_per_state() const;
-		fixed_point_t get_colonial_range() const;
-
-		fixed_point_t get_infrastructure() const;
-		bool spawned_railway_track() const;
-	};
-
-	struct BuildingType : HasIdentifier {
-		friend struct BuildingManager;
-
-	private:
-		BuildingType(std::string_view new_identifier);
-
-	public:
-		BuildingType(BuildingType&&) = default;
 	};
 
 	enum class ExpansionState { CannotExpand, CanExpand, Preparing, Expanding };
@@ -115,35 +86,26 @@ namespace OpenVic {
 		using level_t = Building::level_t;
 
 	private:
-		Building const& building;
+		Building const& PROPERTY(building);
 
-		level_t level = 0;
-		ExpansionState expansion_state = ExpansionState::CannotExpand;
-		Date start, end;
-		float expansion_progress;
+		level_t PROPERTY(level);
+		ExpansionState PROPERTY(expansion_state);
+		Date PROPERTY(start_date)
+		Date PROPERTY(end_date);
+		float PROPERTY(expansion_progress);
 
 		bool _can_expand() const;
 
 	public:
-		BuildingInstance(Building const& building);
+		BuildingInstance(Building const& new_building, level_t new_level = 0);
 		BuildingInstance(BuildingInstance&&) = default;
 
-		Building const& get_building() const;
-
-		level_t get_current_level() const;
 		void set_level(level_t new_level);
-
-		ExpansionState get_expansion_state() const;
-		Date get_start_date() const;
-		Date get_end_date() const;
-		float get_expansion_progress() const;
 
 		bool expand();
 		void update_state(Date today);
 		void tick(Date today);
 	};
-
-	struct Province;
 
 	struct BuildingManager {
 		using level_t = Building::level_t; // this is getting ridiculous
@@ -165,7 +127,5 @@ namespace OpenVic {
 			GoodManager const& good_manager, ProductionTypeManager const& production_type_manager,
 			ModifierManager& modifier_manager, ast::NodeCPtr root
 		);
-
-		bool generate_province_buildings(Province& province) const;
 	};
 }

--- a/src/openvic-simulation/economy/BuildingInstance.cpp
+++ b/src/openvic-simulation/economy/BuildingInstance.cpp
@@ -1,0 +1,52 @@
+#include "BuildingInstance.hpp"
+
+using namespace OpenVic;
+
+BuildingInstance::BuildingInstance(BuildingType const& new_building_type, level_t new_level)
+	: HasIdentifier { building_type.get_identifier() }, building_type { new_building_type }, level { new_level },
+	expansion_state { ExpansionState::CannotExpand } {}
+
+bool BuildingInstance::_can_expand() const {
+	return level < building_type.get_max_level();
+}
+
+void BuildingInstance::set_level(BuildingInstance::level_t new_level) {
+	level = new_level;
+}
+
+bool BuildingInstance::expand() {
+	if (expansion_state == ExpansionState::CanExpand) {
+		expansion_state = ExpansionState::Preparing;
+		expansion_progress = 0.0f;
+		return true;
+	}
+	return false;
+}
+
+/* REQUIREMENTS:
+ * MAP-71, MAP-74, MAP-77
+ */
+void BuildingInstance::update_state(Date today) {
+	switch (expansion_state) {
+	case ExpansionState::Preparing:
+		start_date = today;
+		end_date = start_date + building_type.get_build_time();
+		break;
+	case ExpansionState::Expanding:
+		expansion_progress = static_cast<double>(today - start_date) / static_cast<double>(end_date - start_date);
+		break;
+	default: expansion_state = _can_expand() ? ExpansionState::CanExpand : ExpansionState::CannotExpand;
+	}
+}
+
+void BuildingInstance::tick(Date today) {
+	if (expansion_state == ExpansionState::Preparing) {
+		expansion_state = ExpansionState::Expanding;
+	}
+	if (expansion_state == ExpansionState::Expanding) {
+		if (end_date <= today) {
+			level++;
+			expansion_state = ExpansionState::CannotExpand;
+		}
+	}
+}

--- a/src/openvic-simulation/economy/BuildingInstance.hpp
+++ b/src/openvic-simulation/economy/BuildingInstance.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "openvic-simulation/economy/BuildingType.hpp"
+
+namespace OpenVic {
+
+	struct BuildingInstance : HasIdentifier { // used in the actual game
+		using level_t = BuildingType::level_t;
+
+		enum class ExpansionState { CannotExpand, CanExpand, Preparing, Expanding };
+
+	private:
+		BuildingType const& PROPERTY(building_type);
+
+		level_t PROPERTY(level);
+		ExpansionState PROPERTY(expansion_state);
+		Date PROPERTY(start_date)
+		Date PROPERTY(end_date);
+		float PROPERTY(expansion_progress);
+
+		bool _can_expand() const;
+
+	public:
+		BuildingInstance(BuildingType const& new_building_type, level_t new_level = 0);
+		BuildingInstance(BuildingInstance&&) = default;
+
+		void set_level(level_t new_level);
+
+		bool expand();
+		void update_state(Date today);
+		void tick(Date today);
+	};
+}

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -1,12 +1,10 @@
-#include "Building.hpp"
+#include "BuildingType.hpp"
 
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-BuildingType::BuildingType(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
-
-Building::Building(
-	std::string_view identifier, BuildingType const& type, ARGS
+BuildingType::BuildingType(
+	std::string_view identifier, ARGS
 ) : HasIdentifier { identifier }, type { type }, modifier { std::move(modifier) }, on_completion { on_completion },
 	completion_size { completion_size }, max_level { max_level }, goods_cost { std::move(goods_cost) }, cost { cost },
 	build_time { build_time }, visibility { visibility }, on_map { on_map }, default_enabled { default_enabled },
@@ -16,81 +14,16 @@ Building::Building(
 	colonial_range { colonial_range }, infrastructure { infrastructure }, spawn_railway_track { spawn_railway_track },
 	sail { sail }, steam { steam }, capital { capital }, port { port } {}
 
-BuildingInstance::BuildingInstance(Building const& new_building, level_t new_level)
-	: HasIdentifier { building.get_identifier() }, building { new_building }, level { new_level },
-	expansion_state { ExpansionState::CannotExpand } {}
+BuildingManager::BuildingManager() : building_types { "building types" } {}
 
-bool BuildingInstance::_can_expand() const {
-	return level < building.get_max_level();
-}
-
-void BuildingInstance::set_level(BuildingInstance::level_t new_level) {
-	level = new_level;
-}
-
-bool BuildingInstance::expand() {
-	if (expansion_state == ExpansionState::CanExpand) {
-		expansion_state = ExpansionState::Preparing;
-		expansion_progress = 0.0f;
-		return true;
-	}
-	return false;
-}
-
-/* REQUIREMENTS:
- * MAP-71, MAP-74, MAP-77
- */
-void BuildingInstance::update_state(Date today) {
-	switch (expansion_state) {
-	case ExpansionState::Preparing:
-		start_date = today;
-		end_date = start_date + building.get_build_time();
-		break;
-	case ExpansionState::Expanding:
-		expansion_progress = static_cast<double>(today - start_date) / static_cast<double>(end_date - start_date);
-		break;
-	default: expansion_state = _can_expand() ? ExpansionState::CanExpand : ExpansionState::CannotExpand;
-	}
-}
-
-void BuildingInstance::tick(Date today) {
-	if (expansion_state == ExpansionState::Preparing) {
-		expansion_state = ExpansionState::Expanding;
-	}
-	if (expansion_state == ExpansionState::Expanding) {
-		if (end_date <= today) {
-			level++;
-			expansion_state = ExpansionState::CannotExpand;
-		}
-	}
-}
-
-BuildingManager::BuildingManager() : building_types { "building types" }, buildings { "buildings" } {}
-
-bool BuildingManager::add_building_type(std::string_view identifier) {
-	if (identifier.empty()) {
-		Logger::error("Invalid building type identifier - empty!");
-		return false;
-	}
-	return building_types.add_item({ identifier }, duplicate_ignore_callback);
-}
-
-bool BuildingManager::add_building(std::string_view identifier, BuildingType const* type, ARGS) {
-	if (!building_types.is_locked()) {
-		Logger::error("Cannot add buildings until building types are locked!");
-		return false;
-	}
+bool BuildingManager::add_building_type(std::string_view identifier, ARGS) {
 	if (identifier.empty()) {
 		Logger::error("Invalid building identifier - empty!");
 		return false;
 	}
-	if (type == nullptr) {
-		Logger::error("Invalid building type for ", identifier, ": null");
-		return false;
-	}
 
-	return buildings.add_item({
-		identifier, *type, std::move(modifier), on_completion, completion_size, max_level, std::move(goods_cost),
+	return building_types.add_item({
+		identifier, type, std::move(modifier), on_completion, completion_size, max_level, std::move(goods_cost),
 		cost, build_time, visibility, on_map, default_enabled, production_type, pop_build_factory, strategic_factory,
 		advanced_factory, fort_level, naval_capacity, std::move(colonial_points), in_province, one_per_state,
 		colonial_range, infrastructure, spawn_railway_track, sail, steam, capital, port
@@ -101,20 +34,14 @@ bool BuildingManager::load_buildings_file(
 	GoodManager const& good_manager, ProductionTypeManager const& production_type_manager, ModifierManager& modifier_manager,
 	ast::NodeCPtr root
 ) {
-	bool ret = expect_dictionary_reserve_length(buildings, [this](std::string_view, ast::NodeCPtr value) -> bool {
-		return expect_key("type", expect_identifier(
-			std::bind(&BuildingManager::add_building_type, this, std::placeholders::_1)
-		))(value);
-	})(root);
-	lock_building_types();
-
-	ret &= expect_dictionary(
+	const bool ret = expect_dictionary_reserve_length(
+		building_types,
 		[this, &good_manager, &production_type_manager, &modifier_manager](std::string_view key, ast::NodeCPtr value) -> bool {
-			BuildingType const* type = nullptr;
+			std::string_view type;
 			ProductionType const* production_type = nullptr;
 			std::string_view on_completion;
 			fixed_point_t completion_size = 0, cost = 0, infrastructure = 0, colonial_range = 0;
-			Building::level_t max_level = 0, fort_level = 0;
+			BuildingType::level_t max_level = 0, fort_level = 0;
 			Good::good_map_t goods_cost;
 			Timespan build_time;
 			bool visibility = false, on_map = false, default_enabled = false, pop_build_factory = false;
@@ -126,7 +53,7 @@ bool BuildingManager::load_buildings_file(
 			ModifierValue modifier;
 
 			bool ret = modifier_manager.expect_modifier_value_and_keys(move_variable_callback(modifier),
-				"type", ONE_EXACTLY, expect_building_type_identifier(assign_variable_callback_pointer(type)),
+				"type", ONE_EXACTLY, expect_identifier(assign_variable_callback(type)),
 				"on_completion", ZERO_OR_ONE, expect_identifier(assign_variable_callback(on_completion)),
 				"completion_size", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(completion_size)),
 				"max_level", ONE_EXACTLY, expect_uint(assign_variable_callback(max_level)),
@@ -160,7 +87,7 @@ bool BuildingManager::load_buildings_file(
 				"port", ZERO_OR_ONE, expect_bool(assign_variable_callback(port))
 			)(value);
 
-			ret &= add_building(
+			ret &= add_building_type(
 				key, type, std::move(modifier), on_completion, completion_size, max_level, std::move(goods_cost), cost,
 				build_time, visibility, on_map, default_enabled, production_type, pop_build_factory, strategic_factory,
 				advanced_factory, fort_level, naval_capacity, std::move(colonial_points), in_province, one_per_state,
@@ -170,16 +97,16 @@ bool BuildingManager::load_buildings_file(
 			return ret;
 		}
 	)(root);
-	lock_buildings();
+	lock_building_types();
 
-	for (Building const& building : buildings.get_items()) {
+	for (BuildingType const& building_type : building_types.get_items()) {
 		std::string max_modifier_prefix = "max_";
 		std::string min_modifier_prefix = "min_build_";
 		modifier_manager.add_modifier_effect(
-			max_modifier_prefix.append(building.get_identifier()), true, ModifierEffect::format_t::INT
+			max_modifier_prefix.append(building_type.get_identifier()), true, ModifierEffect::format_t::INT
 		);
 		modifier_manager.add_modifier_effect(
-			min_modifier_prefix.append(building.get_identifier()), false, ModifierEffect::format_t::INT
+			min_modifier_prefix.append(building_type.get_identifier()), false, ModifierEffect::format_t::INT
 		);
 	}
 

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/economy/Good.hpp"
 #include "openvic-simulation/economy/ProductionType.hpp"
 #include "openvic-simulation/types/Date.hpp"
@@ -8,8 +8,8 @@
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 
 #define ARGS \
-	ModifierValue&& modifier, std::string_view on_completion, fixed_point_t completion_size, level_t max_level, \
-	Good::good_map_t&& goods_cost, fixed_point_t cost, Timespan build_time, bool visibility, bool on_map, \
+	std::string_view type, ModifierValue&& modifier, std::string_view on_completion, fixed_point_t completion_size, \
+	level_t max_level, Good::good_map_t&& goods_cost, fixed_point_t cost, Timespan build_time, bool visibility, bool on_map, \
 	bool default_enabled, ProductionType const* production_type, bool pop_build_factory, bool strategic_factory, \
 	bool advanced_factory, level_t fort_level, uint64_t naval_capacity, std::vector<fixed_point_t>&& colonial_points, \
 	bool in_province, bool one_per_state, fixed_point_t colonial_range, fixed_point_t infrastructure, \
@@ -19,28 +19,18 @@ namespace OpenVic {
 
 	struct BuildingManager;
 
-	struct BuildingType : HasIdentifier {
-		friend struct BuildingManager;
-
-	private:
-		BuildingType(std::string_view new_identifier);
-
-	public:
-		BuildingType(BuildingType&&) = default;
-	};
-
 	/* REQUIREMENTS:
 	 * MAP-11, MAP-72, MAP-73
 	 * MAP-12, MAP-75, MAP-76
 	 * MAP-13, MAP-78, MAP-79
 	 */
-	struct Building : HasIdentifier {
+	struct BuildingType : HasIdentifier {
 		friend struct BuildingManager;
 
 		using level_t = int16_t;
 
 	private:
-		BuildingType const& PROPERTY(type);
+		std::string PROPERTY(type);
 		ModifierValue PROPERTY(modifier);
 		std::string PROPERTY(on_completion); // probably sound played on completion
 		fixed_point_t PROPERTY(completion_size);
@@ -73,55 +63,23 @@ namespace OpenVic {
 		bool PROPERTY(capital); // only in naval base
 		bool PROPERTY(port); // only in naval base
 
-		Building(std::string_view identifier, BuildingType const& type, ARGS);
+		BuildingType(std::string_view identifier, ARGS);
 
 	public:
-		Building(Building&&) = default;
-	};
-
-	enum class ExpansionState { CannotExpand, CanExpand, Preparing, Expanding };
-
-	struct BuildingInstance : HasIdentifier { // used in the actual game
-		friend struct BuildingManager;
-		using level_t = Building::level_t;
-
-	private:
-		Building const& PROPERTY(building);
-
-		level_t PROPERTY(level);
-		ExpansionState PROPERTY(expansion_state);
-		Date PROPERTY(start_date)
-		Date PROPERTY(end_date);
-		float PROPERTY(expansion_progress);
-
-		bool _can_expand() const;
-
-	public:
-		BuildingInstance(Building const& new_building, level_t new_level = 0);
-		BuildingInstance(BuildingInstance&&) = default;
-
-		void set_level(level_t new_level);
-
-		bool expand();
-		void update_state(Date today);
-		void tick(Date today);
+		BuildingType(BuildingType&&) = default;
 	};
 
 	struct BuildingManager {
-		using level_t = Building::level_t; // this is getting ridiculous
+		using level_t = BuildingType::level_t; // this is getting ridiculous
 
 	private:
 		IdentifierRegistry<BuildingType> building_types;
-		IdentifierRegistry<Building> buildings;
 
 	public:
 		BuildingManager();
 
-		bool add_building_type(std::string_view identifier);
+		bool add_building_type(std::string_view identifier, ARGS);
 		IDENTIFIER_REGISTRY_ACCESSORS(building_type)
-
-		bool add_building(std::string_view identifier, BuildingType const* type, ARGS);
-		IDENTIFIER_REGISTRY_ACCESSORS(building)
 
 		bool load_buildings_file(
 			GoodManager const& good_manager, ProductionTypeManager const& production_type_manager,

--- a/src/openvic-simulation/economy/EconomyManager.hpp
+++ b/src/openvic-simulation/economy/EconomyManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/economy/Building.hpp"
+#include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/economy/Good.hpp"
 #include "openvic-simulation/economy/ProductionType.hpp"
 

--- a/src/openvic-simulation/economy/Good.hpp
+++ b/src/openvic-simulation/economy/Good.hpp
@@ -33,7 +33,7 @@ namespace OpenVic {
 		using price_t = fixed_point_t;
 		static constexpr price_t NULL_PRICE = fixed_point_t::_0();
 
-		using good_map_t = decimal_map_t<Good const*>;
+		using good_map_t = fixed_point_map_t<Good const*>;
 
 	private:
 		GoodCategory const& category;

--- a/src/openvic-simulation/economy/Good.hpp
+++ b/src/openvic-simulation/economy/Good.hpp
@@ -73,7 +73,7 @@ namespace OpenVic {
 		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(good_category, good_categories)
 
 		bool add_good(
-			std::string_view identifier, colour_t colour, GoodCategory const* category, Good::price_t base_price,
+			std::string_view identifier, colour_t colour, GoodCategory const& category, Good::price_t base_price,
 			bool available_from_start, bool tradeable, bool money, bool overseas_penalty
 		);
 		IDENTIFIER_REGISTRY_ACCESSORS(good)

--- a/src/openvic-simulation/economy/ProductionType.cpp
+++ b/src/openvic-simulation/economy/ProductionType.cpp
@@ -145,7 +145,7 @@ node_callback_t ProductionTypeManager::_expect_employed_pop_list(
 		return false; \
 	}
 
-bool ProductionTypeManager::add_production_type(PRODUCTION_TYPE_ARGS, GoodManager const& good_manager) {
+bool ProductionTypeManager::add_production_type(PRODUCTION_TYPE_ARGS) {
 	if (identifier.empty()) {
 		Logger::error("Invalid production type identifier - empty!");
 		return false;
@@ -274,7 +274,7 @@ bool ProductionTypeManager::load_production_types_file(
 
 			ret &= add_production_type(
 				key, owner, employees, type, workforce, std::move(input_goods), output_goods, value, std::move(bonuses),
-				std::move(efficiency), coastal, farm, mine, good_manager
+				std::move(efficiency), coastal, farm, mine
 			);
 			return ret;
 		}

--- a/src/openvic-simulation/economy/ProductionType.hpp
+++ b/src/openvic-simulation/economy/ProductionType.hpp
@@ -101,7 +101,7 @@ namespace OpenVic {
 	public:
 		ProductionTypeManager();
 
-		bool add_production_type(PRODUCTION_TYPE_ARGS, GoodManager const& good_manager);
+		bool add_production_type(PRODUCTION_TYPE_ARGS);
 		IDENTIFIER_REGISTRY_ACCESSORS(production_type)
 
 		bool load_production_types_file(GoodManager const& good_manager, PopManager const& pop_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -31,7 +31,7 @@ namespace OpenVic {
 		std::optional<Religion const*> PROPERTY(religion);
 		std::optional<CountryParty const*> PROPERTY(ruling_party);
 		std::optional<Date> PROPERTY(last_election);
-		decimal_map_t<Ideology const*> PROPERTY(upper_house);
+		fixed_point_map_t<Ideology const*> PROPERTY(upper_house);
 		std::optional<Province const*> PROPERTY(capital);
 		std::optional<GovernmentType const*> PROPERTY(government_type);
 		std::optional<fixed_point_t> PROPERTY(plurality);

--- a/src/openvic-simulation/history/HistoryManager.hpp
+++ b/src/openvic-simulation/history/HistoryManager.hpp
@@ -19,9 +19,5 @@ namespace OpenVic {
 		REF_GETTERS(country_manager)
 		REF_GETTERS(province_manager)
 		REF_GETTERS(diplomacy_manager)
-
-		inline bool load_bookmark_file(ast::NodeCPtr root) {
-			return bookmark_manager.load_bookmark_file(root);
-		}
 	};
 }

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -33,10 +33,10 @@ bool ProvinceHistoryMap::_load_history_entry(
 		[this, &game_manager, &building_manager, &entry](
 			std::string_view key, ast::NodeCPtr value) -> bool {
 			// used for province buildings like forts or railroads
-			Building const* building = building_manager.get_building_by_identifier(key);
-			if (building != nullptr) {
-				return expect_uint<Building::level_t>([&entry, building](Building::level_t level) -> bool {
-					entry.province_buildings[building] = level;
+			BuildingType const* building_type = building_manager.get_building_type_by_identifier(key);
+			if (building_type != nullptr) {
+				return expect_uint<BuildingType::level_t>([&entry, building_type](BuildingType::level_t level) -> bool {
+					entry.province_buildings[building_type] = level;
 					return true;
 				})(value);
 			}
@@ -83,17 +83,17 @@ bool ProvinceHistoryMap::_load_history_entry(
 			return ret;
 		},
 		"state_building", ZERO_OR_MORE, [&building_manager, &entry](ast::NodeCPtr node) -> bool {
-			Building const* building = nullptr;
+			BuildingType const* building_type = nullptr;
 			uint8_t level = 0;
 
 			const bool ret = expect_dictionary_keys(
 				"level", ONE_EXACTLY, expect_uint(assign_variable_callback(level)),
-				"building", ONE_EXACTLY, building_manager.expect_building_identifier(
-					assign_variable_callback_pointer(building)
+				"building", ONE_EXACTLY, building_manager.expect_building_type_identifier(
+					assign_variable_callback_pointer(building_type)
 				),
 				"upgrade", ZERO_OR_ONE, success_callback // doesn't appear to have an effect
 			)(node);
-			entry.state_buildings[building] = level;
+			entry.state_buildings[building_type] = level;
 			return ret;
 		}
 	)(root);

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -36,7 +36,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 			Building const* building = building_manager.get_building_by_identifier(key);
 			if (building != nullptr) {
 				return expect_uint<Building::level_t>([&entry, building](Building::level_t level) -> bool {
-					entry.buildings[building] = level;
+					entry.province_buildings[building] = level;
 					return true;
 				})(value);
 			}
@@ -93,7 +93,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 				),
 				"upgrade", ZERO_OR_ONE, success_callback // doesn't appear to have an effect
 			)(node);
-			entry.buildings[building] = level;
+			entry.state_buildings[building] = level;
 			return ret;
 		}
 	)(root);

--- a/src/openvic-simulation/history/ProvinceHistory.hpp
+++ b/src/openvic-simulation/history/ProvinceHistory.hpp
@@ -33,7 +33,7 @@ namespace OpenVic {
 		std::optional<Province::life_rating_t> PROPERTY(life_rating);
 		std::optional<TerrainType const*> PROPERTY(terrain_type);
 		building_level_map_t PROPERTY(buildings);
-		decimal_map_t<Ideology const*> PROPERTY(party_loyalties);
+		fixed_point_map_t<Ideology const*> PROPERTY(party_loyalties);
 
 		ProvinceHistoryEntry(Province const& new_province, Date new_date);
 	};

--- a/src/openvic-simulation/history/ProvinceHistory.hpp
+++ b/src/openvic-simulation/history/ProvinceHistory.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "openvic-simulation/country/Country.hpp"
-#include "openvic-simulation/economy/Building.hpp"
+#include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/economy/Good.hpp"
 #include "openvic-simulation/history/Bookmark.hpp"
 #include "openvic-simulation/history/HistoryMap.hpp"
@@ -30,8 +30,8 @@ namespace OpenVic {
 		std::optional<Good const*> PROPERTY(rgo);
 		std::optional<Province::life_rating_t> PROPERTY(life_rating);
 		std::optional<TerrainType const*> PROPERTY(terrain_type);
-		std::map<Building const*, Building::level_t> PROPERTY(province_buildings);
-		std::map<Building const*, Building::level_t> PROPERTY(state_buildings);
+		std::map<BuildingType const*, BuildingType::level_t> PROPERTY(province_buildings);
+		std::map<BuildingType const*, BuildingType::level_t> PROPERTY(state_buildings);
 		fixed_point_map_t<Ideology const*> PROPERTY(party_loyalties);
 
 		ProvinceHistoryEntry(Province const& new_province, Date new_date);

--- a/src/openvic-simulation/history/ProvinceHistory.hpp
+++ b/src/openvic-simulation/history/ProvinceHistory.hpp
@@ -18,8 +18,6 @@ namespace OpenVic {
 	struct ProvinceHistoryEntry : HistoryEntry {
 		friend struct ProvinceHistoryMap;
 
-		using building_level_map_t = std::map<Building const*, Building::level_t>;
-
 	private:
 		Province const& PROPERTY(province);
 
@@ -32,7 +30,8 @@ namespace OpenVic {
 		std::optional<Good const*> PROPERTY(rgo);
 		std::optional<Province::life_rating_t> PROPERTY(life_rating);
 		std::optional<TerrainType const*> PROPERTY(terrain_type);
-		building_level_map_t PROPERTY(buildings);
+		std::map<Building const*, Building::level_t> PROPERTY(province_buildings);
+		std::map<Building const*, Building::level_t> PROPERTY(state_buildings);
 		fixed_point_map_t<Ideology const*> PROPERTY(party_loyalties);
 
 		ProvinceHistoryEntry(Province const& new_province, Date new_date);

--- a/src/openvic-simulation/interface/GUI.cpp
+++ b/src/openvic-simulation/interface/GUI.cpp
@@ -17,7 +17,7 @@ bool Element::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_m
 		{ "CENTER", CENTER }
 	};
 	ret &= add_key_map_entries(key_map,
-		"position", ONE_EXACTLY, expect_ivec2(assign_variable_callback(position)),
+		"position", ONE_EXACTLY, expect_fvec2(assign_variable_callback(position)),
 		"orientation", ZERO_OR_ONE, expect_string(expect_mapped_string(orientation_map, assign_variable_callback(orientation))),
 		"Orientation", ZERO_OR_ONE, expect_string(expect_mapped_string(orientation_map, assign_variable_callback(orientation)))
 	);
@@ -68,7 +68,7 @@ bool Window::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_ma
 	ret &= Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"backGround", ZERO_OR_ONE, success_callback, // TODO - load as potential panel texture (almost always empty)
-		"size", ONE_EXACTLY, expect_ivec2(assign_variable_callback(size)),
+		"size", ONE_EXACTLY, expect_fvec2(assign_variable_callback(size)),
 		"moveable", ONE_EXACTLY, expect_int_bool(assign_variable_callback(moveable)),
 		"dontRender", ZERO_OR_ONE, success_callback, // always empty string?
 		"horizontalBorder", ZERO_OR_ONE, success_callback,
@@ -144,8 +144,8 @@ bool Text::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_mana
 	ret &= add_key_map_entries(key_map,
 		"text", ZERO_OR_ONE, expect_string(assign_variable_callback_string(text), true),
 		"font", ONE_EXACTLY, expect_string(ui_manager.expect_font_str(assign_variable_callback_pointer(font))),
-		"maxWidth", ONE_EXACTLY, expect_uint(assign_variable_callback(max_size.x)),
-		"maxHeight", ONE_EXACTLY, expect_uint(assign_variable_callback(max_size.y)),
+		"maxWidth", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(max_size.x)),
+		"maxHeight", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(max_size.y)),
 
 		"borderSize", ZERO_OR_ONE, success_callback,
 		"fixedsize", ZERO_OR_ONE, success_callback,
@@ -161,7 +161,7 @@ OverlappingElementsBox::OverlappingElementsBox() : size {} {}
 bool OverlappingElementsBox::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = AlignedElement::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
-		"size", ONE_EXACTLY, expect_ivec2(assign_variable_callback(size)),
+		"size", ONE_EXACTLY, expect_fvec2(assign_variable_callback(size)),
 		"spacing", ONE_EXACTLY, success_callback
 	);
 	return ret;
@@ -173,7 +173,7 @@ bool ListBox::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_m
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"backGround", ZERO_OR_ONE, success_callback,
-		"size", ONE_EXACTLY, expect_ivec2(assign_variable_callback(size)),
+		"size", ONE_EXACTLY, expect_fvec2(assign_variable_callback(size)),
 		"spacing", ZERO_OR_ONE, success_callback,
 		"scrollbartype", ZERO_OR_ONE, success_callback, // TODO - implement modable listbox scrollbars
 		"borderSize", ZERO_OR_ONE, success_callback

--- a/src/openvic-simulation/interface/GUI.hpp
+++ b/src/openvic-simulation/interface/GUI.hpp
@@ -17,7 +17,7 @@ namespace OpenVic::GUI {
 		};
 
 	private:
-		ivec2_t PROPERTY(position);
+		fvec2_t PROPERTY(position);
 		orientation_t PROPERTY(orientation);
 
 	protected:
@@ -65,7 +65,7 @@ namespace OpenVic::GUI {
 
 		NamedInstanceRegistry<Element, UIManager const&> elements;
 
-		ivec2_t PROPERTY(size);
+		fvec2_t PROPERTY(size);
 		bool PROPERTY(moveable);
 		bool PROPERTY(fullscreen);
 		// TODO - background, dontRender, horizontalBorder, verticalBorder
@@ -179,7 +179,7 @@ namespace OpenVic::GUI {
 
 		std::string PROPERTY(text);
 		GFX::Font const* PROPERTY(font);
-		ivec2_t PROPERTY(max_size); // maxWidth, maxHeight
+		fvec2_t PROPERTY(max_size); // maxWidth, maxHeight
 
 		// TODO - borderSize, fixedsize, textureFile
 
@@ -198,7 +198,7 @@ namespace OpenVic::GUI {
 	class OverlappingElementsBox final : public AlignedElement {
 		friend std::unique_ptr<OverlappingElementsBox> std::make_unique<OverlappingElementsBox>();
 
-		ivec2_t PROPERTY(size);
+		fvec2_t PROPERTY(size);
 
 		// TODO - spacing
 
@@ -217,7 +217,7 @@ namespace OpenVic::GUI {
 	class ListBox final : public Element {
 		friend std::unique_ptr<ListBox> std::make_unique<ListBox>();
 
-		ivec2_t PROPERTY(size);
+		fvec2_t PROPERTY(size);
 
 		// TODO - backGround, spacing, scrollbartype, borderSize
 

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -624,6 +624,6 @@ bool Map::_generate_province_adjacencies() {
 
 bool Map::generate_and_load_province_adjacencies(std::vector<ovdl::csv::LineObject> const& additional_adjacencies) {
 	bool ret = _generate_province_adjacencies();
-	// TODO - read additional adjacencies
+	// TODO - DEV TASK: read additional adjacencies
 	return ret;
 }

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -36,6 +36,7 @@ namespace OpenVic {
 	};
 
 	struct GoodManager;
+	struct ProvinceHistoryManager;
 
 	/* REQUIREMENTS:
 	 * MAP-4
@@ -109,7 +110,8 @@ namespace OpenVic {
 		 * that is the maximum allowed number of provinces plus one for the index-zero "null province". */
 		bool generate_mapmode_colours(Mapmode::index_t index, uint8_t* target) const;
 
-		bool setup(BuildingManager const& building_manager, PopManager const& pop_manager);
+		bool reset(BuildingManager const& building_manager);
+		bool apply_history_to_provinces(ProvinceHistoryManager const& history_manager, Date date);
 
 		void update_highest_province_population();
 		Pop::pop_size_t get_highest_province_population() const;

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -14,7 +14,10 @@ namespace OpenVic {
 	struct Mapmode : HasIdentifier {
 		friend struct Map;
 
-		using colour_func_t = std::function<colour_t(Map const&, Province const&)>;
+		/* Bottom 32 bits are the base colour, top 32 are the stripe colour, both in ARGB format with the alpha channels
+		 * controlling interpolation with the terrain colour (0 = all terrain, 255 = all corresponding RGB) */
+		using base_stripe_t = uint64_t;
+		using colour_func_t = std::function<base_stripe_t(Map const&, Province const&)>;
 		using index_t = size_t;
 
 	private:
@@ -29,7 +32,7 @@ namespace OpenVic {
 		Mapmode(Mapmode&&) = default;
 
 		index_t get_index() const;
-		colour_t get_colour(Map const& map, Province const& province) const;
+		base_stripe_t get_base_stripe_colours(Map const& map, Province const& province) const;
 	};
 
 	struct GoodManager;
@@ -98,7 +101,12 @@ namespace OpenVic {
 		bool add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func);
 		IDENTIFIER_REGISTRY_ACCESSORS(mapmode)
 		Mapmode const* get_mapmode_by_index(size_t index) const;
-		static constexpr size_t MAPMODE_COLOUR_SIZE = 4;
+
+		/* The mapmode colour image contains of a list of base colours and stripe colours. Each colour is four bytes
+		 * in RGBA format, with the alpha value being used to interpolate with the terrain colour, so A = 0 is fully terrain
+		 * and A = 255 is fully the RGB colour packaged with A. The base and stripe colours for each province are packed
+		 * together adjacently, so each province's entry is 8 bytes long. The list contains Province::MAX_INDEX + 1 entries,
+		 * that is the maximum allowed number of provinces plus one for the index-zero "null province". */
 		bool generate_mapmode_colours(Mapmode::index_t index, uint8_t* target) const;
 
 		bool setup(BuildingManager const& building_manager, PopManager const& pop_manager);

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -149,10 +149,10 @@ bool Province::reset(BuildingManager const& building_manager) {
 	buildings.reset();
 	bool ret = true;
 	if (!get_water()) {
-		if (building_manager.building_types_are_locked() && building_manager.buildings_are_locked()) {
-			for (Building const& building : building_manager.get_buildings()) {
-				if (building.get_in_province()) {
-					ret &= buildings.add_item({ building });
+		if (building_manager.building_types_are_locked()) {
+			for (BuildingType const& building_type : building_manager.get_building_types()) {
+				if (building_type.get_in_province()) {
+					ret &= buildings.add_item({ building_type });
 				}
 			}
 		} else {

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -16,7 +16,7 @@ Province::index_t Province::get_index() const {
 	return index;
 }
 
-Region* Province::get_region() const {
+Region const* Province::get_region() const {
 	return region;
 }
 

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -13,7 +13,7 @@ namespace OpenVic {
 	struct Good;
 	struct TerrainType;
 	struct TerrainTypeMapping;
-	struct ProvinceHistoryMap;
+	struct ProvinceHistoryEntry;
 
 	/* REQUIREMENTS:
 	 * MAP-5, MAP-7, MAP-8, MAP-43, MAP-47
@@ -34,14 +34,10 @@ namespace OpenVic {
 
 		private:
 			Province const* const province;
-			const distance_t distance;
-			flags_t flags;
+			const distance_t PROPERTY(distance);
+			flags_t PROPERTY(flags);
 
 			adjacency_t(Province const* province, distance_t distance, flags_t flags);
-
-		public:
-			distance_t get_distance() const;
-			flags_t get_flags() const;
 		};
 
 		struct province_positions_t {
@@ -64,62 +60,50 @@ namespace OpenVic {
 		static constexpr index_t NULL_INDEX = 0, MAX_INDEX = std::numeric_limits<index_t>::max();
 
 	private:
-		const index_t index;
-		Region const* region = nullptr;
-		bool on_map = false, has_region = false, water = false;
-		life_rating_t life_rating = 0;
-		colony_status_t colony_status = colony_status_t::STATE;
-		IdentifierRegistry<BuildingInstance> buildings;
-		// TODO - change this into a factory-like structure
-		Good const* rgo = nullptr;
+		const index_t PROPERTY(index);
+		Region* PROPERTY(region);
+		bool PROPERTY(on_map);
+		bool PROPERTY(has_region);
+		bool PROPERTY(water);
+		/* Terrain type calculated from terrain image */
+		TerrainType const* PROPERTY(default_terrain_type);
 
-		std::vector<Pop> pops;
-		Pop::pop_size_t total_population;
+		std::vector<adjacency_t> PROPERTY(adjacencies);
+		province_positions_t positions;
+
+		TerrainType const* PROPERTY(terrain_type);
+		life_rating_t PROPERTY(life_rating);
+		colony_status_t PROPERTY(colony_status);
+		Country const* PROPERTY(owner);
+		Country const* PROPERTY(controller);
+		std::vector<Country const*> PROPERTY(cores);
+		bool PROPERTY(slave);
+		// TODO - change this into a factory-like structure
+		Good const* PROPERTY(rgo);
+		IdentifierRegistry<BuildingInstance> buildings;
+
+		std::vector<Pop> PROPERTY(pops);
+		Pop::pop_size_t PROPERTY(total_population);
 		fixed_point_map_t<PopType const*> PROPERTY(pop_type_distribution);
 		fixed_point_map_t<Ideology const*> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
 		fixed_point_map_t<Religion const*> PROPERTY(religion_distribution);
-
-		std::vector<adjacency_t> adjacencies;
-		province_positions_t positions;
-
-		TerrainType const* terrain_type = nullptr;
-
-		void _set_terrain_type(TerrainType const* type);
-
-		Country const* owner = nullptr;
-		Country const* controller = nullptr;
-		std::vector<Country const*> cores;
-		bool slave = false;
 
 		Province(std::string_view new_identifier, colour_t new_colour, index_t new_index);
 
 	public:
 		Province(Province&&) = default;
 
-		index_t get_index() const;
-		Region const* get_region() const;
-		bool get_on_map() const;
-		bool get_has_region() const;
-		bool get_water() const;
-		TerrainType const* get_terrain_type() const;
-		life_rating_t get_life_rating() const;
-		colony_status_t get_colony_status() const;
+		std::string to_string() const;
+
 		bool load_positions(BuildingManager const& building_manager, ast::NodeCPtr root);
 
-		bool add_building(BuildingInstance&& building_instance);
 		IDENTIFIER_REGISTRY_ACCESSORS(building)
-		void reset_buildings();
 		bool expand_building(std::string_view building_type_identifier);
-		Good const* get_rgo() const;
-		std::string to_string() const;
 
 		bool load_pop_list(PopManager const& pop_manager, ast::NodeCPtr root);
 		bool add_pop(Pop&& pop);
-		void clear_pops();
 		size_t get_pop_count() const;
-		std::vector<Pop> const& get_pops() const;
-		Pop::pop_size_t get_total_population() const;
 		void update_pops();
 
 		void update_state(Date today);
@@ -127,13 +111,8 @@ namespace OpenVic {
 
 		bool is_adjacent_to(Province const* province);
 		bool add_adjacency(Province const* province, distance_t distance, flags_t flags);
-		std::vector<adjacency_t> const& get_adjacencies() const;
 
-		Country const* get_owner() const;
-		Country const* get_controller() const;
-		std::vector<Country const*> const& get_cores() const;
-		bool is_slave() const;
-
-		void apply_history_to_province(ProvinceHistoryMap const& history, Date date);
+		bool reset(BuildingManager const& building_manager);
+		bool apply_history_to_province(ProvinceHistoryEntry const* entry);
 	};
 }

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -65,7 +65,7 @@ namespace OpenVic {
 
 	private:
 		const index_t index;
-		Region* region = nullptr;
+		Region const* region = nullptr;
 		bool on_map = false, has_region = false, water = false;
 		life_rating_t life_rating = 0;
 		colony_status_t colony_status = colony_status_t::STATE;
@@ -75,10 +75,10 @@ namespace OpenVic {
 
 		std::vector<Pop> pops;
 		Pop::pop_size_t total_population;
-		decimal_map_t<PopType const*> PROPERTY(pop_type_distribution);
-		decimal_map_t<Ideology const*> PROPERTY(ideology_distribution);
-		decimal_map_t<Culture const*> PROPERTY(culture_distribution);
-		decimal_map_t<Religion const*> PROPERTY(religion_distribution);
+		fixed_point_map_t<PopType const*> PROPERTY(pop_type_distribution);
+		fixed_point_map_t<Ideology const*> PROPERTY(ideology_distribution);
+		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
+		fixed_point_map_t<Religion const*> PROPERTY(religion_distribution);
 
 		std::vector<adjacency_t> adjacencies;
 		province_positions_t positions;
@@ -98,7 +98,7 @@ namespace OpenVic {
 		Province(Province&&) = default;
 
 		index_t get_index() const;
-		Region* get_region() const;
+		Region const* get_region() const;
 		bool get_on_map() const;
 		bool get_has_region() const;
 		bool get_water() const;

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -2,7 +2,7 @@
 
 #include <cassert>
 
-#include "openvic-simulation/economy/Building.hpp"
+#include "openvic-simulation/economy/BuildingInstance.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
 #include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/country/Country.hpp"

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -65,18 +65,15 @@ ProvinceSet::provinces_t const& ProvinceSet::get_provinces() const {
 	return provinces;
 }
 
+static constexpr colour_t ERROR_REGION_COLOUR = COLOUR_COMPONENT << 16;
+
 Region::Region(std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta)
-	: HasIdentifier { new_identifier }, ProvinceSet { std::move(new_provinces) }, meta { new_meta } {
+	: HasIdentifierAndColour {
+		new_identifier, new_provinces.size() > 0 ? new_provinces.front()->get_colour() : ERROR_REGION_COLOUR, false, false
+	}, ProvinceSet { std::move(new_provinces) }, meta { new_meta } {
 	lock();
 }
 
 bool Region::get_meta() const {
 	return meta;
-}
-
-colour_t Region::get_colour() const {
-	if (empty()) {
-		return FULL_COLOUR << 16;
-	}
-	return get_provinces().front()->get_colour();
 }

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -28,7 +28,7 @@ namespace OpenVic {
 	/* REQUIREMENTS:
 	 * MAP-6, MAP-44, MAP-48
 	 */
-	struct Region : HasIdentifier, ProvinceSet {
+	struct Region : HasIdentifierAndColour, ProvinceSet {
 		friend struct Map;
 
 	private:
@@ -44,6 +44,5 @@ namespace OpenVic {
 		Region(Region&&) = default;
 
 		bool get_meta() const;
-		colour_t get_colour() const;
 	};
 }

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 
 namespace OpenVic {
 	struct TerrainTypeManager;

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <string_view>
 
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -117,7 +117,7 @@ bool WargoalTypeManager::load_wargoal_file(ast::NodeCPtr root) {
 				},
 				"sprite_index", ONE_EXACTLY, expect_identifier(assign_variable_callback(sprite)),
 				"war_name", ONE_EXACTLY, expect_identifier_or_string(assign_variable_callback(war_name)),
-				"months", ONE_EXACTLY, expect_months(assign_variable_callback(available)),
+				"months", ZERO_OR_ONE, expect_months(assign_variable_callback(available)),
 				"truce_months", ONE_EXACTLY, expect_months(assign_variable_callback(truce)),
 				"is_triggered_only", ZERO_OR_ONE, expect_bool(assign_variable_callback(triggered_only)),
 				"is_civil_war", ZERO_OR_ONE, expect_bool(assign_variable_callback(civil_war)),

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/types/EnumBitfield.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/utility/Getters.hpp"

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -47,7 +47,7 @@ namespace OpenVic {
 			WAR_SCORE_BATTLE_FACTOR,
 			CONSTRUCTION_SPEED
 		};
-		using peace_modifiers_t = decimal_map_t<PEACE_MODIFIERS>;
+		using peace_modifiers_t = fixed_point_map_t<PEACE_MODIFIERS>;
 
 	private:
 		const std::string PROPERTY(sprite);

--- a/src/openvic-simulation/misc/Define.hpp
+++ b/src/openvic-simulation/misc/Define.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <concepts>
-#include <memory>
+#include <optional>
 
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
@@ -32,8 +32,8 @@ namespace OpenVic {
 	private:
 		IdentifierRegistry<Define> defines;
 
-		std::unique_ptr<Date> start_date = nullptr;
-		std::unique_ptr<Date> end_date = nullptr;
+		std::optional<Date> start_date;
+		std::optional<Date> end_date;
 
 	public:
 		DefineManager();
@@ -44,6 +44,7 @@ namespace OpenVic {
 
 		Date get_start_date() const;
 		Date get_end_date() const;
+		bool in_game_period(Date date) const;
 
 		bool load_defines_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -100,7 +100,7 @@ Date ModifierInstance::get_expiry_date() const {
 	return expiry_date;
 }
 
-ModifierManager::ModifierManager() : modifier_effects { "modifier effects" }, modifiers { "modifiers" } {}
+ModifierManager::ModifierManager() : modifier_effects { "modifier effects" }, event_modifiers { "event modifiers" } {}
 
 bool ModifierManager::add_modifier_effect(std::string_view identifier, bool positive_good, ModifierEffect::format_t format) {
 	if (identifier.empty()) {
@@ -112,7 +112,7 @@ bool ModifierManager::add_modifier_effect(std::string_view identifier, bool posi
 	);
 }
 
-bool ModifierManager::add_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon) {
+bool ModifierManager::add_event_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon) {
 	if (identifier.empty()) {
 		Logger::error("Invalid modifier effect identifier - empty!");
 		return false;
@@ -121,7 +121,7 @@ bool ModifierManager::add_modifier(std::string_view identifier, ModifierValue&& 
 		Logger::error("Invalid modifier icon for ", identifier, ": ", icon);
 		return false;
 	}
-	return modifiers.add_item({ identifier, std::move(values), icon });
+	return event_modifiers.add_item({ identifier, std::move(values), icon }, duplicate_warning_callback);
 }
 
 bool ModifierManager::setup_modifier_effects() {
@@ -220,6 +220,7 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= add_modifier_effect("local_factory_throughput", true);
 	ret &= add_modifier_effect("local_repair", true);
 	ret &= add_modifier_effect("local_rgo_output", true);
+	ret &= add_modifier_effect("local_RGO_output", true);
 	ret &= add_modifier_effect("local_RGO_throughput", true);
 	ret &= add_modifier_effect("local_ruling_party_support", true);
 	ret &= add_modifier_effect("local_ship_build", false);
@@ -252,6 +253,39 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= add_modifier_effect("speed", true);
 
 	return ret;
+}
+
+bool ModifierManager::load_crime_modifiers(ast::NodeCPtr root) {
+	// TODO - DEV TASK: read crime modifiers
+	return true;
+}
+
+bool ModifierManager::load_event_modifiers(ast::NodeCPtr root) {
+	// TODO - DEV TASK: read event modifiers - example framework below
+	return true;
+	/*return expect_dictionary_reserve_length(
+		event_modifiers,
+		[this](std::string_view key, ast::NodeCPtr value) -> bool {
+			ModifierValue modifier_value;
+			Modifier::icon_t icon = 0;
+			bool ret = expect_modifier_value_and_keys(
+				move_variable_callback(modifier_value),
+				"icon", ONE_EXACTLY, expect_uint(assign_variable_callback(icon))
+			)(value);
+			ret &= add_event_modifier(key, std::move(modifier_value), icon);
+			return ret;
+		}
+	)(root);*/
+}
+
+bool ModifierManager::load_static_modifiers(ast::NodeCPtr root) {
+	// TODO - DEV TASK: read static modifiers
+	return true;
+}
+
+bool ModifierManager::load_triggered_modifiers(ast::NodeCPtr root) {
+	// TODO - DEV TASK: read triggered modifiers
+	return true;
 }
 
 key_value_callback_t ModifierManager::_modifier_effect_callback(

--- a/src/openvic-simulation/misc/Modifier.hpp
+++ b/src/openvic-simulation/misc/Modifier.hpp
@@ -106,7 +106,7 @@ namespace OpenVic {
 		 */
 	private:
 		IdentifierInstanceRegistry<ModifierEffect> modifier_effects;
-		IdentifierRegistry<Modifier> modifiers;
+		IdentifierRegistry<Modifier> event_modifiers;
 
 		/* effect_validator takes in ModifierEffect const& */
 		NodeTools::key_value_callback_t _modifier_effect_callback(
@@ -123,10 +123,15 @@ namespace OpenVic {
 		);
 		IDENTIFIER_REGISTRY_ACCESSORS(modifier_effect)
 
-		bool add_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
-		IDENTIFIER_REGISTRY_ACCESSORS(modifier)
+		bool add_event_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
+		IDENTIFIER_REGISTRY_ACCESSORS(event_modifier)
 
 		bool setup_modifier_effects();
+
+		bool load_crime_modifiers(ast::NodeCPtr root);
+		bool load_event_modifiers(ast::NodeCPtr root);
+		bool load_static_modifiers(ast::NodeCPtr root);
+		bool load_triggered_modifiers(ast::NodeCPtr root);
 
 		NodeTools::node_callback_t expect_validated_modifier_value_and_default(
 			NodeTools::callback_t<ModifierValue&&> modifier_callback, NodeTools::key_value_callback_t default_callback,

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -23,9 +23,9 @@ namespace OpenVic {
 		friend struct NationalFocusManager;
 
 	public:
-		using pop_promotion_map_t = std::map<PopType const*, fixed_point_t>;
-		using party_loyalty_map_t = std::map<Ideology const*, fixed_point_t>;
-		using production_map_t = std::map<Good const*, fixed_point_t>;
+		using pop_promotion_map_t = fixed_point_map_t<PopType const*>;
+		using party_loyalty_map_t = fixed_point_map_t<Ideology const*>;
+		using production_map_t = fixed_point_map_t<Good const*>;
 
 	private:
 		uint8_t PROPERTY(icon);

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -2,7 +2,7 @@
 
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
 #include "openvic-simulation/economy/Good.hpp"
@@ -14,7 +14,7 @@ namespace OpenVic {
 
 	struct NationalFocusGroup : HasIdentifier {
 		friend struct NationalFocusManager;
-	
+
 	private:
 		NationalFocusGroup(std::string_view new_identifier);
 	};
@@ -39,8 +39,8 @@ namespace OpenVic {
 			std::string_view new_identifier,
 			uint8_t new_icon,
 			NationalFocusGroup const& new_group,
-			ModifierValue&& new_modifiers, 
-			pop_promotion_map_t&& new_encouraged_promotion, 
+			ModifierValue&& new_modifiers,
+			pop_promotion_map_t&& new_encouraged_promotion,
 			party_loyalty_map_t&& new_encouraged_loyalty,
 			production_map_t&& new_encouraged_production
 		);
@@ -64,8 +64,8 @@ namespace OpenVic {
 			std::string_view identifier,
 			uint8_t icon,
 			NationalFocusGroup const& group,
-			ModifierValue&& modifiers, 
-			NationalFocus::pop_promotion_map_t&& encouraged_promotion, 
+			ModifierValue&& modifiers,
+			NationalFocus::pop_promotion_map_t&& encouraged_promotion,
 			NationalFocus::party_loyalty_map_t&& encouraged_loyalty,
 			NationalFocus::production_map_t&& encouraged_production
 		);

--- a/src/openvic-simulation/politics/NationalValue.hpp
+++ b/src/openvic-simulation/politics/NationalValue.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/Modifier.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -71,7 +71,7 @@ namespace OpenVic {
 			size_t& total_expected_cultures, GraphicalCultureType const* default_unit_graphical_culture_type,
 			std::string_view culture_group_key, ast::NodeCPtr culture_group_node
 		);
-		bool _load_culture(CultureGroup const* culture_group, std::string_view culture_key, ast::NodeCPtr node);
+		bool _load_culture(CultureGroup const& culture_group, std::string_view culture_key, ast::NodeCPtr node);
 
 	public:
 		CultureManager();
@@ -80,13 +80,13 @@ namespace OpenVic {
 		IDENTIFIER_REGISTRY_ACCESSORS(graphical_culture_type)
 
 		bool add_culture_group(
-			std::string_view identifier, std::string_view leader, GraphicalCultureType const* new_graphical_culture_type,
+			std::string_view identifier, std::string_view leader, GraphicalCultureType const* graphical_culture_type,
 			bool is_overseas
 		);
 		IDENTIFIER_REGISTRY_ACCESSORS(culture_group)
 
 		bool add_culture(
-			std::string_view identifier, colour_t colour, CultureGroup const* group, std::vector<std::string>&& first_names,
+			std::string_view identifier, colour_t colour, CultureGroup const& group, std::vector<std::string>&& first_names,
 			std::vector<std::string>&& last_names
 		);
 		IDENTIFIER_REGISTRY_ACCESSORS(culture)

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -49,7 +49,7 @@ namespace OpenVic {
 		friend struct PopManager;
 
 		using sprite_t = uint8_t;
-		using rebel_units_t = decimal_map_t<Unit const*>;
+		using rebel_units_t = fixed_point_map_t<Unit const*>;
 
 	private:
 		const enum class strata_t { POOR, MIDDLE, RICH } strata;

--- a/src/openvic-simulation/pop/Religion.hpp
+++ b/src/openvic-simulation/pop/Religion.hpp
@@ -52,7 +52,7 @@ namespace OpenVic {
 		IDENTIFIER_REGISTRY_ACCESSORS(religion_group)
 
 		bool add_religion(
-			std::string_view identifier, colour_t colour, ReligionGroup const* group, Religion::icon_t icon, bool pagan
+			std::string_view identifier, colour_t colour, ReligionGroup const& group, Religion::icon_t icon, bool pagan
 		);
 		IDENTIFIER_REGISTRY_ACCESSORS(religion)
 

--- a/src/openvic-simulation/types/Colour.hpp
+++ b/src/openvic-simulation/types/Colour.hpp
@@ -15,7 +15,7 @@ namespace OpenVic {
 	 * When colour_t is used in a purely graphical context, NULL_COLOUR
 	 * should be allowed.
 	 */
-	static constexpr colour_t NULL_COLOUR = 0, FULL_COLOUR = 0xFF;
+	static constexpr colour_t NULL_COLOUR = 0, COLOUR_COMPONENT = 0xFF;
 	static constexpr colour_t MAX_COLOUR_RGB = 0xFFFFFF, MAX_COLOUR_ARGB = 0xFFFFFFFF;
 
 	constexpr colour_t float_to_colour_byte(float f, float min = 0.0f, float max = 1.0f) {

--- a/src/openvic-simulation/types/Date.cpp
+++ b/src/openvic-simulation/types/Date.cpp
@@ -204,6 +204,10 @@ Date Date::operator++(int) {
 	return old;
 }
 
+bool Date::in_range(Date start, Date end) const {
+	return start <= *this && *this <= end;
+}
+
 std::string Date::to_string() const {
 	std::stringstream ss;
 	ss << *this;

--- a/src/openvic-simulation/types/Date.hpp
+++ b/src/openvic-simulation/types/Date.hpp
@@ -91,6 +91,8 @@ namespace OpenVic {
 		Date& operator++();
 		Date operator++(int);
 
+		bool in_range(Date start, Date end) const;
+
 		std::string to_string() const;
 		explicit operator std::string() const;
 		// Parsed from string of the form YYYY.MM.DD

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -333,6 +333,9 @@ namespace OpenVic {
 	size_t get_##singular##_count() const { \
 		return plural.size(); \
 	} \
+	bool plural##_empty() const { \
+		return plural.empty(); \
+	} \
 	std::vector<decltype(plural)::storage_type> const& get_##plural() const { \
 		return plural.get_items(); \
 	} \

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
 
@@ -76,22 +77,6 @@ namespace OpenVic {
 		HasIdentifierAndColour& operator=(HasIdentifierAndColour const&) = delete;
 		HasIdentifierAndColour& operator=(HasIdentifierAndColour&&) = delete;
 	};
-
-	template<typename T>
-	using decimal_map_t = std::map<T, fixed_point_t>;
-
-	template<typename T>
-	constexpr typename decimal_map_t<T>::value_type get_largest_item(decimal_map_t<T> const& map) {
-		constexpr auto pred = [](typename decimal_map_t<T>::value_type a, typename decimal_map_t<T>::value_type b) -> bool {
-			return a.second < b.second;
-		};
-		const typename decimal_map_t<T>::const_iterator result = std::max_element(map.begin(), map.end(), pred);
-		if (result != map.end()) {
-			return *result;
-		} else {
-			return { nullptr, -1 };
-		}
-	}
 
 	/* Callbacks for trying to add duplicate keys via UniqueKeyRegistry::add_item */
 	static bool duplicate_fail_callback(std::string_view registry_name, std::string_view duplicate_identifier) {
@@ -274,10 +259,10 @@ namespace OpenVic {
 		}
 
 		NodeTools::node_callback_t expect_item_decimal_map(
-			NodeTools::callback_t<decimal_map_t<value_type const*>&&> callback
+			NodeTools::callback_t<fixed_point_map_t<value_type const*>&&> callback
 		) const {
 			return [this, callback](ast::NodeCPtr node) -> bool {
-				decimal_map_t<value_type const*> map;
+				fixed_point_map_t<value_type const*> map;
 				bool ret = expect_item_dictionary([&map](value_type const& key, ast::NodeCPtr value) -> bool {
 					fixed_point_t val;
 					const bool ret = NodeTools::expect_fixed_point(NodeTools::assign_variable_callback(val))(value);
@@ -370,7 +355,7 @@ namespace OpenVic {
 		return plural.expect_item_dictionary(callback); \
 	} \
 	NodeTools::node_callback_t expect_##singular##_decimal_map( \
-		NodeTools::callback_t<decimal_map_t<decltype(plural)::value_type const*>&&> callback \
+		NodeTools::callback_t<fixed_point_map_t<decltype(plural)::value_type const*>&&> callback \
 	) const { \
 		return plural.expect_item_decimal_map(callback); \
 	}

--- a/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+
+namespace OpenVic {
+
+	template<typename T>
+	using fixed_point_map_t = std::map<T, fixed_point_t>;
+
+	template<typename T>
+	using fixed_point_map_value_t = typename fixed_point_map_t<T>::value_type;
+
+	template<typename T>
+	using fixed_point_map_const_iterator_t = typename fixed_point_map_t<T>::const_iterator;
+
+	template<typename T>
+	constexpr fixed_point_t get_total(fixed_point_map_t<T> const& map) {
+		fixed_point_t total = 0;
+		for (auto const& [key, value] : map) {
+			total += value;
+		}
+		return total;
+	}
+
+	template<typename T>
+	constexpr fixed_point_map_const_iterator_t<T> get_largest_item(fixed_point_map_t<T> const& map) {
+		constexpr auto pred = [](fixed_point_map_value_t<T> a, fixed_point_map_value_t<T> b) -> bool {
+			return a.second < b.second;
+		};
+		return std::max_element(map.begin(), map.end(), pred);
+	}
+
+	template<typename T>
+	constexpr std::pair<fixed_point_map_const_iterator_t<T>, fixed_point_map_const_iterator_t<T>> get_largest_two_items(
+		fixed_point_map_t<T> const& map
+	) {
+		fixed_point_map_const_iterator_t<T> largest = map.end(), second_largest = map.end();
+		for (fixed_point_map_const_iterator_t<T> it = map.begin(); it != map.end(); ++it) {
+			if (largest == map.end() || it->second > largest->second) {
+				second_largest = largest;
+				largest = it;
+			} else if (second_largest == map.end() || it->second > second_largest->second) {
+				second_largest = it;
+			}
+		}
+		return std::make_pair(std::move(largest), std::move(second_largest));
+	}
+}


### PR DESCRIPTION
- Changed mapmodes to have 2 colours (base and stripe).
- Removed default land/sea colour tinting from mapmodes,  now terrain mapmode has no province tinting at all.
- Renamed `decimal_map_t` to `fixed_point_map_t`, moved it to `FixedPointMap.hpp` and added more helper functions (for finding the second largest item in a distribution and checking if it's at least a third of the total, for culture and religion mapmodes).
- Organised various map reset and setup code into a chain of `reset` functions and a chain of `apply_history_...` functions, with its tip (at least in this repo) being `GameManager::load_bookmark`, which resets and then loads province history up to the date of the bookmark.
- Moved `Modifier.*pp` to the `misc` folder.
- Changed various things to use the `PROPERTY` macro.
- Made `expect_assign` print an error when the callback fails, helping with errors inside lists and dictionaries.