### PR TITLE
Improved identifier registry macro

### DIFF
--- a/src/openvic-simulation/country/Country.cpp
+++ b/src/openvic-simulation/country/Country.cpp
@@ -35,8 +35,6 @@ Country::Country(
 	parties { std::move(new_parties) }, unit_names { std::move(new_unit_names) }, dynamic_tag { new_dynamic_tag },
 	alternative_colours { std::move(new_alternative_colours) } {}
 
-CountryManager::CountryManager() : countries { "countries" } {}
-
 bool CountryManager::add_country(
 	std::string_view identifier, colour_t colour, GraphicalCultureType const* graphical_culture,
 	IdentifierRegistry<CountryParty>&& parties, Country::unit_names_map_t&& unit_names, bool dynamic_tag,

--- a/src/openvic-simulation/country/Country.hpp
+++ b/src/openvic-simulation/country/Country.hpp
@@ -58,7 +58,7 @@ namespace OpenVic {
 		/* Not const to allow elements to be moved, otherwise a copy is forced
 		 * which causes a compile error as the copy constructor has been deleted.
 		 */
-		IdentifierRegistry<CountryParty> parties;
+		IdentifierRegistry<CountryParty> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(party, parties);
 		const unit_names_map_t PROPERTY(unit_names);
 		const bool PROPERTY_CUSTOM_PREFIX(dynamic_tag, is);
 		const government_colour_map_t PROPERTY(alternative_colours);
@@ -72,28 +72,23 @@ namespace OpenVic {
 	public:
 		Country(Country&&) = default;
 
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(party, parties)
-
 		// TODO - get_colour including alternative colours
 	};
 
 	struct CountryManager {
 	private:
-		IdentifierRegistry<Country> countries;
+		IdentifierRegistry<Country> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(country, countries);
 
 		NodeTools::node_callback_t load_country_party(
 			PoliticsManager const& politics_manager, IdentifierRegistry<CountryParty>& country_parties
 		) const;
 
 	public:
-		CountryManager();
-
 		bool add_country(
 			std::string_view identifier, colour_t colour, GraphicalCultureType const* graphical_culture,
 			IdentifierRegistry<CountryParty>&& parties, Country::unit_names_map_t&& unit_names, bool dynamic_tag,
 			Country::government_colour_map_t&& alternative_colours
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(country, countries)
 
 		bool load_countries(GameManager const& game_manager, Dataloader const& dataloader, ast::NodeCPtr root);
 		bool load_country_data_file(

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -14,8 +14,6 @@ BuildingType::BuildingType(
 	colonial_range { colonial_range }, infrastructure { infrastructure }, spawn_railway_track { spawn_railway_track },
 	sail { sail }, steam { steam }, capital { capital }, port { port } {}
 
-BuildingTypeManager::BuildingTypeManager() : building_types { "building types" } {}
-
 bool BuildingTypeManager::add_building_type(std::string_view identifier, ARGS) {
 	if (identifier.empty()) {
 		Logger::error("Invalid building identifier - empty!");

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -73,13 +73,10 @@ namespace OpenVic {
 		using level_t = BuildingType::level_t; // this is getting ridiculous
 
 	private:
-		IdentifierRegistry<BuildingType> building_types;
+		IdentifierRegistry<BuildingType> IDENTIFIER_REGISTRY(building_type);
 
 	public:
-		BuildingTypeManager();
-
 		bool add_building_type(std::string_view identifier, ARGS);
-		IDENTIFIER_REGISTRY_ACCESSORS(building_type)
 
 		bool load_buildings_file(
 			GoodManager const& good_manager, ProductionTypeManager const& production_type_manager,

--- a/src/openvic-simulation/economy/Good.cpp
+++ b/src/openvic-simulation/economy/Good.cpp
@@ -21,8 +21,6 @@ void Good::reset_to_defaults() {
 	price = base_price;
 }
 
-GoodManager::GoodManager() : good_categories { "good categories" }, goods { "goods" } {}
-
 bool GoodManager::add_good_category(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid good category identifier - empty!");

--- a/src/openvic-simulation/economy/Good.hpp
+++ b/src/openvic-simulation/economy/Good.hpp
@@ -63,20 +63,16 @@ namespace OpenVic {
 
 	struct GoodManager {
 	private:
-		IdentifierRegistry<GoodCategory> good_categories;
-		IdentifierRegistry<Good> goods;
+		IdentifierRegistry<GoodCategory> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(good_category, good_categories);
+		IdentifierRegistry<Good> IDENTIFIER_REGISTRY(good);
 
 	public:
-		GoodManager();
-
 		bool add_good_category(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(good_category, good_categories)
 
 		bool add_good(
 			std::string_view identifier, colour_t colour, GoodCategory const& category, Good::price_t base_price,
 			bool available_from_start, bool tradeable, bool money, bool overseas_penalty
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(good)
 
 		void reset_to_defaults();
 		bool load_goods_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/economy/ProductionType.cpp
+++ b/src/openvic-simulation/economy/ProductionType.cpp
@@ -14,7 +14,7 @@ ProductionType::ProductionType(
 	input_goods { std::move(input_goods) }, output_goods { output_goods }, value { value }, bonuses { std::move(bonuses) },
 	efficiency { std::move(efficiency) }, coastal { coastal }, farm { farm }, mine { mine } {}
 
-ProductionTypeManager::ProductionTypeManager() : production_types { "production types" }, rgo_owner_sprite { 0 } {}
+ProductionTypeManager::ProductionTypeManager() : rgo_owner_sprite { 0 } {}
 
 node_callback_t ProductionTypeManager::_expect_employed_pop(
 	GoodManager const& good_manager, PopManager const& pop_manager, callback_t<EmployedPop&&> cb

--- a/src/openvic-simulation/economy/ProductionType.hpp
+++ b/src/openvic-simulation/economy/ProductionType.hpp
@@ -66,7 +66,7 @@ namespace OpenVic {
 
 	struct ProductionTypeManager {
 	private:
-		IdentifierRegistry<ProductionType> production_types;
+		IdentifierRegistry<ProductionType> IDENTIFIER_REGISTRY(production_type);
 		PopType::sprite_t PROPERTY(rgo_owner_sprite);
 
 		NodeTools::node_callback_t _expect_employed_pop(
@@ -81,7 +81,6 @@ namespace OpenVic {
 		ProductionTypeManager();
 
 		bool add_production_type(PRODUCTION_TYPE_ARGS);
-		IDENTIFIER_REGISTRY_ACCESSORS(production_type)
 
 		bool load_production_types_file(GoodManager const& good_manager, PopManager const& pop_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/history/Bookmark.cpp
+++ b/src/openvic-simulation/history/Bookmark.cpp
@@ -16,8 +16,6 @@ Bookmark::Bookmark(
 ) : HasIdentifier { std::to_string(new_index) }, name { new_name }, description { new_description }, date { new_date },
 	initial_camera_x { new_initial_camera_x }, initial_camera_y { new_initial_camera_y } {}
 
-BookmarkManager::BookmarkManager() : bookmarks { "bookmarks" } {}
-
 bool BookmarkManager::add_bookmark(
 	std::string_view name, std::string_view description, Date date, uint32_t initial_camera_x, uint32_t initial_camera_y
 ) {

--- a/src/openvic-simulation/history/Bookmark.hpp
+++ b/src/openvic-simulation/history/Bookmark.hpp
@@ -30,17 +30,13 @@ namespace OpenVic {
 
 	struct BookmarkManager {
 	private:
-		IdentifierRegistry<Bookmark> bookmarks;
+		IdentifierRegistry<Bookmark> IDENTIFIER_REGISTRY(bookmark);
 
 	public:
-		BookmarkManager();
-
 		bool add_bookmark(
 			std::string_view name, std::string_view description, Date date, uint32_t initial_camera_x,
 			uint32_t initial_camera_y
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(bookmark)
-
 		bool load_bookmark_file(ast::NodeCPtr root);
 	};
 }

--- a/src/openvic-simulation/interface/GUI.cpp
+++ b/src/openvic-simulation/interface/GUI.cpp
@@ -42,11 +42,9 @@ bool Element::_fill_elements_key_map(
 	return ret;
 }
 
-Scene::Scene() : elements { "scene elements" } {}
-
 bool Scene::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
 	return Element::_fill_elements_key_map(key_map, [this](std::unique_ptr<Element>&& element) -> bool {
-		return elements.add_item(std::move(element));
+		return scene_elements.add_item(std::move(element));
 	}, ui_manager);
 }
 
@@ -59,11 +57,11 @@ node_callback_t Scene::expect_scene(
 	}, ui_manager);
 }
 
-Window::Window() : elements { "window elements" }, size {}, moveable { false }, fullscreen { false } {}
+Window::Window() : moveable { false }, fullscreen { false } {}
 
 bool Window::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_elements_key_map(key_map, [this](std::unique_ptr<Element>&& element) -> bool {
-		return elements.add_item(std::move(element));
+		return window_elements.add_item(std::move(element));
 	}, ui_manager);
 	ret &= Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,

--- a/src/openvic-simulation/interface/GUI.hpp
+++ b/src/openvic-simulation/interface/GUI.hpp
@@ -40,10 +40,10 @@ namespace OpenVic::GUI {
 	class Scene : public Named<UIManager const&> {
 		friend std::unique_ptr<Scene> std::make_unique<Scene>();
 
-		NamedInstanceRegistry<Element, UIManager const&> elements;
+		NamedInstanceRegistry<Element, UIManager const&> IDENTIFIER_REGISTRY(scene_element);
 
 	protected:
-		Scene();
+		Scene() = default;
 
 		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
 
@@ -57,13 +57,12 @@ namespace OpenVic::GUI {
 			std::string_view scene_name, NodeTools::callback_t<std::unique_ptr<Scene>&&> callback, UIManager const& ui_manager
 		);
 
-		IDENTIFIER_REGISTRY_ACCESSORS(element)
 	};
 
 	class Window final : public Element {
 		friend std::unique_ptr<Window> std::make_unique<Window>();
 
-		NamedInstanceRegistry<Element, UIManager const&> elements;
+		NamedInstanceRegistry<Element, UIManager const&> IDENTIFIER_REGISTRY(window_element);
 
 		fvec2_t PROPERTY(size);
 		bool PROPERTY(moveable);
@@ -80,8 +79,6 @@ namespace OpenVic::GUI {
 		virtual ~Window() = default;
 
 		OV_DETAIL_GET_TYPE
-
-		IDENTIFIER_REGISTRY_ACCESSORS(element)
 	};
 
 	class Icon final : public Element {
@@ -127,7 +124,7 @@ namespace OpenVic::GUI {
 		// TODO - clicksound
 
 	protected:
-		Button() ;
+		Button();
 
 		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
 

--- a/src/openvic-simulation/interface/UI.cpp
+++ b/src/openvic-simulation/interface/UI.cpp
@@ -5,8 +5,6 @@ using namespace OpenVic::NodeTools;
 using namespace OpenVic::GFX;
 using namespace OpenVic::GUI;
 
-UIManager::UIManager() : sprites { "sprites" }, scenes { "scenes" }, fonts { "fonts" } {}
-
 bool UIManager::add_font(std::string_view identifier, colour_t colour, std::string_view fontname) {
 	if (identifier.empty()) {
 		Logger::error("Invalid font identifier - empty!");

--- a/src/openvic-simulation/interface/UI.hpp
+++ b/src/openvic-simulation/interface/UI.hpp
@@ -4,21 +4,14 @@
 
 namespace OpenVic {
 
-	class UIManager {
-
-		NamedInstanceRegistry<GFX::Sprite> sprites;
-		NamedInstanceRegistry<GUI::Scene, UIManager const&> scenes;
-		IdentifierRegistry<GFX::Font> fonts;
+	class UIManager { 
+		NamedInstanceRegistry<GFX::Sprite> IDENTIFIER_REGISTRY(sprite);
+		NamedInstanceRegistry<GUI::Scene, UIManager const&> IDENTIFIER_REGISTRY(scene);
+		IdentifierRegistry<GFX::Font> IDENTIFIER_REGISTRY(font);
 
 		bool _load_font(ast::NodeCPtr node);
 
 	public:
-		UIManager();
-
-		IDENTIFIER_REGISTRY_ACCESSORS(sprite)
-		IDENTIFIER_REGISTRY_ACCESSORS(scene)
-		IDENTIFIER_REGISTRY_ACCESSORS(font)
-
 		bool add_font(std::string_view identifier, colour_t colour, std::string_view fontname);
 
 		bool load_gfx_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/map/Crime.cpp
+++ b/src/openvic-simulation/map/Crime.cpp
@@ -6,8 +6,6 @@ using namespace OpenVic::NodeTools;
 Crime::Crime(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, bool new_default_active)
   : TriggeredModifier { new_identifier, std::move(new_values), new_icon }, default_active { new_default_active } {}
 
-CrimeManager::CrimeManager() : crime_modifiers { "crime modifiers" } {}
-
 bool CrimeManager::add_crime_modifier(
 	std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, bool default_active
 ) {

--- a/src/openvic-simulation/map/Crime.hpp
+++ b/src/openvic-simulation/map/Crime.hpp
@@ -17,15 +17,12 @@ namespace OpenVic {
 
 	struct CrimeManager {
 	private:
-		IdentifierRegistry<Crime> crime_modifiers;
+		IdentifierRegistry<Crime> IDENTIFIER_REGISTRY(crime_modifier);
 
 	public:
-		CrimeManager();
-
 		bool add_crime_modifier(
 			std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, bool default_active
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(crime_modifier)
 
 		bool load_crime_modifiers(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -25,8 +25,6 @@ Mapmode::base_stripe_t Mapmode::get_base_stripe_colours(Map const& map, Province
 	return colour_func ? colour_func(map, province) : NULL_COLOUR;
 }
 
-Map::Map() : provinces { "provinces" }, regions { "regions" }, mapmodes { "mapmodes" } {}
-
 bool Map::add_province(std::string_view identifier, colour_t colour) {
 	if (provinces.size() >= max_provinces) {
 		Logger::error(

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -53,9 +53,9 @@ namespace OpenVic {
 	private:
 		using colour_index_map_t = std::map<colour_t, Province::index_t>;
 
-		IdentifierRegistry<Province> provinces;
-		IdentifierRegistry<Region> regions;
-		IdentifierRegistry<Mapmode> mapmodes;
+		IdentifierRegistry<Province> IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(province, 1);
+		IdentifierRegistry<Region> IDENTIFIER_REGISTRY(region);
+		IdentifierRegistry<Mapmode> IDENTIFIER_REGISTRY(mapmode);
 		ProvinceSet water_provinces;
 		TerrainTypeManager PROPERTY_REF(terrain_type_manager);
 
@@ -73,10 +73,7 @@ namespace OpenVic {
 		StateManager PROPERTY_REF(state_manager);
 
 	public:
-		Map();
-
 		bool add_province(std::string_view identifier, colour_t colour);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_INDEX_OFFSET(province, 1)
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(province, 1);
 
 		bool set_water_province(std::string_view identifier);
@@ -95,11 +92,9 @@ namespace OpenVic {
 		std::vector<shape_pixel_t> const& get_province_shape_image() const;
 
 		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
-		IDENTIFIER_REGISTRY_ACCESSORS(region)
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(region)
 
 		bool add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func);
-		IDENTIFIER_REGISTRY_ACCESSORS(mapmode)
 
 		/* The mapmode colour image contains of a list of base colours and stripe colours. Each colour is four bytes
 		 * in RGBA format, with the alpha value being used to interpolate with the terrain colour, so A = 0 is fully terrain

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -80,7 +80,7 @@ namespace OpenVic {
 		Crime const* PROPERTY_RW(crime);
 		// TODO - change this into a factory-like structure
 		Good const* PROPERTY(rgo);
-		IdentifierRegistry<BuildingInstance> buildings;
+		IdentifierRegistry<BuildingInstance> IDENTIFIER_REGISTRY(building);
 
 		std::vector<Pop> PROPERTY(pops);
 		Pop::pop_size_t PROPERTY(total_population);
@@ -98,7 +98,6 @@ namespace OpenVic {
 
 		bool load_positions(BuildingTypeManager const& building_type_manager, ast::NodeCPtr root);
 
-		IDENTIFIER_REGISTRY_ACCESSORS(building)
 		bool expand_building(std::string_view building_type_identifier);
 
 		bool load_pop_list(PopManager const& pop_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -16,9 +16,6 @@ TerrainTypeMapping::TerrainTypeMapping(
 ) : HasIdentifier { new_identifier }, type { new_type }, terrain_indices { std::move(new_terrain_indicies) },
 	priority { new_priority }, has_texture { new_has_texture } {}
 
-TerrainTypeManager::TerrainTypeManager()
-	: terrain_types { "terrain types" }, terrain_type_mappings { "terrain type mappings" } {}
-
 bool TerrainTypeManager::add_terrain_type(
 	std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water
 ) {

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -41,8 +41,8 @@ namespace OpenVic {
 	struct TerrainTypeManager {
 	private:
 		using terrain_type_mappings_map_t = std::map<TerrainTypeMapping::index_t, size_t>;
-		IdentifierRegistry<TerrainType> terrain_types;
-		IdentifierRegistry<TerrainTypeMapping> terrain_type_mappings;
+		IdentifierRegistry<TerrainType> IDENTIFIER_REGISTRY(terrain_type);
+		IdentifierRegistry<TerrainTypeMapping> IDENTIFIER_REGISTRY(terrain_type_mapping);
 		terrain_type_mappings_map_t terrain_type_mappings_map;
 
 		TerrainTypeMapping::index_t terrain_texture_limit = 0, terrain_texture_count = 0;
@@ -51,16 +51,12 @@ namespace OpenVic {
 		bool _load_terrain_type_mapping(std::string_view key, ast::NodeCPtr value);
 
 	public:
-		TerrainTypeManager();
-
 		bool add_terrain_type(std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water);
-		IDENTIFIER_REGISTRY_ACCESSORS(terrain_type)
 
 		bool add_terrain_type_mapping(
 			std::string_view identifier, TerrainType const* type, std::vector<TerrainTypeMapping::index_t>&& terrain_indicies,
 			TerrainTypeMapping::index_t priority, bool has_texture
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(terrain_type_mapping)
 
 		TerrainTypeMapping const* get_terrain_type_mapping_for(TerrainTypeMapping::index_t idx) const;
 

--- a/src/openvic-simulation/military/Deployment.cpp
+++ b/src/openvic-simulation/military/Deployment.cpp
@@ -28,8 +28,6 @@ Deployment::Deployment(
 ) : HasIdentifier { new_path }, armies { std::move(new_armies) }, navies { std::move(new_navies) },
 	leaders { std::move(new_leaders) } {}
 
-DeploymentManager::DeploymentManager() : deployments { "deployments" } {}
-
 bool DeploymentManager::add_deployment(
 	std::string_view path, std::vector<Army>&& armies, std::vector<Navy>&& navies, std::vector<Leader>&& leaders
 ) {

--- a/src/openvic-simulation/military/Deployment.hpp
+++ b/src/openvic-simulation/military/Deployment.hpp
@@ -90,16 +90,13 @@ namespace OpenVic {
 
 	struct DeploymentManager {
 	private:
-		IdentifierInstanceRegistry<Deployment> deployments;
+		IdentifierInstanceRegistry<Deployment> IDENTIFIER_REGISTRY(deployment);
 		string_set_t missing_oob_files;
 
 	public:
-		DeploymentManager();
-
 		bool add_deployment(
 			std::string_view path, std::vector<Army>&& armies, std::vector<Navy>&& navies, std::vector<Leader>&& leaders
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(deployment)
 
 		bool load_oob_file(
 			GameManager const& game_manager, Dataloader const& dataloader, std::string_view history_path,

--- a/src/openvic-simulation/military/LeaderTrait.cpp
+++ b/src/openvic-simulation/military/LeaderTrait.cpp
@@ -14,8 +14,6 @@ bool LeaderTrait::is_background_trait() const {
 	return trait_type == trait_type_t::BACKGROUND;
 }
 
-LeaderTraitManager::LeaderTraitManager() : leader_traits { "leader trait" } {}
-
 bool LeaderTraitManager::add_leader_trait(
 	std::string_view identifier, LeaderTrait::trait_type_t type, ModifierValue&& modifiers
 ) {

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -43,16 +43,13 @@ namespace OpenVic {
 
 	struct LeaderTraitManager {
 	private:
-		IdentifierRegistry<LeaderTrait> leader_traits;
+		IdentifierRegistry<LeaderTrait> IDENTIFIER_REGISTRY(leader_trait);
 		static inline const string_set_t allowed_modifiers = {
 			"attack", "defence", "morale", "organisation", "reconnaissance", "speed", "attrition", "experience", "reliability"
 		};
 
 	public:
-		LeaderTraitManager();
-
 		bool add_leader_trait(std::string_view identifier, LeaderTrait::trait_type_t type, ModifierValue&& modifiers);
-		IDENTIFIER_REGISTRY_ACCESSORS(leader_trait)
 
 		bool load_leader_traits_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/military/Unit.cpp
+++ b/src/openvic-simulation/military/Unit.cpp
@@ -39,8 +39,6 @@ NavalUnit::NavalUnit(
 	supply_consumption_score { supply_consumption_score }, hull { hull }, gun_power { gun_power }, fire_range { fire_range },
 	evasion { evasion }, torpedo_attack { torpedo_attack } {};
 
-UnitManager::UnitManager() : units { "units" } {}
-
 bool UnitManager::_check_shared_parameters(std::string_view identifier, UNIT_PARAMS) {
 	if (identifier.empty()) {
 		Logger::error("Invalid religion identifier - empty!");

--- a/src/openvic-simulation/military/Unit.hpp
+++ b/src/openvic-simulation/military/Unit.hpp
@@ -111,16 +111,13 @@ namespace OpenVic {
 
 	struct UnitManager {
 	private:
-		IdentifierRegistry<Unit> units;
+		IdentifierRegistry<Unit> IDENTIFIER_REGISTRY(unit);
 
 		bool _check_shared_parameters(std::string_view identifier, UNIT_PARAMS);
 
 	public:
-		UnitManager();
-
 		bool add_land_unit(std::string_view identifier, UNIT_PARAMS, LAND_PARAMS);
 		bool add_naval_unit(std::string_view identifier, UNIT_PARAMS, NAVY_PARAMS);
-		IDENTIFIER_REGISTRY_ACCESSORS(unit)
 
 		static NodeTools::callback_t<std::string_view> expect_type_str(NodeTools::Callback<Unit::type_t> auto callback);
 

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -33,8 +33,6 @@ WargoalType::WargoalType(
 	modifiers { std::move(new_modifiers) },
 	peace_options { new_peace_options } {}
 
-WargoalTypeManager::WargoalTypeManager() : wargoal_types { "wargoal types" } {}
-
 const std::vector<WargoalType const*>& WargoalTypeManager::get_peace_priority_list() const {
 	return peace_priorities;
 }

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -87,12 +87,10 @@ namespace OpenVic {
 
 	struct WargoalTypeManager {
 	private:
-		IdentifierRegistry<WargoalType> wargoal_types;
+		IdentifierRegistry<WargoalType> IDENTIFIER_REGISTRY(wargoal_type);
 		std::vector<WargoalType const*> PROPERTY(peace_priorities);
 
 	public:
-		WargoalTypeManager();
-
 		const std::vector<WargoalType const*>& get_peace_priority_list() const;
 
 		bool add_wargoal_type(
@@ -110,7 +108,6 @@ namespace OpenVic {
 			WargoalType::peace_modifiers_t&& modifiers,
 			peace_options_t peace_options
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(wargoal_type)
 
 		bool load_wargoal_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/misc/Decision.cpp
+++ b/src/openvic-simulation/misc/Decision.cpp
@@ -12,8 +12,6 @@ Decision::Decision(
 	news_desc_long { new_news_desc_long }, news_desc_medium { new_news_desc_medium },
 	news_desc_short { new_news_desc_short }, picture { new_picture } {}
 
-DecisionManager::DecisionManager() : decisions { "decisions" } {}
-
 bool DecisionManager::add_decision(
 	std::string_view identifier, bool alert, bool news, std::string_view news_title,
 	std::string_view news_desc_long, std::string_view news_desc_medium,

--- a/src/openvic-simulation/misc/Decision.hpp
+++ b/src/openvic-simulation/misc/Decision.hpp
@@ -30,17 +30,14 @@ namespace OpenVic {
 
 	struct DecisionManager {
 	private:
-		IdentifierRegistry<Decision> decisions;
+		IdentifierRegistry<Decision> IDENTIFIER_REGISTRY(decision);
 
 	public:
-		DecisionManager();
-
 		bool add_decision(
 			std::string_view identifier, bool alert, bool news, std::string_view news_title,
 			std::string_view news_desc_long, std::string_view news_desc_medium,
 			std::string_view news_desc_short, std::string_view picture
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(decision)
 
 		bool load_decision_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/misc/Define.cpp
+++ b/src/openvic-simulation/misc/Define.cpp
@@ -29,8 +29,6 @@ uint64_t Define::get_value_as_uint() const {
 	return std::strtoull(value.data(), nullptr, 10);
 }
 
-DefineManager::DefineManager() : defines { "defines" } {}
-
 bool DefineManager::add_define(std::string_view name, std::string&& value, Define::Type type) {
 	return defines.add_item({ name, std::move(value), type }, duplicate_warning_callback);
 }

--- a/src/openvic-simulation/misc/Define.hpp
+++ b/src/openvic-simulation/misc/Define.hpp
@@ -30,17 +30,14 @@ namespace OpenVic {
 
 	struct DefineManager {
 	private:
-		IdentifierRegistry<Define> defines;
+		IdentifierRegistry<Define> IDENTIFIER_REGISTRY(define);
 
 		std::optional<Date> start_date;
 		std::optional<Date> end_date;
 
 	public:
-		DefineManager();
-
 		bool add_define(std::string_view name, std::string&& value, Define::Type type);
 		bool add_date_define(std::string_view name, Date date);
-		IDENTIFIER_REGISTRY_ACCESSORS(define)
 
 		Date get_start_date() const;
 		Date get_end_date() const;

--- a/src/openvic-simulation/misc/Event.cpp
+++ b/src/openvic-simulation/misc/Event.cpp
@@ -20,8 +20,6 @@ Event::Event(
 	news_desc_long { new_news_desc_long }, news_desc_medium { new_news_desc_medium }, news_desc_short { new_news_desc_short },
 	election { new_election }, election_issue_group { new_election_issue_group }, options { std::move(new_options) } {}
 
-EventManager::EventManager() : events { "events" } {}
-
 bool EventManager::register_event(
 	std::string_view identifier, std::string_view title, std::string_view description, std::string_view image,
 	Event::event_type_t type, bool triggered_only, bool major, bool fire_only_once, bool allows_multiple_instances, bool news,

--- a/src/openvic-simulation/misc/Event.hpp
+++ b/src/openvic-simulation/misc/Event.hpp
@@ -65,11 +65,9 @@ namespace OpenVic {
 
 	struct EventManager {
 	private:
-		IdentifierRegistry<Event> events;
+		IdentifierRegistry<Event> IDENTIFIER_REGISTRY(event);
 
 	public:
-		EventManager();
-
 		bool register_event(
 			std::string_view identifier, std::string_view title, std::string_view description, std::string_view image,
 			Event::event_type_t type, bool triggered_only, bool major, bool fire_only_once, bool allows_multiple_instances,
@@ -77,7 +75,6 @@ namespace OpenVic {
 			std::string_view news_desc_short, bool election, IssueGroup const* election_issue_group,
 			std::vector<Event::EventOption>&& options
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(event);
 
 		bool load_event_file(IssueManager const& issue_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -84,10 +84,6 @@ TriggeredModifier::TriggeredModifier(std::string_view new_identifier, ModifierVa
 ModifierInstance::ModifierInstance(Modifier const& modifier, Date expiry_date)
 	: modifier { modifier }, expiry_date { expiry_date } {}
 
-ModifierManager::ModifierManager()
-  : modifier_effects { "modifier effects" }, event_modifiers { "event modifiers" }, static_modifiers { "static modifiers" },
-	triggered_modifiers { "triggered modifiers" } {}
-
 bool ModifierManager::add_modifier_effect(std::string_view identifier, bool positive_good, ModifierEffect::format_t format) {
 	if (identifier.empty()) {
 		Logger::error("Invalid modifier effect identifier - empty!");

--- a/src/openvic-simulation/misc/Modifier.hpp
+++ b/src/openvic-simulation/misc/Modifier.hpp
@@ -110,12 +110,12 @@ namespace OpenVic {
 		 * so instead we use an IdentifierInstanceRegistry (using std::unique_ptr's under the hood).
 		 */
 	private:
-		IdentifierInstanceRegistry<ModifierEffect> modifier_effects;
+		IdentifierInstanceRegistry<ModifierEffect> IDENTIFIER_REGISTRY(modifier_effect);
 		string_set_t complex_modifiers;
 
-		IdentifierRegistry<Modifier> event_modifiers;
-		IdentifierRegistry<Modifier> static_modifiers;
-		IdentifierRegistry<TriggeredModifier> triggered_modifiers;
+		IdentifierRegistry<Modifier> IDENTIFIER_REGISTRY(event_modifier);
+		IdentifierRegistry<Modifier> IDENTIFIER_REGISTRY(static_modifier);
+		IdentifierRegistry<TriggeredModifier> IDENTIFIER_REGISTRY(triggered_modifier);
 
 		/* effect_validator takes in ModifierEffect const& */
 		NodeTools::key_value_callback_t _modifier_effect_callback(
@@ -124,28 +124,22 @@ namespace OpenVic {
 		) const;
 
 	public:
-		ModifierManager();
-
 		bool add_modifier_effect(
 			std::string_view identifier, bool positive_good,
 			ModifierEffect::format_t format = ModifierEffect::format_t::PROPORTION_DECIMAL
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(modifier_effect)
 
 		void register_complex_modifier(std::string_view identifier);
 
 		bool setup_modifier_effects();
 
 		bool add_event_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
-		IDENTIFIER_REGISTRY_ACCESSORS(event_modifier)
 		bool load_event_modifiers(ast::NodeCPtr root);
 
 		bool add_static_modifier(std::string_view identifier, ModifierValue&& values);
-		IDENTIFIER_REGISTRY_ACCESSORS(static_modifier)
 		bool load_static_modifiers(ast::NodeCPtr root);
 
 		bool add_triggered_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
-		IDENTIFIER_REGISTRY_ACCESSORS(triggered_modifier)
 		bool load_triggered_modifiers(ast::NodeCPtr root);
 
 		NodeTools::node_callback_t expect_validated_modifier_value_and_default(

--- a/src/openvic-simulation/politics/Government.cpp
+++ b/src/openvic-simulation/politics/Government.cpp
@@ -1,7 +1,5 @@
 #include "Government.hpp"
 
-#include "openvic-simulation/GameManager.hpp"
-
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
@@ -15,8 +13,6 @@ GovernmentType::GovernmentType(
 bool GovernmentType::is_ideology_compatible(Ideology const* ideology) const {
 	return std::find(ideologies.begin(), ideologies.end(), ideology) != ideologies.end();
 }
-
-GovernmentTypeManager::GovernmentTypeManager() : government_types { "government types" } {}
 
 bool GovernmentTypeManager::add_government_type(
 	std::string_view identifier, std::vector<Ideology const*>&& ideologies, bool elections, bool appoint_ruling_party,

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -28,17 +28,14 @@ namespace OpenVic {
 
 	struct GovernmentTypeManager {
 	private:
-		IdentifierRegistry<GovernmentType> government_types;
+		IdentifierRegistry<GovernmentType> IDENTIFIER_REGISTRY(government_type);
 		std::vector<std::string> PROPERTY(flag_types);
 
 	public:
-		GovernmentTypeManager();
-
 		bool add_government_type(
 			std::string_view identifier, std::vector<Ideology const*>&& ideologies, bool elections, bool appoint_ruling_party,
 			Timespan term_duration, std::string_view flag_type
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(government_type)
 
 		bool load_government_types_file(IdeologyManager const& ideology_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/politics/Ideology.cpp
+++ b/src/openvic-simulation/politics/Ideology.cpp
@@ -11,8 +11,6 @@ Ideology::Ideology(
 ) : HasIdentifierAndColour { new_identifier, new_colour, false, false }, group { new_group }, uncivilised { new_uncivilised },
 	can_reduce_militancy { new_can_reduce_militancy }, spawn_date { new_spawn_date } {}
 
-IdeologyManager::IdeologyManager() : ideology_groups { "ideology groups" }, ideologies { "ideologies" } {}
-
 bool IdeologyManager::add_ideology_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid ideology group identifier - empty!");

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -37,20 +37,16 @@ namespace OpenVic {
 
 	struct IdeologyManager {
 	private:
-		IdentifierRegistry<IdeologyGroup> ideology_groups;
-		IdentifierRegistry<Ideology> ideologies;
+		IdentifierRegistry<IdeologyGroup> IDENTIFIER_REGISTRY(ideology_group);
+		IdentifierRegistry<Ideology> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(ideology, ideologies);
 
 	public:
-		IdeologyManager();
-
 		bool add_ideology_group(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(ideology_group)
 
 		bool add_ideology(
 			std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised,
 			bool can_reduce_militancy, Date spawn_date
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(ideology, ideologies)
 
 		bool load_ideology_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -16,10 +16,6 @@ ReformGroup::ReformGroup(std::string_view identifier, ReformType const& type, bo
 Reform::Reform(std::string_view identifier, ReformGroup const& group, size_t ordinal)
 	: Issue { identifier, group }, ordinal { ordinal }, reform_group { group } {}
 
-IssueManager::IssueManager()
-  : issue_groups { "issue groups" }, issues { "issues" }, reform_types { "reform types" }, reform_groups { "reform groups" },
-	reforms { "reforms" } {}
-
 bool IssueManager::add_issue_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid issue group identifier - empty!");

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -84,11 +84,11 @@ namespace OpenVic {
 	// Issue manager - holds the registries
 	struct IssueManager {
 	private:
-		IdentifierRegistry<IssueGroup> issue_groups;
-		IdentifierRegistry<Issue> issues;
-		IdentifierRegistry<ReformType> reform_types;
-		IdentifierRegistry<ReformGroup> reform_groups;
-		IdentifierRegistry<Reform> reforms;
+		IdentifierRegistry<IssueGroup> IDENTIFIER_REGISTRY(issue_group);
+		IdentifierRegistry<Issue> IDENTIFIER_REGISTRY(issue);
+		IdentifierRegistry<ReformType> IDENTIFIER_REGISTRY(reform_type);
+		IdentifierRegistry<ReformGroup> IDENTIFIER_REGISTRY(reform_group);
+		IdentifierRegistry<Reform> IDENTIFIER_REGISTRY(reform);
 
 		bool _load_issue_group(size_t& expected_issues, std::string_view identifier, ast::NodeCPtr node);
 		bool _load_issue(std::string_view identifier, IssueGroup const* group, ast::NodeCPtr node);
@@ -98,22 +98,15 @@ namespace OpenVic {
 		bool _load_reform(size_t& ordinal, std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node);
 
 	public:
-		IssueManager();
-
 		bool add_issue_group(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(issue_group)
 
 		bool add_issue(std::string_view identifier, IssueGroup const* group);
-		IDENTIFIER_REGISTRY_ACCESSORS(issue)
 
 		bool add_reform_type(std::string_view identifier, bool uncivilised);
-		IDENTIFIER_REGISTRY_ACCESSORS(reform_type)
 
 		bool add_reform_group(std::string_view identifier, ReformType const* type, bool ordered, bool administrative);
-		IDENTIFIER_REGISTRY_ACCESSORS(reform_group)
 
 		bool add_reform(std::string_view identifier, ReformGroup const* group, size_t ordinal);
-		IDENTIFIER_REGISTRY_ACCESSORS(reform)
 
 		bool load_issues_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -23,8 +23,6 @@ NationalFocus::NationalFocus(
 	encouraged_loyalty { std::move(new_encouraged_loyalty) },
 	encouraged_production { std::move(new_encouraged_production) } {}
 
-NationalFocusManager::NationalFocusManager() : national_focus_groups { "national focus groups" }, national_foci { "national foci" } {}
-
 inline bool NationalFocusManager::add_national_focus_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("No identifier for national focus group!");

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -51,14 +51,11 @@ namespace OpenVic {
 
 	struct NationalFocusManager {
 	private:
-		IdentifierRegistry<NationalFocusGroup> national_focus_groups;
-		IdentifierRegistry<NationalFocus> national_foci;
+		IdentifierRegistry<NationalFocusGroup> IDENTIFIER_REGISTRY(national_focus_group);
+		IdentifierRegistry<NationalFocus> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(national_focus, national_foci);
 
 	public:
-		NationalFocusManager();
-
 		inline bool add_national_focus_group(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(national_focus_group)
 
 		inline bool add_national_focus(
 			std::string_view identifier,
@@ -69,7 +66,6 @@ namespace OpenVic {
 			NationalFocus::party_loyalty_map_t&& encouraged_loyalty,
 			NationalFocus::production_map_t&& encouraged_production
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(national_focus, national_foci)
 
 		bool load_national_foci_file(PopManager const& pop_manager, IdeologyManager const& ideology_manager, GoodManager const& good_manager, ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/politics/NationalValue.cpp
+++ b/src/openvic-simulation/politics/NationalValue.cpp
@@ -6,8 +6,6 @@ using namespace OpenVic::NodeTools;
 NationalValue::NationalValue(std::string_view new_identifier, ModifierValue&& new_modifiers)
 	: HasIdentifier { new_identifier }, modifiers { std::move(new_modifiers) } {}
 
-NationalValueManager::NationalValueManager() : national_values { "national values" } {}
-
 bool NationalValueManager::add_national_value(std::string_view identifier, ModifierValue&& modifiers) {
 	if (identifier.empty()) {
 		Logger::error("Invalid national value identifier - empty!");

--- a/src/openvic-simulation/politics/NationalValue.hpp
+++ b/src/openvic-simulation/politics/NationalValue.hpp
@@ -20,13 +20,10 @@ namespace OpenVic {
 
 	struct NationalValueManager {
 	private:
-		IdentifierRegistry<NationalValue> national_values;
+		IdentifierRegistry<NationalValue> IDENTIFIER_REGISTRY(national_value);
 
 	public:
-		NationalValueManager();
-
 		bool add_national_value(std::string_view identifier, ModifierValue&& modifiers);
-		IDENTIFIER_REGISTRY_ACCESSORS(national_value)
 
 		bool load_national_values_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -16,8 +16,6 @@ RebelType::RebelType(
 	allow_all_ideologies { allow_all_ideologies }, resilient { resilient }, reinforcing { reinforcing }, general { general },
 	smart { smart }, unit_transfer { unit_transfer }, occupation_mult { occupation_mult } {}
 
-RebelManager::RebelManager() : rebel_types { "rebel types" } {}
-
 bool RebelManager::add_rebel_type(
 	std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
 	RebelType::government_map_t&& desired_governments, RebelType::defection_t defection,

--- a/src/openvic-simulation/politics/Rebel.hpp
+++ b/src/openvic-simulation/politics/Rebel.hpp
@@ -65,12 +65,9 @@ namespace OpenVic {
 
 	struct RebelManager {
 	private:
-		IdentifierRegistry<RebelType> rebel_types;
+		IdentifierRegistry<RebelType> IDENTIFIER_REGISTRY(rebel_type);
 
 	public:
-		RebelManager();
-
-		IDENTIFIER_REGISTRY_ACCESSORS(rebel_type)
 		bool add_rebel_type(
 			std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
 			RebelType::government_map_t&& desired_governments, RebelType::defection_t defection,

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -19,9 +19,6 @@ Culture::Culture(
 ) : HasIdentifierAndColour { new_identifier, new_colour, false, false }, group { new_group },
 	first_names { std::move(new_first_names) }, last_names { std::move(new_last_names) } {}
 
-CultureManager::CultureManager()
-	: graphical_culture_types { "graphical culture types" }, culture_groups { "culture groups" }, cultures { "cultures" } {}
-
 bool CultureManager::add_graphical_culture_type(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid culture group identifier - empty!");

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -56,9 +56,9 @@ namespace OpenVic {
 
 	struct CultureManager {
 	private:
-		IdentifierRegistry<GraphicalCultureType> graphical_culture_types;
-		IdentifierRegistry<CultureGroup> culture_groups;
-		IdentifierRegistry<Culture> cultures;
+		IdentifierRegistry<GraphicalCultureType> IDENTIFIER_REGISTRY(graphical_culture_type);
+		IdentifierRegistry<CultureGroup> IDENTIFIER_REGISTRY(culture_group);
+		IdentifierRegistry<Culture> IDENTIFIER_REGISTRY(culture);
 
 		bool _load_culture_group(
 			size_t& total_expected_cultures, GraphicalCultureType const* default_unit_graphical_culture_type,
@@ -67,22 +67,17 @@ namespace OpenVic {
 		bool _load_culture(CultureGroup const& culture_group, std::string_view culture_key, ast::NodeCPtr node);
 
 	public:
-		CultureManager();
-
 		bool add_graphical_culture_type(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(graphical_culture_type)
 
 		bool add_culture_group(
 			std::string_view identifier, std::string_view leader, GraphicalCultureType const* graphical_culture_type,
 			bool is_overseas
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(culture_group)
 
 		bool add_culture(
 			std::string_view identifier, colour_t colour, CultureGroup const& group, std::vector<std::string>&& first_names,
 			std::vector<std::string>&& last_names
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(culture)
 
 		bool load_graphical_culture_type_file(ast::NodeCPtr root);
 		bool load_culture_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -40,7 +40,7 @@ PopType::PopType(
 	assert(merge_max_size >= 0);
 }
 
-PopManager::PopManager() : pop_types { "pop types" }, slave_sprite { 0 }, administrative_sprite { 0 } {}
+PopManager::PopManager() : slave_sprite { 0 }, administrative_sprite { 0 } {}
 
 bool PopManager::add_pop_type(
 	std::string_view identifier, colour_t colour, PopType::strata_t strata, PopType::sprite_t sprite,

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -89,7 +89,7 @@ namespace OpenVic {
 
 	struct PopManager {
 	private:
-		IdentifierRegistry<PopType> pop_types;
+		IdentifierRegistry<PopType> IDENTIFIER_REGISTRY(pop_type);
 		PopType::sprite_t PROPERTY(slave_sprite);
 		PopType::sprite_t PROPERTY(administrative_sprite);
 
@@ -107,7 +107,6 @@ namespace OpenVic {
 			bool can_be_recruited, bool can_reduce_consciousness, bool administrative_efficiency, bool can_build, bool factory,
 			bool can_work_factory, bool unemployment
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(pop_type)
 
 		bool load_pop_type_file(
 			std::string_view filestem, UnitManager const& unit_manager, GoodManager const& good_manager, ast::NodeCPtr root

--- a/src/openvic-simulation/pop/Religion.cpp
+++ b/src/openvic-simulation/pop/Religion.cpp
@@ -14,8 +14,6 @@ Religion::Religion(
 	assert(icon > 0);
 }
 
-ReligionManager::ReligionManager() : religion_groups { "religion groups" }, religions { "religions" } {}
-
 bool ReligionManager::add_religion_group(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid religion group identifier - empty!");

--- a/src/openvic-simulation/pop/Religion.hpp
+++ b/src/openvic-simulation/pop/Religion.hpp
@@ -38,19 +38,15 @@ namespace OpenVic {
 
 	struct ReligionManager {
 	private:
-		IdentifierRegistry<ReligionGroup> religion_groups;
-		IdentifierRegistry<Religion> religions;
+		IdentifierRegistry<ReligionGroup> IDENTIFIER_REGISTRY(religion_group);
+		IdentifierRegistry<Religion> IDENTIFIER_REGISTRY(religion);
 
 	public:
-		ReligionManager();
-
 		bool add_religion_group(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(religion_group)
 
 		bool add_religion(
 			std::string_view identifier, colour_t colour, ReligionGroup const& group, Religion::icon_t icon, bool pagan
 		);
-		IDENTIFIER_REGISTRY_ACCESSORS(religion)
 
 		bool load_religion_file(ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/research/Invention.cpp
+++ b/src/openvic-simulation/research/Invention.cpp
@@ -16,8 +16,6 @@ Invention::Invention(
 	enabled_crimes { std::move(new_enabled_crimes) }, unlock_gas_attack { new_unlock_gas_attack },
 	unlock_gas_defence { new_unlock_gas_defence } {} //TODO icon
 
-InventionManager::InventionManager() : inventions { "inventions" } {}
-
 bool InventionManager::add_invention(
 	std::string_view identifier, ModifierValue&& values, bool news, Invention::unit_set_t&& activated_units,
 	Invention::building_set_t&& activated_buildings, Invention::crime_set_t&& enabled_crimes,

--- a/src/openvic-simulation/research/Invention.hpp
+++ b/src/openvic-simulation/research/Invention.hpp
@@ -38,18 +38,14 @@ namespace OpenVic {
 	};
 
 	struct InventionManager {
-		IdentifierRegistry<Invention> inventions;
+		IdentifierRegistry<Invention> IDENTIFIER_REGISTRY(invention);
 
 	public:
-		InventionManager();
-
 		bool add_invention(
 			std::string_view identifier, ModifierValue&& values, bool news, Invention::unit_set_t&& activated_units,
 			Invention::building_set_t&& activated_buildings, Invention::crime_set_t&& enabled_crimes, bool unlock_gas_attack,
 			bool unlock_gas_defence
 		);
-
-		IDENTIFIER_REGISTRY_ACCESSORS(invention)
 
 		bool load_inventions_file(
 			ModifierManager const& modifier_manager, UnitManager const& unit_manager,

--- a/src/openvic-simulation/research/Technology.cpp
+++ b/src/openvic-simulation/research/Technology.cpp
@@ -19,10 +19,6 @@ Technology::Technology(
 TechnologySchool::TechnologySchool(std::string_view new_identifier, ModifierValue&& new_values)
 	: Modifier { new_identifier, std::move(new_values), 0 } {}
 
-TechnologyManager::TechnologyManager()
-  : technology_folders { "technology folders" }, technology_areas { "technology areas" }, technologies { "technologies" },
-	technology_schools { "technology schools" } {}
-
 bool TechnologyManager::add_technology_folder(std::string_view identifier) {
 	if (identifier.empty()) {
 		Logger::error("Invalid technology folder identifier - empty!");

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -64,28 +64,22 @@ namespace OpenVic {
 	};
 
 	struct TechnologyManager {
-		IdentifierRegistry<TechnologyFolder> technology_folders;
-		IdentifierRegistry<TechnologyArea> technology_areas;
-		IdentifierRegistry<Technology> technologies;
-		IdentifierRegistry<TechnologySchool> technology_schools;
+		IdentifierRegistry<TechnologyFolder> IDENTIFIER_REGISTRY(technology_folder);
+		IdentifierRegistry<TechnologyArea> IDENTIFIER_REGISTRY(technology_area);
+		IdentifierRegistry<Technology> IDENTIFIER_REGISTRY_CUSTOM_PLURAL(technology, technologies);
+		IdentifierRegistry<TechnologySchool> IDENTIFIER_REGISTRY(technology_school);
 
 	public:
-		TechnologyManager();
-
 		bool add_technology_folder(std::string_view identifier);
-		IDENTIFIER_REGISTRY_ACCESSORS(technology_folder)
 
 		bool add_technology_area(std::string_view identifier, TechnologyFolder const* folder);
-		IDENTIFIER_REGISTRY_ACCESSORS(technology_area)
 
 		bool add_technology(
 			std::string_view identifier, TechnologyArea const* area, Date::year_t year, fixed_point_t cost,
 			bool unciv_military, uint8_t unit, Technology::unit_set_t&& activated_units,
 			Technology::building_set_t&& activated_buildings, ModifierValue&& values);
-		IDENTIFIER_REGISTRY_ACCESSORS_CUSTOM_PLURAL(technology, technologies)
 
 		bool add_technology_school(std::string_view identifier, ModifierValue&& values);
-		IDENTIFIER_REGISTRY_ACCESSORS(technology_school)
 
 		bool load_technology_file_areas(ast::NodeCPtr root); // common/technology.txt
 		bool load_technology_file_schools(ModifierManager const& modifier_manager, ast::NodeCPtr root); // also common/technology.txt


### PR DESCRIPTION
The macro now also declares the registry and its initial value, sparing us a lot of constructors.

I also took the liberty of slightly tweaking the existing stuff to reuse more code.

Left it as a draft because it shouldn't be merged with pending stuff, to spare us some rebases.