### PR TITLE
Province building scaffolding

### DIFF
--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -68,14 +68,18 @@ bool GameManager::load_bookmark(Bookmark const* new_bookmark) {
 	return ret;
 }
 
-bool GameManager::expand_building(Province::index_t province_index, std::string_view building_type_identifier) {
+bool GameManager::expand_selected_province_building(size_t building_index) {
 	set_needs_update();
-	Province* province = map.get_province_by_index(province_index);
+	Province* province = map.get_selected_province();
 	if (province == nullptr) {
-		Logger::error("Invalid province index ", province_index, " while trying to expand building ", building_type_identifier);
+		Logger::error("Cannot expand building index ", building_index, " - no province selected!");
 		return false;
 	}
-	return province->expand_building(building_type_identifier);
+	if (building_index < 0) {
+		Logger::error("Invalid building index ", building_index, " while trying to expand in province ", province);
+		return false;
+	}
+	return province->expand_building(building_index);
 }
 
 static constexpr colour_argb_t::value_type ALPHA_VALUE = colour_argb_t::colour_traits::alpha_from_float(0.7f);

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -54,7 +54,7 @@ namespace OpenVic {
 		bool reset();
 		bool load_bookmark(Bookmark const* new_bookmark);
 
-		bool expand_building(Province::index_t province_index, std::string_view building_type_identifier);
+		bool expand_selected_province_building(size_t building_index);
 
 		/* Hardcoded data for defining things for which parsing from files has
 		 * not been implemented, currently mapmodes and building types.

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -321,6 +321,16 @@ bool Dataloader::_load_pop_types(GameManager& game_manager) const {
 	);
 	pop_manager.lock_stratas();
 	pop_manager.lock_pop_types();
+
+	if (pop_manager.get_slave_sprite() <= 0) {
+		Logger::error("No slave pop type sprite found!");
+		ret = false;
+	}
+	if (pop_manager.get_administrative_sprite() <= 0) {
+		Logger::error("No administrative pop type sprite found!");
+		ret = false;
+	}
+
 	ret &= pop_manager.generate_modifiers(game_manager.get_modifier_manager());
 	return ret;
 }

--- a/src/openvic-simulation/economy/BuildingInstance.cpp
+++ b/src/openvic-simulation/economy/BuildingInstance.cpp
@@ -4,7 +4,7 @@ using namespace OpenVic;
 
 BuildingInstance::BuildingInstance(BuildingType const& new_building_type, level_t new_level)
 	: HasIdentifier { new_building_type.get_identifier() }, building_type { new_building_type }, level { new_level },
-	expansion_state { ExpansionState::CannotExpand } {}
+	expansion_state { ExpansionState::CannotExpand }, start_date {}, end_date {}, expansion_progress { 0.0f } {}
 
 bool BuildingInstance::_can_expand() const {
 	return level < building_type.get_max_level();
@@ -29,7 +29,8 @@ void BuildingInstance::update_state(Date today) {
 		end_date = start_date + building_type.get_build_time();
 		break;
 	case ExpansionState::Expanding:
-		expansion_progress = static_cast<double>(today - start_date) / static_cast<double>(end_date - start_date);
+		expansion_progress =
+			static_cast<float>((today - start_date).to_int()) / static_cast<float>((end_date - start_date).to_int());
 		break;
 	default: expansion_state = _can_expand() ? ExpansionState::CanExpand : ExpansionState::CannotExpand;
 	}

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -104,17 +104,40 @@ bool BuildingTypeManager::load_buildings_file(
 			min_modifier_prefix.append(building_type.get_identifier()), false, ModifierEffect::format_t::INT
 		);
 
+		if (building_type.is_in_province()) {
+			province_building_types.emplace_back(&building_type);
+		}
+
 		if (building_type.is_port()) {
-			if (port_building_type == nullptr) {
-				port_building_type = &building_type;
+			if (building_type.is_in_province()) {
+				if (port_building_type == nullptr) {
+					port_building_type = &building_type;
+				} else {
+					Logger::error(
+						"Building type ", building_type, " is marked as a port, but we are already using ", port_building_type,
+						" as the port building type!"
+					);
+					ret = false;
+				}
 			} else {
-				Logger::error(
-					"Building type ", building_type, " is marked as a port, but we are already using ", port_building_type,
-					" as the port building type!"
-				);
+				Logger::error("Building type ", building_type, " is marked as a port, but is not a province building!");
 				ret = false;
 			}
 		}
+	}
+
+	if (port_building_type == nullptr) {
+		Logger::error("No port building type found!");
+		ret = false;
+	}
+	if (province_building_types.empty()) {
+		Logger::error("No province building types found!");
+		ret = false;
+	} else {
+		Logger::info(
+			"Found ", province_building_types.size(), " province building types out of ", get_building_type_count(),
+			" total building types"
+		);
 	}
 
 	return ret;

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -47,11 +47,11 @@ namespace OpenVic {
 		bool PROPERTY(strategic_factory);
 		bool PROPERTY(advanced_factory);
 
-		level_t PROPERTY(fort_level); // probably the step-per-level
+		level_t PROPERTY(fort_level); // fort bonus step-per-level
 
 		uint64_t PROPERTY(naval_capacity);
 		std::vector<fixed_point_t> PROPERTY(colonial_points);
-		bool PROPERTY(in_province); // province
+		bool PROPERTY_CUSTOM_PREFIX(in_province, is); // province
 		bool PROPERTY(one_per_state);
 		fixed_point_t PROPERTY(colonial_range);
 
@@ -74,6 +74,7 @@ namespace OpenVic {
 
 	private:
 		IdentifierRegistry<BuildingType> IDENTIFIER_REGISTRY(building_type);
+		std::vector<BuildingType const*> PROPERTY(province_building_types);
 		BuildingType const* PROPERTY(port_building_type);
 
 	public:

--- a/src/openvic-simulation/economy/ProductionType.cpp
+++ b/src/openvic-simulation/economy/ProductionType.cpp
@@ -212,5 +212,10 @@ bool ProductionTypeManager::load_production_types_file(
 
 	production_types.lock();
 
+	if (rgo_owner_sprite <= 0) {
+		Logger::error("No RGO owner pop type sprite found!");
+		ret = false;
+	}
+
 	return ret;
 }

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -30,7 +30,7 @@ Mapmode::base_stripe_t Mapmode::get_base_stripe_colours(Map const& map, Province
 }
 
 Map::Map()
-  : width { 0 }, height { 0 }, max_provinces { Province::MAX_INDEX }, selected_province_index { Province::NULL_INDEX },
+  : width { 0 }, height { 0 }, max_provinces { Province::MAX_INDEX }, selected_province { nullptr },
 	highest_province_population { 0 }, total_map_population { 0 } {}
 
 bool Map::add_province(std::string_view identifier, colour_t colour) {
@@ -181,18 +181,24 @@ bool Map::set_max_provinces(Province::index_t new_max_provinces) {
 }
 
 void Map::set_selected_province(Province::index_t index) {
-	if (index > get_province_count()) {
-		Logger::error(
-			"Trying to set selected province to an invalid index ", index, " (max index is ", get_province_count(), ")"
-		);
-		selected_province_index = Province::NULL_INDEX;
+	if (index == Province::NULL_INDEX) {
+		selected_province = nullptr;
 	} else {
-		selected_province_index = index;
+		selected_province = get_province_by_index(index);
+		if (selected_province == nullptr) {
+			Logger::error(
+				"Trying to set selected province to an invalid index ", index, " (max index is ", get_province_count(), ")"
+			);
+		}
 	}
 }
 
-Province const* Map::get_selected_province() const {
-	return get_province_by_index(get_selected_province_index());
+Province* Map::get_selected_province() {
+	return selected_province;
+}
+
+Province::index_t Map::get_selected_province_index() const {
+	return selected_province != nullptr ? selected_province->get_index() : Province::NULL_INDEX;
 }
 
 bool Map::add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func) {

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -72,7 +72,7 @@ namespace OpenVic {
 		colour_index_map_t colour_index_map;
 
 		Province::index_t PROPERTY(max_provinces);
-		Province::index_t PROPERTY(selected_province_index);
+		Province* PROPERTY(selected_province);
 		Pop::pop_size_t PROPERTY(highest_province_population)
 		Pop::pop_size_t PROPERTY(total_map_population);
 
@@ -94,7 +94,8 @@ namespace OpenVic {
 		Province::index_t get_province_index_at(size_t x, size_t y) const;
 		bool set_max_provinces(Province::index_t new_max_provinces);
 		void set_selected_province(Province::index_t index);
-		Province const* get_selected_province() const;
+		Province* get_selected_province();
+		Province::index_t get_selected_province_index() const;
 
 		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(region)

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -58,9 +58,10 @@ bool Province::load_positions(BuildingTypeManager const& building_type_manager, 
 	return ret;
 }
 
-bool Province::expand_building(std::string_view building_type_identifier) {
-	BuildingInstance* building = buildings.get_item_by_identifier(building_type_identifier);
+bool Province::expand_building(size_t building_index) {
+	BuildingInstance* building = buildings.get_item_by_index(building_index);
 	if (building == nullptr) {
+		Logger::error("Trying to expand non-existent building index ", building_index, " in province ", get_identifier());
 		return false;
 	}
 	return building->expand();
@@ -360,10 +361,8 @@ bool Province::reset(BuildingTypeManager const& building_type_manager) {
 	bool ret = true;
 	if (!is_water()) {
 		if (building_type_manager.building_types_are_locked()) {
-			for (BuildingType const& building_type : building_type_manager.get_building_types()) {
-				if (building_type.get_in_province()) {
-					ret &= buildings.add_item({ building_type });
-				}
+			for (BuildingType const* building_type : building_type_manager.get_province_building_types()) {
+				ret &= buildings.add_item({ *building_type });
 			}
 		} else {
 			Logger::error("Cannot generate buildings until building types are locked!");

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -130,7 +130,7 @@ namespace OpenVic {
 
 		bool load_positions(BuildingTypeManager const& building_type_manager, ast::NodeCPtr root);
 
-		bool expand_building(std::string_view building_type_identifier);
+		bool expand_building(size_t building_index);
 
 		bool add_pop(Pop&& pop);
 		bool add_pop_vec(std::vector<Pop> const& pop_vec);

--- a/src/openvic-simulation/types/Date.cpp
+++ b/src/openvic-simulation/types/Date.cpp
@@ -68,11 +68,11 @@ Timespan Timespan::operator++(int) {
 	return old;
 }
 
-Timespan::operator day_t() const {
+Timespan::day_t Timespan::to_int() const {
 	return days;
 }
 
-Timespan::operator double() const {
+Timespan::operator day_t() const {
 	return days;
 }
 

--- a/src/openvic-simulation/types/Date.hpp
+++ b/src/openvic-simulation/types/Date.hpp
@@ -33,8 +33,8 @@ namespace OpenVic {
 		Timespan& operator++();
 		Timespan operator++(int);
 
+		day_t to_int() const;
 		explicit operator day_t() const;
-		explicit operator double() const;
 		std::string to_string() const;
 		explicit operator std::string() const;
 


### PR DESCRIPTION
- Record province building types in a list, with their index in that list being used to identify them in the UI-SIM interface (eg when expanding buildings).
- Selected province is now stored as a province pointer rather than a province index.
- Date to double conversion removed, float is still used for expansion progress (as it has no impact on the simulation) but in general floating point use should be discouraged.