### PR TITLE
Dataloading climate and continents

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -603,8 +603,7 @@ bool Dataloader::_load_map_dir(GameManager& game_manager) const {
 	static constexpr std::string_view default_region = "region.txt";
 	static constexpr std::string_view default_region_sea = "region_sea.txt"; // TODO
 	static constexpr std::string_view default_province_flag_sprite = "province_flag_sprites"; // TODO
-
-	static constexpr std::string_view climate_filename = "climate.txt"; // TODO
+	static constexpr std::string_view climate_file = "climate.txt"; // TODO
 
 	/* Parser stored so the filename string_views persist until the end of this function. */
 	const v2script::Parser parser = parse_defines(lookup_file(append_string_views(map_directory, defaults_filename)));
@@ -699,6 +698,22 @@ bool Dataloader::_load_map_dir(GameManager& game_manager) const {
 		parse_defines(lookup_file(append_string_views(map_directory, positions))).get_file_node()
 	)) {
 		Logger::error("Failed to load province positions file!");
+		ret = false;
+	}
+
+	if (!map.load_climate_file(
+		game_manager.get_modifier_manager(),
+		parse_defines(lookup_file(append_string_views(map_directory, climate_file))).get_file_node()
+	)) {
+		Logger::error("Failed to load climates!");
+		ret = false;
+	}
+
+	if (!map.load_continent_file(
+		game_manager.get_modifier_manager(),
+		parse_defines(lookup_file(append_string_views(map_directory, continent))).get_file_node()
+	)) {
+		Logger::error("Failed to load continents!");
 		ret = false;
 	}
 

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -49,7 +49,6 @@ namespace OpenVic {
 	 * MAP-4
 	 */
 	struct Map {
-
 #pragma pack(push, 1)
 		/* Used to represent tightly packed 3-byte integer pixel information. */
 		struct shape_pixel_t {
@@ -63,6 +62,8 @@ namespace OpenVic {
 		IdentifierRegistry<Province> IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(province, 1);
 		IdentifierRegistry<Region> IDENTIFIER_REGISTRY(region);
 		IdentifierRegistry<Mapmode> IDENTIFIER_REGISTRY(mapmode);
+		IdentifierRegistry<Climate> IDENTIFIER_REGISTRY(climate);
+		IdentifierRegistry<Continent> IDENTIFIER_REGISTRY(continent);
 		ProvinceSet water_provinces;
 		TerrainTypeManager PROPERTY_REF(terrain_type_manager);
 
@@ -132,5 +133,7 @@ namespace OpenVic {
 		bool load_region_file(ast::NodeCPtr root);
 		bool load_map_images(fs::path const& province_path, fs::path const& terrain_path, bool detailed_errors);
 		bool generate_and_load_province_adjacencies(std::vector<ovdl::csv::LineObject> const& additional_adjacencies);
+		bool load_climate_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
+		bool load_continent_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};
 }

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -8,8 +8,8 @@ using namespace OpenVic::NodeTools;
 Province::Province(
 	std::string_view new_identifier, colour_t new_colour, index_t new_index
 ) : HasIdentifierAndColour { new_identifier, new_colour, true }, index { new_index }, region { nullptr },
-	on_map { false }, has_region { false }, water { false }, coastal { false }, port { false },
-	default_terrain_type { nullptr }, positions {}, terrain_type { nullptr }, life_rating { 0 },
+	climate { nullptr }, continent { nullptr }, on_map { false }, has_region { false }, water { false }, coastal { false },
+	port { false }, default_terrain_type { nullptr }, positions {}, terrain_type { nullptr }, life_rating { 0 },
 	colony_status { colony_status_t::STATE }, state { nullptr }, owner { nullptr }, controller { nullptr }, slave { false },
 	crime { nullptr }, rgo { nullptr }, buildings { "buildings", false }, total_population { 0 } {
 	assert(index != NULL_INDEX);

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -16,6 +16,10 @@ namespace OpenVic {
 	struct TerrainType;
 	struct TerrainTypeMapping;
 	struct ProvinceHistoryEntry;
+	struct ProvinceSetModifier;
+	using Climate = ProvinceSetModifier;
+	using Continent = ProvinceSetModifier;
+
 
 	/* REQUIREMENTS:
 	 * MAP-5, MAP-7, MAP-8, MAP-43, MAP-47
@@ -88,6 +92,8 @@ namespace OpenVic {
 		/* Immutable attributes (unchanged after initial game load) */
 		const index_t PROPERTY(index);
 		Region const* PROPERTY(region);
+		Climate const* PROPERTY(climate);
+		Continent const* PROPERTY(continent);
 		bool PROPERTY(on_map);
 		bool PROPERTY(has_region);
 		bool PROPERTY_CUSTOM_PREFIX(water, is);

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -94,6 +94,9 @@ ProvinceSet::provinces_t const& ProvinceSet::get_provinces() const {
 Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_meta)
 	: HasIdentifierAndColour { new_identifier, new_colour, false }, meta { new_meta } {}
 
+ProvinceSetModifier::ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values)
+	: Modifier { new_identifier, std::move(new_values), 0 } {}
+
 bool Region::get_meta() const {
 	return meta;
 }

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -27,6 +27,14 @@ namespace OpenVic {
 		provinces_t const& get_provinces() const;
 	};
 
+	struct ProvinceSetModifier : Modifier, ProvinceSet {
+		friend struct Map;
+	private:
+		ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values);
+	public:
+		ProvinceSetModifier(ProvinceSetModifier&&) = default;
+	};
+
 	/* REQUIREMENTS:
 	 * MAP-6, MAP-44, MAP-48
 	 */

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -5,7 +5,7 @@
 namespace OpenVic {
 	struct TerrainTypeManager;
 
-	struct TerrainType : HasIdentifierAndColour, ModifierValue {
+	struct TerrainType : HasIdentifierAndColour {
 		friend struct TerrainTypeManager;
 
 	private:


### PR DESCRIPTION
The `Climate` and `Continent` structs would've been perfectly identical, so I created one `ProvinceSetModifier` struct with `Climate`and `Continent` as aliases. They are both a list of provinces associated with some modifiers, so they should each be a `ProvinceSet`, and conversely the provinces should have references to their `Climate` and `Continent`. Both references - the one stored in the `Climate`/`Continent` and the one(s) stored in `Province` - should be stored as `const` pointers.

~~To ensure that the reference to `Climate` and `Continent` each `Province` holds is immutable, I had to make that annoying for loop at the end. It's only ran once, so the double loop isn't too much a performance concern.~~

~~It's maybe worth looking into making a variant of `ProvinceSet` holding `Province const*` instead, but I'll wait on hearing from someone else before embarking in that.~~