### PR TITLE
Additional adjacency loading

### DIFF
--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -203,6 +203,43 @@ bool GameManager::load_hardcoded_defines() {
 		},
 		{
 			"mapmode_religion", shaded_mapmode(&Province::get_religion_distribution)
+		},
+		{
+			"mapmode_adjacencies", [](Map const& map, Province const& province) -> Mapmode::base_stripe_t {
+				Province const* selected_province = map.get_selected_province();
+				if (selected_province != nullptr) {
+					if (selected_province == &province) {
+						return make_solid_base_stripe(ALPHA_VALUE | 0xFFFFFF);
+					}
+					colour_t base = NULL_COLOUR, stripe = NULL_COLOUR;
+					Province::adjacency_t const* adj = selected_province->get_adjacency_to(&province);
+					if (adj != nullptr) {
+						using enum Province::adjacency_t::type_t;
+						switch (adj->get_type()) {
+						case LAND: base = 0x00FF00; break;
+						case WATER: base = 0x0000FF; break;
+						case COASTAL: base = 0xF9D199; break;
+						case IMPASSABLE: base = 0x8B4513; break;
+						case STRAIT: base = 0x00FFFF; break;
+						case CANAL: base = 0x888888; break;
+						default: base = 0xFF0000; break;
+						}
+						base |= ALPHA_VALUE;
+						stripe = base;
+					}
+					if (selected_province->has_adjacency_going_through(&province)) {
+						stripe = ALPHA_VALUE | 0xFFFF00;
+					}
+
+					return combine_base_stripe(base, stripe);
+				}
+				return NULL_COLOUR;
+			}
+		},
+		{
+			"mapmode_port", make_solid_base_stripe_func([](Map const& map, Province const& province) -> colour_t {
+				return province.has_port() ? ALPHA_VALUE | 0xFFFFFF : NULL_COLOUR;
+			})
 		}
 	};
 

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -585,15 +585,18 @@ bool Dataloader::_load_map_dir(GameManager& game_manager) const {
 	static constexpr std::string_view default_provinces = "provinces.bmp";
 	static constexpr std::string_view default_positions = "positions.txt";
 	static constexpr std::string_view default_terrain = "terrain.bmp";
-	static constexpr std::string_view default_rivers = "rivers.bmp";
+	static constexpr std::string_view default_rivers = "rivers.bmp"; // TODO
 	static constexpr std::string_view default_terrain_definition = "terrain.txt";
-	static constexpr std::string_view default_tree_definition = "trees.txt";
-	static constexpr std::string_view default_continent = "continent.txt";
+	static constexpr std::string_view default_tree_definition = "trees.txt"; // TODO
+	static constexpr std::string_view default_continent = "continent.txt"; // TODO
 	static constexpr std::string_view default_adjacencies = "adjacencies.csv";
 	static constexpr std::string_view default_region = "region.txt";
-	static constexpr std::string_view default_region_sea = "region_sea.txt";
-	static constexpr std::string_view default_province_flag_sprite = "province_flag_sprites";
+	static constexpr std::string_view default_region_sea = "region_sea.txt"; // TODO
+	static constexpr std::string_view default_province_flag_sprite = "province_flag_sprites"; // TODO
 
+	static constexpr std::string_view climate_filename = "climate.txt"; // TODO
+
+	/* Parser stored so the filename string_views persist until the end of this function. */
 	const v2script::Parser parser = parse_defines(lookup_file(append_string_views(map_directory, defaults_filename)));
 
 	std::vector<std::string_view> water_province_identifiers;
@@ -645,14 +648,6 @@ bool Dataloader::_load_map_dir(GameManager& game_manager) const {
 		ret = false;
 	}
 
-	if (!map.load_province_positions(
-		game_manager.get_economy_manager().get_building_type_manager(),
-		parse_defines(lookup_file(append_string_views(map_directory, positions))).get_file_node()
-	)) {
-		Logger::error("Failed to load province positions file!");
-		ret = false;
-	}
-
 	if (!map.load_region_file(parse_defines(lookup_file(append_string_views(map_directory, region))).get_file_node())) {
 		Logger::error("Failed to load region file!");
 		ret = false;
@@ -679,10 +674,21 @@ bool Dataloader::_load_map_dir(GameManager& game_manager) const {
 		ret = false;
 	}
 
-	if (!map.generate_and_load_province_adjacencies(
+	if (map.generate_and_load_province_adjacencies(
 		parse_csv(lookup_file(append_string_views(map_directory, adjacencies))).get_lines()
 	)) {
+		Logger::info("Successfully generated and loaded province adjacencies!");
+	} else {
 		Logger::error("Failed to generate and load province adjacencies!");
+		ret = false;
+	}
+
+	/* Must be loaded after adjacencies so we know what provinces are coastal, and so can have a port */
+	if (!map.load_province_positions(
+		game_manager.get_economy_manager().get_building_type_manager(),
+		parse_defines(lookup_file(append_string_views(map_directory, positions))).get_file_node()
+	)) {
+		Logger::error("Failed to load province positions file!");
 		ret = false;
 	}
 

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -61,7 +61,7 @@ namespace OpenVic {
 		bool PROPERTY(sail); // only in clipper shipyard
 		bool PROPERTY(steam); // only in steamer shipyard
 		bool PROPERTY(capital); // only in naval base
-		bool PROPERTY(port); // only in naval base
+		bool PROPERTY_CUSTOM_PREFIX(port, is); // only in naval base
 
 		BuildingType(std::string_view identifier, ARGS);
 
@@ -74,8 +74,11 @@ namespace OpenVic {
 
 	private:
 		IdentifierRegistry<BuildingType> IDENTIFIER_REGISTRY(building_type);
+		BuildingType const* PROPERTY(port_building_type);
 
 	public:
+		BuildingTypeManager();
+
 		bool add_building_type(std::string_view identifier, ARGS);
 
 		bool load_buildings_file(

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -101,7 +101,7 @@ void ProvinceHistoryManager::lock_province_histories(Map const& map, bool detail
 	for (size_t idx = 0; idx < province_checklist.size(); ++idx) {
 		if (!province_checklist[idx]) {
 			Province const& province = *map.get_province_by_index(idx + 1);
-			if (!province.get_water()) {
+			if (!province.is_water()) {
 				if (detailed_errors) {
 					Logger::warning("Province history missing for province: ", province.get_identifier());
 				}

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -59,20 +59,24 @@ namespace OpenVic {
 		ProvinceSet water_provinces;
 		TerrainTypeManager PROPERTY_REF(terrain_type_manager);
 
-		size_t width = 0, height = 0;
-		std::vector<shape_pixel_t> province_shape_image;
+		int32_t PROPERTY(width);
+		int32_t PROPERTY(height);
+		std::vector<shape_pixel_t> PROPERTY(province_shape_image);
 		colour_index_map_t colour_index_map;
 
-		Province::index_t max_provinces = Province::MAX_INDEX;
-		Province::index_t selected_province = Province::NULL_INDEX;
-		Pop::pop_size_t highest_province_population, total_map_population;
+		Province::index_t PROPERTY(max_provinces);
+		Province::index_t PROPERTY(selected_province_index);
+		Pop::pop_size_t PROPERTY(highest_province_population)
+		Pop::pop_size_t PROPERTY(total_map_population);
 
 		Province::index_t get_index_from_colour(colour_t colour) const;
-		bool _generate_province_adjacencies();
+		bool _generate_standard_province_adjacencies();
 
 		StateManager PROPERTY_REF(state_manager);
 
 	public:
+		Map();
+
 		bool add_province(std::string_view identifier, colour_t colour);
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(province, 1);
 
@@ -82,14 +86,8 @@ namespace OpenVic {
 
 		Province::index_t get_province_index_at(size_t x, size_t y) const;
 		bool set_max_provinces(Province::index_t new_max_provinces);
-		Province::index_t get_max_provinces() const;
 		void set_selected_province(Province::index_t index);
-		Province::index_t get_selected_province_index() const;
 		Province const* get_selected_province() const;
-
-		size_t get_width() const;
-		size_t get_height() const;
-		std::vector<shape_pixel_t> const& get_province_shape_image() const;
 
 		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(region)
@@ -107,14 +105,13 @@ namespace OpenVic {
 		bool apply_history_to_provinces(ProvinceHistoryManager const& history_manager, Date date);
 
 		void update_highest_province_population();
-		Pop::pop_size_t get_highest_province_population() const;
 		void update_total_map_population();
-		Pop::pop_size_t get_total_map_population() const;
 
 		void update_state(Date today);
 		void tick(Date today);
 
 		bool load_province_definitions(std::vector<ovdl::csv::LineObject> const& lines);
+		/* Must be loaded after adjacencies so we know what provinces are coastal, and so can have a port */
 		bool load_province_positions(BuildingTypeManager const& building_type_manager, ast::NodeCPtr root);
 		bool load_region_file(ast::NodeCPtr root);
 		bool load_map_images(fs::path const& province_path, fs::path const& terrain_path, bool detailed_errors);

--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -14,6 +14,16 @@ namespace OpenVic {
 		constexpr vec2_t(T new_val) : x { new_val }, y { new_val } {}
 		constexpr vec2_t(T new_x, T new_y) : x { new_x }, y { new_y } {}
 
+		constexpr vec2_t(vec2_t const&) = default;
+		constexpr vec2_t(vec2_t&&) = default;
+		constexpr vec2_t& operator=(vec2_t const&) = default;
+		constexpr vec2_t& operator=(vec2_t&&) = default;
+
+		template<typename S>
+		constexpr explicit operator vec2_t<S>() {
+			return { static_cast<S>(x), static_cast<S>(y) };
+		}
+
 		constexpr vec2_t abs() const {
 			return { x >= 0 ? x : -x, y >= 0 ? y : -y };
 		}


### PR DESCRIPTION
- Basic adjacency generation refactor + additional adjacency loading
- Land-land, water-water and land-water adjacencies are differentiated, and land provinces in a coastal adjacency have their coastal flag set.
- The first BuildingType with the port flag set is recorded, and errors are printed for any further ones with the port flag set.
- Coastal provinces with a building position for the recorded port BuildingType have their port flag set.
- Added mapmodes for displaying adjacencies of the currently selected province and for displaying provinces with their port flag set.