### PR TITLE
Dataloading rebels

### DIFF
--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -16,17 +16,17 @@ namespace OpenVic {
 		using state_updated_func_t = std::function<void()>;
 
 	private:
-		Map map;
-		DefineManager define_manager;
-		EconomyManager economy_manager;
-		MilitaryManager military_manager;
-		ModifierManager modifier_manager;
-		PoliticsManager politics_manager;
-		HistoryManager history_manager;
-		PopManager pop_manager;
-		CountryManager country_manager;
-		UIManager ui_manager;
-		GameAdvancementHook clock;
+		Map PROPERTY_REF(map);
+		DefineManager PROPERTY_REF(define_manager);
+		EconomyManager PROPERTY_REF(economy_manager);
+		MilitaryManager PROPERTY_REF(military_manager);
+		ModifierManager PROPERTY_REF(modifier_manager);
+		PoliticsManager PROPERTY_REF(politics_manager);
+		HistoryManager PROPERTY_REF(history_manager);
+		PopManager PROPERTY_REF(pop_manager);
+		CountryManager PROPERTY_REF(country_manager);
+		UIManager PROPERTY_REF(ui_manager);
+		GameAdvancementHook PROPERTY_REF(clock);
 
 		time_t session_start; /* SS-54, as well as allowing time-tracking */
 		Bookmark const* PROPERTY(bookmark);
@@ -40,18 +40,6 @@ namespace OpenVic {
 
 	public:
 		GameManager(state_updated_func_t state_updated_callback);
-
-		REF_GETTERS(map)
-		REF_GETTERS(define_manager)
-		REF_GETTERS(economy_manager)
-		REF_GETTERS(military_manager)
-		REF_GETTERS(modifier_manager)
-		REF_GETTERS(politics_manager)
-		REF_GETTERS(history_manager)
-		REF_GETTERS(pop_manager)
-		REF_GETTERS(country_manager)
-		REF_GETTERS(ui_manager)
-		REF_GETTERS(clock)
 
 		bool reset();
 		bool load_bookmark(Bookmark const* new_bookmark);

--- a/src/openvic-simulation/country/Country.hpp
+++ b/src/openvic-simulation/country/Country.hpp
@@ -60,7 +60,7 @@ namespace OpenVic {
 		 */
 		IdentifierRegistry<CountryParty> parties;
 		const unit_names_map_t PROPERTY(unit_names);
-		const bool PROPERTY_CUSTOM_NAME(dynamic_tag, is_dynamic_tag);
+		const bool PROPERTY_CUSTOM_PREFIX(dynamic_tag, is);
 		const government_colour_map_t PROPERTY(alternative_colours);
 
 		Country(

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -853,6 +853,7 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 	static const std::string event_modifiers_file = "common/event_modifiers.txt";
 	static const std::string static_modifiers_file = "common/static_modifiers.txt";
 	static const std::string triggered_modifiers_file = "common/triggered_modifiers.txt";
+	static const std::string rebel_types_file = "common/rebel_types.txt";
 
 	bool ret = true;
 
@@ -997,6 +998,14 @@ bool Dataloader::load_defines(GameManager& game_manager) const {
 		game_manager, *this, parse_defines(lookup_file(countries_file)).get_file_node()
 	)) {
 		Logger::error("Failed to load countries!");
+		ret = false;
+	}
+	if (!game_manager.get_politics_manager().get_rebel_manager().load_rebels_file(
+		game_manager.get_politics_manager().get_ideology_manager(),
+		game_manager.get_politics_manager().get_government_type_manager(),
+		parse_defines(lookup_file(rebel_types_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load rebel types!");
 		ret = false;
 	}
 	if (!_load_history(game_manager, false)) {

--- a/src/openvic-simulation/economy/EconomyManager.hpp
+++ b/src/openvic-simulation/economy/EconomyManager.hpp
@@ -7,15 +7,11 @@
 namespace OpenVic {
 	struct EconomyManager {
 	private:
-		BuildingManager building_manager;
-		GoodManager good_manager;
-		ProductionTypeManager production_type_manager;
+		BuildingManager PROPERTY_REF(building_manager);
+		GoodManager PROPERTY_REF(good_manager);
+		ProductionTypeManager PROPERTY_REF(production_type_manager);
 
 	public:
-		REF_GETTERS(building_manager)
-		REF_GETTERS(good_manager)
-		REF_GETTERS(production_type_manager)
-
 		inline bool load_production_types_file(PopManager const& pop_manager, ast::NodeCPtr root) {
 			return production_type_manager.load_production_types_file(good_manager, pop_manager, root);
 		}

--- a/src/openvic-simulation/economy/Good.hpp
+++ b/src/openvic-simulation/economy/Good.hpp
@@ -38,8 +38,8 @@ namespace OpenVic {
 	private:
 		GoodCategory const& PROPERTY(category);
 		const price_t PROPERTY(base_price);
-		const bool PROPERTY_CUSTOM_NAME(available_from_start, is_available_from_start);
-		const bool PROPERTY_CUSTOM_NAME(tradeable, is_tradeable);
+		const bool PROPERTY_CUSTOM_PREFIX(available_from_start, is);
+		const bool PROPERTY_CUSTOM_PREFIX(tradeable, is);
 		const bool PROPERTY(money);
 		const bool PROPERTY(overseas_penalty);
 

--- a/src/openvic-simulation/economy/ProductionType.hpp
+++ b/src/openvic-simulation/economy/ProductionType.hpp
@@ -53,10 +53,10 @@ namespace OpenVic {
 		const std::vector<Bonus> PROPERTY(bonuses);
 
 		const Good::good_map_t PROPERTY(efficiency);
-		const bool PROPERTY_CUSTOM_NAME(coastal, is_coastal); // is_coastal
+		const bool PROPERTY_CUSTOM_PREFIX(coastal, is); // is_coastal
 
-		const bool PROPERTY_CUSTOM_NAME(farm, is_farm);
-		const bool PROPERTY_CUSTOM_NAME(mine, is_mine);
+		const bool PROPERTY_CUSTOM_PREFIX(farm, is);
+		const bool PROPERTY_CUSTOM_PREFIX(mine, is);
 
 		ProductionType(PRODUCTION_TYPE_ARGS);
 

--- a/src/openvic-simulation/history/DiplomaticHistory.hpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.hpp
@@ -19,7 +19,7 @@ namespace OpenVic {
 			friend struct DiplomaticHistoryManager;
 
 		private:
-			Date PROPERTY_CUSTOM_NAME(added, get_date_added);
+			Date PROPERTY_CUSTOM_PREFIX(added, get_date);
 			Country const* PROPERTY(actor);
 			Country const* PROPERTY(receiver);
 			WargoalType const* PROPERTY(wargoal);
@@ -34,8 +34,8 @@ namespace OpenVic {
 
 		private:
 			Country const* PROPERTY(country);
-			Date PROPERTY_CUSTOM_NAME(joined, get_date_joined);
-			std::optional<Date> PROPERTY_CUSTOM_NAME(exited, get_date_exited);
+			Date PROPERTY_CUSTOM_PREFIX(joined, get_date);
+			std::optional<Date> PROPERTY_CUSTOM_PREFIX(exited, get_date);
 
 			war_participant_t(Country const* new_country, Date new_joined, std::optional<Date> new_exited);
 		};
@@ -73,7 +73,7 @@ namespace OpenVic {
 	private:
 		Country const* PROPERTY(overlord);
 		Country const* PROPERTY(subject);
-		const type_t PROPERTY_CUSTOM_NAME(type, get_subject_type);
+		const type_t PROPERTY_CUSTOM_PREFIX(type, get_subject);
 		const Date start;
 		const Date end;
 

--- a/src/openvic-simulation/history/HistoryManager.hpp
+++ b/src/openvic-simulation/history/HistoryManager.hpp
@@ -9,15 +9,9 @@
 namespace OpenVic {
 	struct HistoryManager {
 	private:
-		BookmarkManager bookmark_manager;
-		CountryHistoryManager country_manager;
-		ProvinceHistoryManager province_manager;
-		DiplomaticHistoryManager diplomacy_manager;
-
-	public:
-		REF_GETTERS(bookmark_manager)
-		REF_GETTERS(country_manager)
-		REF_GETTERS(province_manager)
-		REF_GETTERS(diplomacy_manager)
+		BookmarkManager PROPERTY_REF(bookmark_manager);
+		CountryHistoryManager PROPERTY_REF(country_manager);
+		ProvinceHistoryManager PROPERTY_REF(province_manager);
+		DiplomaticHistoryManager PROPERTY_REF(diplomacy_manager);
 	};
 }

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -56,7 +56,7 @@ namespace OpenVic {
 		IdentifierRegistry<Region> regions;
 		IdentifierRegistry<Mapmode> mapmodes;
 		ProvinceSet water_provinces;
-		TerrainTypeManager terrain_type_manager;
+		TerrainTypeManager PROPERTY_REF(terrain_type_manager);
 
 		size_t width = 0, height = 0;
 		std::vector<shape_pixel_t> province_shape_image;
@@ -92,7 +92,6 @@ namespace OpenVic {
 		size_t get_width() const;
 		size_t get_height() const;
 		std::vector<shape_pixel_t> const& get_province_shape_image() const;
-		REF_GETTERS(terrain_type_manager)
 
 		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
 		IDENTIFIER_REGISTRY_ACCESSORS(region)

--- a/src/openvic-simulation/military/MilitaryManager.hpp
+++ b/src/openvic-simulation/military/MilitaryManager.hpp
@@ -8,15 +8,9 @@
 namespace OpenVic {
 	struct MilitaryManager {
 	private:
-		UnitManager unit_manager;
-		LeaderTraitManager leader_trait_manager;
-		DeploymentManager deployment_manager;
-		WargoalTypeManager wargoal_manager;
-
-	public:
-		REF_GETTERS(unit_manager)
-		REF_GETTERS(leader_trait_manager)
-		REF_GETTERS(deployment_manager)
-		REF_GETTERS(wargoal_manager)
+		UnitManager PROPERTY_REF(unit_manager);
+		LeaderTraitManager PROPERTY_REF(leader_trait_manager);
+		DeploymentManager PROPERTY_REF(deployment_manager);
+		WargoalTypeManager PROPERTY_REF(wargoal_manager);
 	};
 }

--- a/src/openvic-simulation/military/Unit.hpp
+++ b/src/openvic-simulation/military/Unit.hpp
@@ -35,9 +35,9 @@ namespace OpenVic {
 		const type_t PROPERTY(type);
 		const icon_t PROPERTY(icon);
 		const std::string PROPERTY(sprite);
-		const bool PROPERTY_CUSTOM_NAME(active, is_active);
+		const bool PROPERTY_CUSTOM_PREFIX(active, is);
 		const std::string PROPERTY(unit_type);
-		const bool PROPERTY_CUSTOM_NAME(floating_flag, has_floating_flag);
+		const bool PROPERTY_CUSTOM_PREFIX(floating_flag, has);
 
 		const uint32_t PROPERTY(priority);
 		const fixed_point_t PROPERTY(max_strength);
@@ -64,7 +64,7 @@ namespace OpenVic {
 		friend struct UnitManager;
 
 	private:
-		const bool PROPERTY_CUSTOM_NAME(primary_culture, is_primary_culture);
+		const bool PROPERTY_CUSTOM_PREFIX(primary_culture, is);
 		const std::string PROPERTY(sprite_override);
 		const std::string PROPERTY(sprite_mount);
 		const std::string PROPERTY(sprite_mount_attach_node);
@@ -87,11 +87,11 @@ namespace OpenVic {
 
 	private:
 		const icon_t PROPERTY(naval_icon);
-		const bool PROPERTY_CUSTOM_NAME(sail, can_sail);
-		const bool PROPERTY_CUSTOM_NAME(transport, is_transport);
-		const bool PROPERTY_CUSTOM_NAME(capital, is_capital);
+		const bool PROPERTY_CUSTOM_PREFIX(sail, can);
+		const bool PROPERTY_CUSTOM_PREFIX(transport, is);
+		const bool PROPERTY_CUSTOM_PREFIX(capital, is);
 		const fixed_point_t PROPERTY(colonial_points);
-		const bool PROPERTY_CUSTOM_NAME(build_overseas, can_build_overseas);
+		const bool PROPERTY_CUSTOM_PREFIX(build_overseas, can);
 		const uint32_t PROPERTY(min_port_level);
 		const int32_t PROPERTY(limit_per_port);
 		const fixed_point_t PROPERTY(supply_consumption_score);

--- a/src/openvic-simulation/misc/Modifier.hpp
+++ b/src/openvic-simulation/misc/Modifier.hpp
@@ -19,7 +19,7 @@ namespace OpenVic {
 		/* If true, positive values will be green and negative values will be red.
 		 * If false, the colours will be switced.
 		 */
-		const bool PROPERTY_CUSTOM_NAME(positive_good, is_positive_good);
+		const bool PROPERTY_CUSTOM_PREFIX(positive_good, is);
 		const format_t PROPERTY(format);
 
 		// TODO - format/precision, e.g. 80% vs 0.8 vs 0.800, 2 vs 2.0 vs 200%

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -10,8 +10,8 @@ namespace OpenVic {
 
 	private:
 		const std::vector<Ideology const*> PROPERTY(ideologies);
-		const bool PROPERTY_CUSTOM_NAME(elections, holds_elections);
-		const bool PROPERTY_CUSTOM_NAME(appoint_ruling_party, can_appoint_ruling_party);
+		const bool PROPERTY_CUSTOM_PREFIX(elections, holds);
+		const bool PROPERTY_CUSTOM_PREFIX(appoint_ruling_party, can);
 		const Timespan PROPERTY(term_duration);
 		const std::string PROPERTY_CUSTOM_NAME(flag_type_identifier, get_flag_type);
 

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -20,7 +20,7 @@ namespace OpenVic {
 
 	private:
 		IdeologyGroup const& PROPERTY(group);
-		const bool PROPERTY_CUSTOM_NAME(uncivilised, is_uncivilised);
+		const bool PROPERTY_CUSTOM_PREFIX(uncivilised, is);
 		const bool PROPERTY(can_reduce_militancy);
 		const Date PROPERTY(spawn_date);
 

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -56,8 +56,8 @@ namespace OpenVic {
 
 	private:
 		ReformType const& PROPERTY(type);
-		const bool PROPERTY_CUSTOM_NAME(ordered, is_ordered); // next_step_only
-		const bool PROPERTY_CUSTOM_NAME(administrative, is_administrative);
+		const bool PROPERTY_CUSTOM_PREFIX(ordered, is); // next_step_only
+		const bool PROPERTY_CUSTOM_PREFIX(administrative, is);
 
 		ReformGroup(std::string_view identifier, ReformType const& type, bool ordered, bool administrative);
 

--- a/src/openvic-simulation/politics/PoliticsManager.hpp
+++ b/src/openvic-simulation/politics/PoliticsManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Rebel.hpp"
 #include "openvic-simulation/politics/Government.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
 #include "openvic-simulation/politics/Issue.hpp"
@@ -14,6 +15,7 @@ namespace OpenVic {
 		IssueManager PROPERTY_REF(issue_manager);
 		NationalValueManager PROPERTY_REF(national_value_manager);
 		NationalFocusManager PROPERTY_REF(national_focus_manager);
+		RebelManager PROPERTY_REF(rebel_manager);
 
 	public:
 		inline bool load_government_types_file(ast::NodeCPtr root) {

--- a/src/openvic-simulation/politics/PoliticsManager.hpp
+++ b/src/openvic-simulation/politics/PoliticsManager.hpp
@@ -9,19 +9,13 @@
 namespace OpenVic {
 	struct PoliticsManager {
 	private:
-		GovernmentTypeManager government_type_manager;
-		IdeologyManager ideology_manager;
-		IssueManager issue_manager;
-		NationalValueManager national_value_manager;
-		NationalFocusManager national_focus_manager;
+		GovernmentTypeManager PROPERTY_REF(government_type_manager);
+		IdeologyManager PROPERTY_REF(ideology_manager);
+		IssueManager PROPERTY_REF(issue_manager);
+		NationalValueManager PROPERTY_REF(national_value_manager);
+		NationalFocusManager PROPERTY_REF(national_focus_manager);
 
 	public:
-		REF_GETTERS(government_type_manager)
-		REF_GETTERS(ideology_manager)
-		REF_GETTERS(issue_manager)
-		REF_GETTERS(national_value_manager)
-		REF_GETTERS(national_focus_manager)
-
 		inline bool load_government_types_file(ast::NodeCPtr root) {
 			return government_type_manager.load_government_types_file(ideology_manager, root);
 		}

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -1,0 +1,138 @@
+#include "Rebel.hpp"
+
+using namespace OpenVic;
+using namespace OpenVic::NodeTools;
+
+RebelType::RebelType(std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
+	RebelType::government_map_t desired_governments, RebelType::defection_t defection, RebelType::independence_t independence, uint16_t defect_delay,
+	Ideology const* ideology, bool allow_all_cultures, bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient,
+	bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult) 
+: HasIdentifier { new_identifier }, icon { icon }, area { area }, break_alliance_on_win { break_alliance_on_win },
+	desired_governments { std::move(desired_governments) }, defection { defection }, independence { independence }, defect_delay { defect_delay },
+	ideology { ideology }, allow_all_cultures { allow_all_cultures }, allow_all_culture_groups { allow_all_culture_groups },
+	allow_all_religions { allow_all_religions }, allow_all_ideologies { allow_all_ideologies }, resilient { resilient }, reinforcing { reinforcing },
+	general { general }, smart { smart }, unit_transfer { unit_transfer }, occupation_mult { occupation_mult } {}
+
+RebelManager::RebelManager() : rebel_types { "rebel types" } {}
+
+bool RebelManager::add_rebel_type(
+	std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win, RebelType::government_map_t desired_governments,
+	RebelType::defection_t defection, RebelType::independence_t independence, uint16_t defect_delay, Ideology const* ideology, bool allow_all_cultures,
+	bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient, bool reinforcing, bool general, bool smart, bool unit_transfer,
+	fixed_point_t occupation_mult) {
+
+	if (new_identifier.empty()) {
+		Logger::error("Invalid rebel type identifier - empty!");
+		return false;
+	}
+
+	return rebel_types.add_item({
+		new_identifier, icon, area, break_alliance_on_win, desired_governments, defection, independence, defect_delay, ideology,
+		allow_all_cultures, allow_all_culture_groups, allow_all_religions, allow_all_ideologies, resilient, reinforcing, general,
+		smart, unit_transfer, occupation_mult 
+	});
+}
+
+bool RebelManager::load_rebels_file(IdeologyManager const& ideology_manager, GovernmentTypeManager const& government_type_manager, ast::NodeCPtr root) {
+	static const string_map_t<RebelType::area_t> area_map = {
+		{ "nation", RebelType::area_t::NATION },
+		{ "nation_religion", RebelType::area_t::NATION_RELIGION },
+		{ "nation_culture", RebelType::area_t::NATION_CULTURE },
+		{ "culture", RebelType::area_t::CULTURE },
+		{ "culture_group", RebelType::area_t::CULTURE_GROUP },
+		{ "religion", RebelType::area_t::RELIGION },
+		{ "all", RebelType::area_t::ALL }
+	};
+
+	static const string_map_t<RebelType::defection_t> defection_map = {
+		{ "none", RebelType::defection_t::NONE },
+		{ "culture", RebelType::defection_t::CULTURE },
+		{ "culture_group", RebelType::defection_t::CULTURE_GROUP },
+		{ "religion", RebelType::defection_t::RELIGION },
+		{ "ideology", RebelType::defection_t::IDEOLOGY },
+		{ "pan_nationalist", RebelType::defection_t::PAN_NATIONALIST },
+		{ "any", RebelType::defection_t::ANY }
+	};
+
+	static const string_map_t<RebelType::independence_t> independence_map = {
+		{ "none", RebelType::independence_t::NONE },
+		{ "culture", RebelType::independence_t::CULTURE },
+		{ "culture_group", RebelType::independence_t::CULTURE_GROUP },
+		{ "religion", RebelType::independence_t::RELIGION },
+		{ "colonial", RebelType::independence_t::COLONIAL },
+		{ "pan_nationalist", RebelType::independence_t::PAN_NATIONALIST },
+		{ "any", RebelType::independence_t::ANY }
+	};
+
+	bool ret = expect_dictionary(
+		[this, &ideology_manager, &government_type_manager](std::string_view identifier, ast::NodeCPtr node) -> bool {
+			RebelType::icon_t icon;
+			RebelType::area_t area;
+			RebelType::government_map_t desired_governments;
+			RebelType::defection_t defection;
+			RebelType::independence_t independence;
+			uint16_t defect_delay;
+			std::string_view ideology_identifier;
+			bool break_alliance_on_win, allow_all_cultures, allow_all_culture_groups, allow_all_religions, allow_all_ideologies, resilient, reinforcing, general, smart, unit_transfer;
+			fixed_point_t occupation_mult;
+
+			bool ret = expect_dictionary_keys(
+				"icon", ONE_EXACTLY, expect_uint(assign_variable_callback(icon)),
+				"area", ONE_EXACTLY, expect_identifier(expect_mapped_string(area_map, assign_variable_callback(area))),
+				"break_alliance_on_win", ZERO_OR_ONE, expect_bool(assign_variable_callback(break_alliance_on_win)),
+				"government", ONE_EXACTLY, expect_dictionary([this, &government_type_manager, &desired_governments](std::string_view key, ast::NodeCPtr value) -> bool {
+					bool ret = true;
+
+					GovernmentType const* from = government_type_manager.get_government_type_by_identifier(key);
+					ret &= from != nullptr; //invalid from
+
+					std::string_view to_identifier;
+					ret &= expect_identifier(assign_variable_callback(to_identifier))(value);
+					
+					GovernmentType const* to = government_type_manager.get_government_type_by_identifier(to_identifier);
+					ret &= to != nullptr; //invalid to
+					
+					if (desired_governments.contains(from)) ret = false; //duplicate
+					else if (ret) desired_governments.emplace(from, to); //only proceed if both values are valid
+
+					return ret;
+				}),
+				"defection", ONE_EXACTLY, expect_identifier(expect_mapped_string(defection_map, assign_variable_callback(defection))),
+				"independence", ONE_EXACTLY, expect_identifier(expect_mapped_string(independence_map, assign_variable_callback(independence))),
+				"defect_delay", ONE_EXACTLY, expect_uint(assign_variable_callback(defect_delay)),
+				"ideology", ZERO_OR_ONE, expect_identifier(assign_variable_callback(ideology_identifier)),
+				"allow_all_cultures", ONE_EXACTLY, expect_bool(assign_variable_callback(allow_all_cultures)),
+				"allow_all_culture_groups", ZERO_OR_ONE, expect_bool(assign_variable_callback(allow_all_culture_groups)),
+				"allow_all_religions", ONE_EXACTLY, expect_bool(assign_variable_callback(allow_all_religions)),
+				"allow_all_ideologies", ONE_EXACTLY, expect_bool(assign_variable_callback(allow_all_ideologies)),
+				"resilient", ONE_EXACTLY, expect_bool(assign_variable_callback(resilient)),
+				"reinforcing", ONE_EXACTLY, expect_bool(assign_variable_callback(reinforcing)),
+				"general", ONE_EXACTLY, expect_bool(assign_variable_callback(general)),
+				"smart", ONE_EXACTLY, expect_bool(assign_variable_callback(smart)),
+				"unit_transfer", ONE_EXACTLY, expect_bool(assign_variable_callback(unit_transfer)),
+				"occupation_mult", ONE_EXACTLY, expect_fixed_point(assign_variable_callback(occupation_mult)),
+				"will_rise", ONE_EXACTLY, success_callback, //TODO
+				"spawn_chance", ONE_EXACTLY, success_callback, //TODO
+				"movement_evaluation", ONE_EXACTLY, success_callback, //TODO
+				"siege_won_trigger", ZERO_OR_ONE, success_callback, //TODO
+				"siege_won_effect", ZERO_OR_ONE, success_callback, //TODO
+				"demands_enforced_trigger", ZERO_OR_ONE, success_callback, //TODO
+				"demands_enforced_effect", ZERO_OR_ONE, success_callback //TODO
+			)(node);
+
+			Ideology const* ideology = ideology_manager.get_ideology_by_identifier(ideology_identifier);
+
+			ret &= add_rebel_type(
+				identifier, icon, area, break_alliance_on_win, desired_governments, defection, independence,defect_delay,
+				ideology, allow_all_cultures, allow_all_culture_groups, allow_all_religions, allow_all_ideologies, resilient, reinforcing,
+				general, smart, unit_transfer, occupation_mult
+			);
+
+			return ret;
+		}
+	)(root);
+
+	lock_rebel_types();
+
+	return ret;
+}

--- a/src/openvic-simulation/politics/Rebel.hpp
+++ b/src/openvic-simulation/politics/Rebel.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "openvic-simulation/types/IdentifierRegistry.hpp"
+#include "openvic-simulation/politics/Government.hpp"
+#include "openvic-simulation/politics/Ideology.hpp"
+#include <cstdint>
+#include <unordered_map>
+
+namespace OpenVic {
+	struct RebelManager;
+
+	struct RebelType : HasIdentifier {
+		friend struct RebelManager;
+
+		using government_map_t = std::unordered_map<GovernmentType const*, GovernmentType const*>;
+		using icon_t = uint16_t;
+
+		enum class area_t {
+			NATION, NATION_RELIGION, NATION_CULTURE,
+			CULTURE, CULTURE_GROUP, RELIGION, ALL
+		};
+
+		enum class defection_t {
+			NONE, CULTURE, CULTURE_GROUP, RELIGION,
+			IDEOLOGY, PAN_NATIONALIST, ANY
+		};
+
+		enum class independence_t {
+			NONE, CULTURE, CULTURE_GROUP, RELIGION,
+			COLONIAL, PAN_NATIONALIST, ANY
+		};
+
+	private:
+		const icon_t PROPERTY(icon);
+		const area_t PROPERTY(area);
+		const bool PROPERTY_CUSTOM_PREFIX(break_alliance_on_win, will);
+		government_map_t PROPERTY(desired_governments); //government
+		const defection_t PROPERTY_CUSTOM_NAME(defection, get_defection_type);
+		const independence_t PROPERTY_CUSTOM_NAME(independence, get_independence_type);
+		const uint16_t PROPERTY(defect_delay);
+		Ideology const* PROPERTY(ideology);
+		const bool PROPERTY_CUSTOM_PREFIX(allow_all_cultures, will);
+		const bool PROPERTY_CUSTOM_PREFIX(allow_all_culture_groups, will);
+		const bool PROPERTY_CUSTOM_PREFIX(allow_all_religions, will);
+		const bool PROPERTY_CUSTOM_PREFIX(allow_all_ideologies, will);
+		const bool PROPERTY_CUSTOM_PREFIX(resilient, is);
+		const bool PROPERTY_CUSTOM_PREFIX(reinforcing, is);
+		const bool PROPERTY_CUSTOM_PREFIX(general, can_have);
+		const bool PROPERTY_CUSTOM_PREFIX(smart, is);
+		const bool PROPERTY_CUSTOM_NAME(unit_transfer, will_transfer_units);
+		const fixed_point_t PROPERTY(occupation_mult);
+
+		RebelType(
+			std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
+			RebelType::government_map_t desired_governments, RebelType::defection_t defection, RebelType::independence_t independence, uint16_t defect_delay,
+			Ideology const* ideology, bool allow_all_cultures, bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient,
+			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult
+		);
+
+	public:
+		RebelType(RebelType&&) = default; 
+	};
+
+	struct RebelManager {
+	private:
+		IdentifierRegistry<RebelType> rebel_types;
+
+	public:
+		RebelManager();
+
+		IDENTIFIER_REGISTRY_ACCESSORS(rebel_type)
+		bool add_rebel_type(
+			std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
+			RebelType::government_map_t desired_governments, RebelType::defection_t defection, RebelType::independence_t independence, uint16_t defect_delay,
+			Ideology const* ideology, bool allow_all_cultures, bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient,
+			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult
+		);
+
+		bool load_rebels_file(IdeologyManager const& ideology_manager, GovernmentTypeManager const& government_type_manager, ast::NodeCPtr root);
+	};
+}

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -80,14 +80,11 @@ namespace OpenVic {
 	private:
 		IdentifierRegistry<PopType> pop_types;
 
-		CultureManager culture_manager;
-		ReligionManager religion_manager;
+		CultureManager PROPERTY_REF(culture_manager);
+		ReligionManager PROPERTY_REF(religion_manager);
 
 	public:
 		PopManager();
-
-		REF_GETTERS(culture_manager)
-		REF_GETTERS(religion_manager)
 
 		bool add_pop_type(
 			std::string_view identifier, colour_t new_colour, PopType::strata_t strata, PopType::sprite_t sprite,

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -105,7 +105,7 @@ namespace OpenVic {
 
 		const std::string name;
 		const bool log_lock;
-		std::vector<_Storage> items;
+		std::vector<_Storage> PROPERTY_REF(items);
 		bool locked = false;
 		string_map_t<size_t> identifier_index_map;
 
@@ -247,8 +247,6 @@ namespace OpenVic {
 		bool has_index(size_t index) const {
 			return index < size();
 		}
-
-		REF_GETTERS(items)
 
 		std::vector<std::string_view> get_item_identifiers() const {
 			std::vector<std::string_view> identifiers(items.size());

--- a/src/openvic-simulation/utility/Getters.hpp
+++ b/src/openvic-simulation/utility/Getters.hpp
@@ -36,13 +36,17 @@
 	constexpr std::string_view get_base_type() const override { \
 		return ::ovdl::detail::type_name<std::decay_t<decltype(*this)>>(); }
 
-#define REF_GETTERS(var) \
-	constexpr decltype(var)& get_##var() { \
-		return var; \
+#define PROPERTY_REF(NAME) PROPERTY_REF_FULL(NAME, private)
+#define PROPERTY_REF_FULL(NAME, ACCESS) \
+	NAME; \
+public: \
+	constexpr decltype(NAME)& get_##NAME() { \
+		return NAME; \
 	} \
-	constexpr decltype(var) const& get_##var() const { \
-		return var; \
-	}
+	constexpr decltype(NAME) const& get_##NAME() const { \
+		return NAME; \
+	} \
+ACCESS:
 
 namespace OpenVic {
 	struct ReturnByValueProperty {};
@@ -88,6 +92,7 @@ namespace OpenVic {
  * 		Province& PROPERTY(province);		// Province& province;			Province const& get_province() const;
  */
 #define PROPERTY(NAME) PROPERTY_ACCESS(NAME, private)
+#define PROPERTY_CUSTOM_PREFIX(NAME, PREFIX) PROPERTY_CUSTOM_NAME(NAME, PREFIX##_##NAME)
 #define PROPERTY_CUSTOM_NAME(NAME, GETTER_NAME) PROPERTY_FULL(NAME, GETTER_NAME, private)
 #define PROPERTY_ACCESS(NAME, ACCESS) PROPERTY_FULL(NAME, get_##NAME, ACCESS)
 #define PROPERTY_FULL(NAME, GETTER_NAME, ACCESS) \


### PR DESCRIPTION
This one should be pretty simple.

The complex values `will_rise`, `spawn_change`, `movement_evaluation`, `siege_won_trigger`, `siege_won_effect`, `demands_enforced_trigger` and `demands_enforced_effect` have been left unimplemented as requested.

I also did some macro work while I was at it, 'cause why not.