### PR TITLE
Made ProvinceSet use Province const* and updated Region loading

### DIFF
--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -87,6 +87,15 @@ namespace OpenVic {
 		bool add_province(std::string_view identifier, colour_t colour);
 		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(province, 1);
 
+		/* This provides a safe way to remove the const qualifier of a Province const*, via a non-const Map.
+		 * It uses a const_cast (the fastest/simplest solution), but this could also be done without it by looking up the
+		 * Province* using the Province const*'s index. Requiring a non-const Map ensures that this function can only be
+		 * used where the Province* could already be accessed by other means, such as the index method, preventing
+		 * misleading code, or in the worst case undefined behaviour. */
+		constexpr Province* remove_province_const(Province const* province) {
+			return const_cast<Province*>(province);
+		}
+
 		bool set_water_province(std::string_view identifier);
 		bool set_water_province_list(std::vector<std::string_view> const& list);
 		void lock_water_provinces();
@@ -97,8 +106,7 @@ namespace OpenVic {
 		Province* get_selected_province();
 		Province::index_t get_selected_province_index() const;
 
-		bool add_region(std::string_view identifier, std::vector<std::string_view> const& province_identifiers);
-		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(region)
+		bool add_region(std::string_view identifier, Region::provinces_t const& provinces);
 
 		bool add_mapmode(std::string_view identifier, Mapmode::colour_func_t colour_func);
 

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -87,7 +87,7 @@ namespace OpenVic {
 	private:
 		/* Immutable attributes (unchanged after initial game load) */
 		const index_t PROPERTY(index);
-		Region* PROPERTY(region);
+		Region const* PROPERTY(region);
 		bool PROPERTY(on_map);
 		bool PROPERTY(has_region);
 		bool PROPERTY_CUSTOM_PREFIX(water, is);

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -5,16 +5,18 @@
 namespace OpenVic {
 
 	struct ProvinceSet {
-		using provinces_t = std::vector<Province*>;
+		using provinces_t = std::vector<Province const*>;
 
 	private:
 		provinces_t provinces;
 		bool locked = false;
 
 	public:
-		ProvinceSet(provinces_t&& new_provinces = {});
-
-		bool add_province(Province* province);
+		/* Returns true if the province is successfully added, false if not (including if it's already in the set). */
+		bool add_province(Province const* province);
+		bool add_provinces(provinces_t const& new_provinces);
+		/* Returns true if the province is successfully removed, false if not (including if it's not in the set). */
+		bool remove_province(Province const* province);
 		void lock(bool log = false);
 		bool is_locked() const;
 		void reset();
@@ -38,7 +40,7 @@ namespace OpenVic {
 		 */
 		const bool meta;
 
-		Region(std::string_view new_identifier, provinces_t&& new_provinces, bool new_meta);
+		Region(std::string_view new_identifier, colour_t new_colour, bool new_meta);
 
 	public:
 		Region(Region&&) = default;

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -21,22 +21,16 @@ namespace OpenVic {
 		);
 	};
 
-	inline bool operator==(const State& lhs, const State& rhs) {
-		return (lhs.get_owner() == rhs.get_owner() && lhs.get_colony_status() == rhs.get_colony_status());
-	}
-
 	struct StateSet {
 		using states_t = std::deque<State>;
 
 	private:
 		Region const& PROPERTY(region);
-		states_t states;
+		states_t PROPERTY(states);
 
 	public:
-		StateSet(Region const& new_region);
+		StateSet(Map& map, Region const& new_region);
 
-		bool add_state(State&& state);
-		bool remove_state(State const* state);
 		states_t& get_states();
 	};
 
@@ -49,6 +43,6 @@ namespace OpenVic {
 		/* Creates states from current province gamestate & regions, sets province state value.
 		 * After this function, the `regions` property is unmanaged and must be carefully updated and
 		 * validated by functions that modify it. */
-		void generate_states(Map const& map);
+		void generate_states(Map& map);
 	};
 } // namespace OpenVic


### PR DESCRIPTION
- `ProvinceSet` now stores `Province const*`s. It no longer has a constructor that accepts a vector of provinces (as that might contain duplicates), instead it has an `add_provinces` function that calls the `add_province` function with every element of a vector and returns false if any of those calls fail. It also has a `remove_province` function.
- `Map` has a `remove_province_const` that allows a non-const `Map` to be used to remove a `Province const*`'s const qualifier (equivalent to looking up the province by its ID, but faster).
- `Region` no longer takes a vector of provinces as a constructor argument, instead they are added using `ProvinceSet`'s `add_provinces`. Since it doesn't get its provinces in its constructor, it needs to get its colour directly, which is handled by `Map::add_region`. `Map::load_region_file` now directly parses `Province const*`s using `expect_province_identifier`, and it has also had some unnecessary checks removed (`has_region` is now only set for a region's provinces after the region is successfully added to the registry, so there can't be provinces with `has_region` set but no valid region).
- Some changes have been made to `State` to account for the `ProvinceSet` const change, but the system is still very rough and needs more design work.