### PR TITLE
Add `BMP::palette_colour_t` as uint32_t

### DIFF
--- a/src/openvic-simulation/utility/BMP.cpp
+++ b/src/openvic-simulation/utility/BMP.cpp
@@ -110,7 +110,7 @@ bool BMP::read_header() {
 
 	palette_size = header.bits_per_pixel > PALETTE_BITS_PER_PIXEL_LIMIT ? 0
 		// Use header.num_colours if it's greater than 0 and at most 1 << header.bits_per_pixel
-		: (0 < header.num_colours && header.num_colours - 1 >> header.bits_per_pixel == 0
+		: (0 < header.num_colours && (header.num_colours - 1) >> header.bits_per_pixel == 0
 		? header.num_colours : 1 << header.bits_per_pixel);
 
 	const uint32_t expected_offset = palette_size * PALETTE_COLOUR_SIZE + sizeof(header);
@@ -182,7 +182,7 @@ uint16_t BMP::get_bits_per_pixel() const {
 	return header.bits_per_pixel;
 }
 
-std::vector<colour_t> const& BMP::get_palette() const {
+std::vector<BMP::palette_colour_t> const& BMP::get_palette() const {
 	if (!palette_read) {
 		Logger::warning("Trying to get BMP palette before loading");
 	}

--- a/src/openvic-simulation/utility/BMP.hpp
+++ b/src/openvic-simulation/utility/BMP.hpp
@@ -32,14 +32,18 @@ namespace OpenVic {
 		} header;
 #pragma pack(pop)
 
+	public:
+		using palette_colour_t = uint32_t;
+
+	private:
 		std::ifstream file;
 		bool header_validated = false, palette_read = false, pixel_data_read = false;
 		uint32_t palette_size = 0;
-		std::vector<colour_t> palette;
+		std::vector<palette_colour_t> palette;
 		std::vector<uint8_t> pixel_data;
 
 	public:
-		static constexpr uint32_t PALETTE_COLOUR_SIZE = sizeof(colour_t);
+		static constexpr uint32_t PALETTE_COLOUR_SIZE = sizeof(palette_colour_t);
 
 		BMP() = default;
 		~BMP();
@@ -54,7 +58,7 @@ namespace OpenVic {
 		int32_t get_width() const;
 		int32_t get_height() const;
 		uint16_t get_bits_per_pixel() const;
-		std::vector<colour_t> const& get_palette() const;
+		std::vector<palette_colour_t> const& get_palette() const;
 		std::vector<uint8_t> const& get_pixel_data() const;
 	};
 }


### PR DESCRIPTION
Change `BMP::palette` to  `std::vector<palette_colour_t>`
Change `BMP::PALETTE_COLOUR_SIZE` to use `sizeof(palette_colour_t)`
Silence warning for `header.num_colours - 1 >> header.bits_per_pixel == 0`