### PR TITLE
Added framework for loading all Conditions and Effects

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -18,7 +18,7 @@ static void print_help(std::ostream& stream, char const* program_name) {
 		<< "(Paths with spaces need to be enclosed in \"quotes\").\n";
 }
 
-static bool headless_load(GameManager& game_manager, Dataloader const& dataloader) {
+static bool headless_load(GameManager& game_manager, Dataloader& dataloader) {
 	bool ret = true;
 
 	if (!dataloader.load_defines(game_manager)) {

--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -66,7 +66,6 @@ bool GameManager::load_bookmark(Bookmark const* new_bookmark) {
 	ret &= map.apply_history_to_provinces(history_manager.get_province_manager(), today);
 	map.get_state_manager().generate_states(map);
 	// TODO - apply country history
-	// TODO - apply pop history
 	return ret;
 }
 

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -3,7 +3,7 @@
 using namespace OpenVic;
 
 bool CountryInstance::add_accepted_culture(Culture const* new_accepted_culture) {
-	if(std::find(accepted_cultures.begin(), accepted_cultures.end(), new_accepted_culture) != accepted_cultures.end()) {
+	if (std::find(accepted_cultures.begin(), accepted_cultures.end(), new_accepted_culture) != accepted_cultures.end()) {
 		Logger::warning("Attempted to add accepted culture ", new_accepted_culture->get_identifier(), " to country ", base_country->get_identifier(), ": already present!");
 		return false;
 	}

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <concepts>
 #include <cstdint>
 #include <functional>
-#include <map>
 #include <optional>
-#include <set>
 #include <type_traits>
 
 #include <openvic-dataloader/v2script/AbstractSyntaxTree.hpp>
@@ -134,7 +131,9 @@ namespace OpenVic {
 		node_callback_t expect_list(node_callback_t callback);
 		node_callback_t expect_length(callback_t<size_t> callback);
 
-		node_callback_t expect_key(std::string_view key, node_callback_t callback, bool* key_found = nullptr);
+		node_callback_t expect_key(
+			std::string_view key, node_callback_t callback, bool* key_found = nullptr, bool allow_duplicates = false
+		);
 
 		node_callback_t expect_dictionary_and_length(length_callback_t length_callback, key_value_callback_t callback);
 		node_callback_t expect_dictionary(key_value_callback_t callback);

--- a/src/openvic-simulation/economy/BuildingInstance.hpp
+++ b/src/openvic-simulation/economy/BuildingInstance.hpp
@@ -14,7 +14,7 @@ namespace OpenVic {
 
 		level_t PROPERTY_RW(level);
 		ExpansionState PROPERTY(expansion_state);
-		Date PROPERTY(start_date)
+		Date PROPERTY(start_date);
 		Date PROPERTY(end_date);
 		float PROPERTY(expansion_progress);
 

--- a/src/openvic-simulation/history/DiplomaticHistory.cpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.cpp
@@ -221,7 +221,7 @@ bool DiplomaticHistoryManager::load_war_history_file(GameManager const& game_man
 					bool ret = expect_dictionary_keys(
 						"actor", ONE_EXACTLY, game_manager.get_country_manager().expect_country_identifier(assign_variable_callback_pointer(actor)),
 						"receiver", ONE_EXACTLY, game_manager.get_country_manager().expect_country_identifier(assign_variable_callback_pointer(receiver)),
-						"casus_belli", ONE_EXACTLY, game_manager.get_military_manager().get_wargoal_manager().expect_wargoal_type_identifier(assign_variable_callback_pointer(type)),
+						"casus_belli", ONE_EXACTLY, game_manager.get_military_manager().get_wargoal_type_manager().expect_wargoal_type_identifier(assign_variable_callback_pointer(type)),
 						"country", ZERO_OR_ONE, game_manager.get_country_manager().expect_country_identifier(assign_variable_callback_pointer(*third_party)),
 						"state_province_id", ZERO_OR_ONE, game_manager.get_map().expect_province_identifier(assign_variable_callback_pointer(*target))
 					)(value);

--- a/src/openvic-simulation/interface/GFX.hpp
+++ b/src/openvic-simulation/interface/GFX.hpp
@@ -138,7 +138,7 @@ namespace OpenVic::GFX {
 	class MaskedFlag final : public Sprite {
 		friend std::unique_ptr<MaskedFlag> std::make_unique<MaskedFlag>();
 
-		std::string PROPERTY(overlay_file)
+		std::string PROPERTY(overlay_file);
 		std::string PROPERTY(mask_file);
 
 	protected:

--- a/src/openvic-simulation/map/Crime.cpp
+++ b/src/openvic-simulation/map/Crime.cpp
@@ -3,17 +3,22 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-Crime::Crime(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, bool new_default_active)
-  : TriggeredModifier { new_identifier, std::move(new_values), new_icon }, default_active { new_default_active } {}
+Crime::Crime(
+	std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, ConditionScript&& new_trigger,
+	bool new_default_active
+) : TriggeredModifier { new_identifier, std::move(new_values), new_icon, std::move(new_trigger) },
+	default_active { new_default_active } {}
 
 bool CrimeManager::add_crime_modifier(
-	std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, bool default_active
+	std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, ConditionScript&& trigger, bool default_active
 ) {
 	if (identifier.empty()) {
 		Logger::error("Invalid crime modifier effect identifier - empty!");
 		return false;
 	}
-	return crime_modifiers.add_item({ identifier, std::move(values), icon, default_active }, duplicate_warning_callback);
+	return crime_modifiers.add_item(
+		{ identifier, std::move(values), icon, std::move(trigger), default_active }, duplicate_warning_callback
+	);
 }
 
 bool CrimeManager::load_crime_modifiers(ModifierManager const& modifier_manager, ast::NodeCPtr root) {
@@ -22,17 +27,26 @@ bool CrimeManager::load_crime_modifiers(ModifierManager const& modifier_manager,
 		[this, &modifier_manager](std::string_view key, ast::NodeCPtr value) -> bool {
 			ModifierValue modifier_value;
 			Modifier::icon_t icon = 0;
+			ConditionScript trigger;
 			bool default_active = false;
 			bool ret = modifier_manager.expect_modifier_value_and_keys(
 				move_variable_callback(modifier_value),
 				"icon", ZERO_OR_ONE, expect_uint(assign_variable_callback(icon)),
-				"trigger", ONE_EXACTLY, success_callback, // TODO - load condition
+				"trigger", ONE_EXACTLY, trigger.expect_script(),
 				"active", ZERO_OR_ONE, expect_bool(assign_variable_callback(default_active))
 			)(value);
-			ret &= add_crime_modifier(key, std::move(modifier_value), icon, default_active);
+			ret &= add_crime_modifier(key, std::move(modifier_value), icon, std::move(trigger), default_active);
 			return ret;
 		}
 	)(root);
 	lock_crime_modifiers();
+	return ret;
+}
+
+bool CrimeManager::parse_scripts(GameManager const& game_manager) {
+	bool ret = true;
+	for (Crime& crime : crime_modifiers.get_items()) {
+		ret &= crime.parse_scripts(game_manager);
+	}
 	return ret;
 }

--- a/src/openvic-simulation/map/Crime.hpp
+++ b/src/openvic-simulation/map/Crime.hpp
@@ -9,7 +9,10 @@ namespace OpenVic {
 	private:
 		const bool PROPERTY(default_active);
 
-		Crime(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, bool new_default_active);
+		Crime(
+			std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, ConditionScript&& new_trigger,
+			bool new_default_active
+		);
 
 	public:
 		Crime(Crime&&) = default;
@@ -21,9 +24,12 @@ namespace OpenVic {
 
 	public:
 		bool add_crime_modifier(
-			std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, bool default_active
+			std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, ConditionScript&& trigger,
+			bool default_active
 		);
 
 		bool load_crime_modifiers(ModifierManager const& modifier_manager, ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager const& game_manager);
 	};
 }

--- a/src/openvic-simulation/map/Map.hpp
+++ b/src/openvic-simulation/map/Map.hpp
@@ -75,7 +75,7 @@ namespace OpenVic {
 
 		Province::index_t PROPERTY(max_provinces);
 		Province* PROPERTY(selected_province);
-		Pop::pop_size_t PROPERTY(highest_province_population)
+		Pop::pop_size_t PROPERTY(highest_province_population);
 		Pop::pop_size_t PROPERTY(total_map_population);
 
 		Province::index_t get_index_from_colour(colour_t colour) const;

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -59,7 +59,7 @@ StateSet::states_t& StateSet::get_states() {
 void StateManager::generate_states(Map& map) {
 	regions.clear();
 	regions.reserve(map.get_region_count());
-	for(Region const& region : map.get_regions()) {
+	for (Region const& region : map.get_regions()) {
 		if (!region.get_meta()) {
 			regions.emplace_back(map, region);
 		}

--- a/src/openvic-simulation/military/MilitaryManager.hpp
+++ b/src/openvic-simulation/military/MilitaryManager.hpp
@@ -11,6 +11,6 @@ namespace OpenVic {
 		UnitManager PROPERTY_REF(unit_manager);
 		LeaderTraitManager PROPERTY_REF(leader_trait_manager);
 		DeploymentManager PROPERTY_REF(deployment_manager);
-		WargoalTypeManager PROPERTY_REF(wargoal_manager);
+		WargoalTypeManager PROPERTY_REF(wargoal_type_manager);
 	};
 }

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/scripts/ConditionScript.hpp"
+#include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/EnumBitfield.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
@@ -9,29 +11,32 @@ namespace OpenVic {
 	struct WargoalTypeManager;
 
 	enum class peace_options_t : uint32_t {
-		PO_ANNEX =				0b100000000000000000,
-		PO_DEMAND_STATE =		0b010000000000000000,
-		PO_COLONY =				0b001000000000000000,
-		PO_ADD_TO_SPHERE =		0b000100000000000000,
-		PO_DISARMAMENT =		0b000010000000000000,
-		PO_REMOVE_FORTS =		0b000001000000000000,
-		PO_REMOVE_NAVAL_BASES =	0b000000100000000000,
-		PO_REPARATIONS =		0b000000010000000000,
-		PO_REPAY_DEBT =			0b000000001000000000,
-		PO_REMOVE_PRESTIGE =	0b000000000100000000,
-		PO_MAKE_PUPPET =		0b000000000010000000,
-		PO_RELEASE_PUPPET =		0b000000000001000000,
-		PO_STATUS_QUO =			0b000000000000100000,
-		PO_INSTALL_COMMUNISM =	0b000000000000010000,
-		PO_REMOVE_COMMUNISM =	0b000000000000001000,
-		PO_REMOVE_CORES =		0b000000000000000100, // only usable with ANNEX, DEMAND_STATE, or TRANSFER_PROVINCES
-		PO_TRANSFER_PROVINCES =	0b000000000000000010,
-		PO_CLEAR_UNION_SPHERE =	0b000000000000000001
+		NO_PEACE_OPTIONS      = 0,
+		PO_ANNEX              = 1 << 0,
+		PO_DEMAND_STATE       = 1 << 1,
+		PO_COLONY             = 1 << 2,
+		PO_ADD_TO_SPHERE      = 1 << 3,
+		PO_DISARMAMENT        = 1 << 4,
+		PO_REMOVE_FORTS       = 1 << 5,
+		PO_REMOVE_NAVAL_BASES = 1 << 6,
+		PO_REPARATIONS        = 1 << 7,
+		PO_REPAY_DEBT         = 1 << 8,
+		PO_REMOVE_PRESTIGE    = 1 << 9,
+		PO_MAKE_PUPPET        = 1 << 10,
+		PO_RELEASE_PUPPET     = 1 << 11,
+		PO_STATUS_QUO         = 1 << 12,
+		PO_INSTALL_COMMUNISM  = 1 << 13,
+		PO_REMOVE_COMMUNISM   = 1 << 14,
+		PO_REMOVE_CORES       = 1 << 15, // only usable with ANNEX, DEMAND_STATE, or TRANSFER_PROVINCES
+		PO_TRANSFER_PROVINCES = 1 << 16,
+		PO_CLEAR_UNION_SPHERE = 1 << 17
 	};
 	template<> struct enable_bitfield<peace_options_t> : std::true_type{};
 
 	struct WargoalType : HasIdentifier {
 		friend struct WargoalTypeManager;
+
+		using sprite_t = uint8_t;
 
 		enum class PEACE_MODIFIERS {
 			BADBOY_FACTOR,
@@ -50,36 +55,40 @@ namespace OpenVic {
 		using peace_modifiers_t = fixed_point_map_t<PEACE_MODIFIERS>;
 
 	private:
-		const std::string PROPERTY(sprite);
-		const std::string PROPERTY(war_name);
+		std::string PROPERTY(war_name);
 		const Timespan PROPERTY(available_length);
 		const Timespan PROPERTY(truce_length);
-		const bool PROPERTY(triggered_only); // only able to be added via effects (or within the code)
-		const bool PROPERTY(civil_war);
+		const sprite_t PROPERTY(sprite_index);
+		const bool PROPERTY_CUSTOM_PREFIX(triggered_only, is); // only able to be added via effects or on_actions
+		const bool PROPERTY_CUSTOM_PREFIX(civil_war, is);
 		const bool PROPERTY(constructing); // can be added to existing wars or justified
 		const bool PROPERTY(crisis); // able to be added to crises
-		const bool PROPERTY(great_war); // automatically add to great wars
-		const bool PROPERTY(mutual); // attacked and defender share wargoal
-		const peace_modifiers_t PROPERTY(modifiers);
-		const peace_options_t PROPERTY(peace_options);
-
-		// TODO: can_use, prerequisites, on_add, on_po_accepted
+		const bool PROPERTY_CUSTOM_PREFIX(great_war_obligatory, is); // automatically add to great war peace offers/demands
+		const bool PROPERTY_CUSTOM_PREFIX(mutual, is); // attacked and defender share wargoal
+		const bool PROPERTY(all_allowed_states); // take all valid states rather than just one
+		const bool PROPERTY(always); // available without justifying
+		peace_modifiers_t PROPERTY(modifiers);
+		peace_options_t PROPERTY(peace_options);
+		ConditionScript PROPERTY(can_use);
+		ConditionScript PROPERTY(is_valid);
+		ConditionScript PROPERTY(allowed_states);
+		ConditionScript PROPERTY(allowed_substate_regions);
+		ConditionScript PROPERTY(allowed_states_in_crisis);
+		ConditionScript PROPERTY(allowed_countries);
+		EffectScript PROPERTY(on_add);
+		EffectScript PROPERTY(on_po_accepted);
 
 		WargoalType(
-			std::string_view new_identifier,
-			std::string_view new_sprite,
-			std::string_view new_war_name,
-			Timespan new_available_length,
-			Timespan new_truce_length,
-			bool new_triggered_only,
-			bool new_civil_war,
-			bool new_constructing,
-			bool new_crisis,
-			bool new_great_war,
-			bool new_mutual,
-			const peace_modifiers_t&& new_modifiers,
-			peace_options_t new_peace_options
+			std::string_view new_identifier, std::string_view new_war_name, Timespan new_available_length,
+			Timespan new_truce_length, sprite_t new_sprite_index, bool new_triggered_only, bool new_civil_war,
+			bool new_constructing, bool new_crisis, bool new_great_war_obligatory, bool new_mutual,
+			bool new_all_allowed_states, bool new_always, peace_modifiers_t&& new_modifiers, peace_options_t new_peace_options,
+			ConditionScript&& new_can_use, ConditionScript&& new_is_valid, ConditionScript&& new_allowed_states,
+			ConditionScript&& new_allowed_substate_regions, ConditionScript&& new_allowed_states_in_crisis,
+			ConditionScript&& new_allowed_countries, EffectScript&& new_on_add, EffectScript&& new_on_po_accepted
 		);
+
+		bool parse_scripts(GameManager& game_manager);
 
 	public:
 		WargoalType(WargoalType&&) = default;
@@ -91,24 +100,18 @@ namespace OpenVic {
 		std::vector<WargoalType const*> PROPERTY(peace_priorities);
 
 	public:
-		const std::vector<WargoalType const*>& get_peace_priority_list() const;
-
 		bool add_wargoal_type(
-			std::string_view identifier,
-			std::string_view sprite,
-			std::string_view war_name,
-			Timespan available_length,
-			Timespan truce_length,
-			bool triggered_only,
-			bool civil_war,
-			bool constructing,
-			bool crisis,
-			bool great_war,
-			bool mutual,
-			WargoalType::peace_modifiers_t&& modifiers,
-			peace_options_t peace_options
+			std::string_view identifier, std::string_view war_name, Timespan available_length,
+			Timespan truce_length, WargoalType::sprite_t sprite_index, bool triggered_only, bool civil_war,
+			bool constructing, bool crisis, bool great_war_obligatory, bool mutual, bool all_allowed_states,
+			bool always, WargoalType::peace_modifiers_t&& modifiers, peace_options_t peace_options,
+			ConditionScript&& can_use, ConditionScript&& is_valid, ConditionScript&& allowed_states,
+			ConditionScript&& allowed_substate_regions, ConditionScript&& allowed_states_in_crisis,
+			ConditionScript&& allowed_countries, EffectScript&& on_add, EffectScript&& on_po_accepted
 		);
 
 		bool load_wargoal_file(ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager& game_manager);
 	};
 } // namespace OpenVic

--- a/src/openvic-simulation/misc/Decision.cpp
+++ b/src/openvic-simulation/misc/Decision.cpp
@@ -6,14 +6,26 @@ using namespace OpenVic::NodeTools;
 Decision::Decision(
 	std::string_view new_identifier, bool new_alert, bool new_news, std::string_view new_news_title,
 	std::string_view new_news_desc_long, std::string_view new_news_desc_medium, std::string_view new_news_desc_short,
-	std::string_view new_picture
+	std::string_view new_picture, ConditionScript&& new_potential, ConditionScript&& new_allow,
+	ConditionalWeight&& new_ai_will_do, EffectScript&& new_effect
 ) : HasIdentifier { new_identifier }, alert { new_alert }, news { new_news }, news_title { new_news_title },
 	news_desc_long { new_news_desc_long }, news_desc_medium { new_news_desc_medium },
-	news_desc_short { new_news_desc_short }, picture { new_picture } {}
+	news_desc_short { new_news_desc_short }, picture { new_picture }, potential { std::move(new_potential) },
+	allow { std::move(new_allow) }, ai_will_do { std::move(new_ai_will_do) }, effect { std::move(new_effect) } {}
+
+bool Decision::parse_scripts(GameManager& game_manager) {
+	bool ret = true;
+	ret &= potential.parse_script(false, game_manager);
+	ret &= allow.parse_script(false, game_manager);
+	ret &= ai_will_do.parse_scripts(game_manager);
+	ret &= effect.parse_script(false, game_manager);
+	return ret;
+}
 
 bool DecisionManager::add_decision(
 	std::string_view identifier, bool alert, bool news, std::string_view news_title, std::string_view news_desc_long,
-	std::string_view news_desc_medium, std::string_view news_desc_short, std::string_view picture
+	std::string_view news_desc_medium, std::string_view news_desc_short, std::string_view picture, ConditionScript&& potential,
+	ConditionScript&& allow, ConditionalWeight&& ai_will_do, EffectScript&& effect
 ) {
 	if (identifier.empty()) {
 		Logger::error("Invalid decision identifier - empty!");
@@ -33,7 +45,8 @@ bool DecisionManager::add_decision(
 	}
 
 	return decisions.add_item({
-		identifier, alert, news, news_title, news_desc_long, news_desc_medium, news_desc_short, picture
+		identifier, alert, news, news_title, news_desc_long, news_desc_medium, news_desc_short, picture, std::move(potential),
+		std::move(allow), std::move(ai_will_do), std::move(effect)
 	}, duplicate_warning_callback);
 }
 
@@ -43,6 +56,9 @@ bool DecisionManager::load_decision_file(ast::NodeCPtr root) {
 			[this](std::string_view identifier, ast::NodeCPtr node) -> bool {
 				bool alert = true, news = false;
 				std::string_view news_title, news_desc_long, news_desc_medium, news_desc_short, picture;
+				ConditionScript potential, allow;
+				ConditionalWeight ai_will_do;
+				EffectScript effect;
 				bool ret = expect_dictionary_keys(
 					"alert", ZERO_OR_ONE, expect_bool(assign_variable_callback(alert)),
 					"news", ZERO_OR_ONE, expect_bool(assign_variable_callback(news)),
@@ -51,16 +67,25 @@ bool DecisionManager::load_decision_file(ast::NodeCPtr root) {
 					"news_desc_medium", ZERO_OR_ONE, expect_string(assign_variable_callback(news_desc_medium)),
 					"news_desc_short", ZERO_OR_ONE, expect_string(assign_variable_callback(news_desc_short)),
 					"picture", ZERO_OR_ONE, expect_identifier_or_string(assign_variable_callback(picture)),
-					"potential", ONE_EXACTLY, success_callback, //TODO
-					"allow", ONE_EXACTLY, success_callback, //TODO
-					"effect", ONE_EXACTLY, success_callback, //TODO
-					"ai_will_do", ZERO_OR_ONE, success_callback //TODO
+					"potential", ONE_EXACTLY, potential.expect_script(),
+					"allow", ONE_EXACTLY, allow.expect_script(),
+					"effect", ONE_EXACTLY, effect.expect_script(),
+					"ai_will_do", ZERO_OR_ONE, ai_will_do.expect_conditional_weight(ConditionalWeight::FACTOR)
 				)(node);
 				ret &= add_decision(
-					identifier, alert, news, news_title, news_desc_long, news_desc_medium, news_desc_short, picture
+					identifier, alert, news, news_title, news_desc_long, news_desc_medium, news_desc_short, picture,
+					std::move(potential), std::move(allow), std::move(ai_will_do), std::move(effect)
 				);
 				return ret;
 			}
 		)
 	)(root);
+}
+
+bool DecisionManager::parse_scripts(GameManager& game_manager) {
+	bool ret = true;
+	for (Decision& decision : decisions.get_items()) {
+		ret &= decision.parse_scripts(game_manager);
+	}
+	return ret;
 }

--- a/src/openvic-simulation/misc/Decision.hpp
+++ b/src/openvic-simulation/misc/Decision.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
+#include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
@@ -11,17 +13,24 @@ namespace OpenVic {
 	private:
 		const bool PROPERTY_CUSTOM_PREFIX(alert, has);
 		const bool PROPERTY_CUSTOM_PREFIX(news, is);
-		const std::string PROPERTY(news_title);
-		const std::string PROPERTY(news_desc_long);
-		const std::string PROPERTY(news_desc_medium);
-		const std::string PROPERTY(news_desc_short);
-		const std::string PROPERTY(picture);
+		std::string PROPERTY(news_title);
+		std::string PROPERTY(news_desc_long);
+		std::string PROPERTY(news_desc_medium);
+		std::string PROPERTY(news_desc_short);
+		std::string PROPERTY(picture);
+		ConditionScript PROPERTY(potential);
+		ConditionScript PROPERTY(allow);
+		ConditionalWeight PROPERTY(ai_will_do);
+		EffectScript PROPERTY(effect);
 
 		Decision(
 			std::string_view new_identifier, bool new_alert, bool new_news, std::string_view new_news_title,
 			std::string_view new_news_desc_long, std::string_view new_news_desc_medium, std::string_view new_news_desc_short,
-			std::string_view new_picture
+			std::string_view new_picture, ConditionScript&& new_potential, ConditionScript&& new_allow,
+			ConditionalWeight&& new_ai_will_do, EffectScript&& new_effect
 		);
+
+		bool parse_scripts(GameManager& game_manager);
 
 	public:
 		Decision(Decision&&) = default;
@@ -34,9 +43,12 @@ namespace OpenVic {
 	public:
 		bool add_decision(
 			std::string_view identifier, bool alert, bool news, std::string_view news_title, std::string_view news_desc_long,
-			std::string_view news_desc_medium, std::string_view news_desc_short, std::string_view picture
+			std::string_view news_desc_medium, std::string_view news_desc_short, std::string_view picture,
+			ConditionScript&& potential, ConditionScript&& allow, ConditionalWeight&& ai_will_do, EffectScript&& effect
 		);
 
 		bool load_decision_file(ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager& game_manager);
 	};
 }

--- a/src/openvic-simulation/misc/Event.hpp
+++ b/src/openvic-simulation/misc/Event.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
+#include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
@@ -15,12 +17,16 @@ namespace OpenVic {
 
 		struct EventOption {
 			friend struct EventManager;
+			friend struct Event;
 
 		private:
 			std::string PROPERTY(title);
-			// TODO: option effects
+			EffectScript PROPERTY(effect);
+			ConditionalWeight PROPERTY(ai_chance);
 
-			EventOption(std::string_view new_title);
+			EventOption(std::string_view new_title, EffectScript&& new_effect, ConditionalWeight&& new_ai_chance);
+
+			bool parse_scripts(GameManager& game_manager);
 
 		public:
 			EventOption(EventOption const&) = delete;
@@ -48,17 +54,22 @@ namespace OpenVic {
 		bool PROPERTY_CUSTOM_PREFIX(election, is);
 		IssueGroup const* PROPERTY(election_issue_group);
 
-		std::vector<EventOption> PROPERTY(options);
+		ConditionScript PROPERTY(trigger);
+		ConditionalWeight PROPERTY(mean_time_to_happen);
+		EffectScript PROPERTY(immediate);
 
-		// TODO: triggers, MTTH, immediate effects
+		std::vector<EventOption> PROPERTY(options);
 
 		Event(
 			std::string_view new_identifier, std::string_view new_title, std::string_view new_description,
 			std::string_view new_image, event_type_t new_type, bool new_triggered_only, bool new_major,
 			bool new_fire_only_once, bool new_allows_multiple_instances, bool new_news, std::string_view new_news_title,
 			std::string_view new_news_desc_long, std::string_view new_news_desc_medium, std::string_view new_news_desc_short,
-			bool new_election, IssueGroup const* new_election_issue_group, std::vector<EventOption>&& new_options
+			bool new_election, IssueGroup const* new_election_issue_group, ConditionScript&& new_trigger,
+			ConditionalWeight&& new_mean_time_to_happen, EffectScript&& new_immediate, std::vector<EventOption>&& new_options
 		);
+
+		bool parse_scripts(GameManager& game_manager);
 
 	public:
 		Event(Event&&) = default;
@@ -88,13 +99,15 @@ namespace OpenVic {
 			std::string_view identifier, std::string_view title, std::string_view description, std::string_view image,
 			Event::event_type_t type, bool triggered_only, bool major, bool fire_only_once, bool allows_multiple_instances,
 			bool news, std::string_view news_title, std::string_view news_desc_long, std::string_view news_desc_medium,
-			std::string_view news_desc_short, bool election, IssueGroup const* election_issue_group,
-			std::vector<Event::EventOption>&& options
+			std::string_view news_desc_short, bool election, IssueGroup const* election_issue_group, ConditionScript&& trigger,
+			ConditionalWeight&& mean_time_to_happen, EffectScript&& immediate, std::vector<Event::EventOption>&& options
 		);
 
 		bool add_on_action(std::string_view identifier, OnAction::weight_map_t&& new_weighted_events);
 
 		bool load_event_file(IssueManager const& issue_manager, ast::NodeCPtr root);
 		bool load_on_action_file(ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager& game_manager);
 	};
 } // namespace OpenVic

--- a/src/openvic-simulation/misc/Modifier.hpp
+++ b/src/openvic-simulation/misc/Modifier.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "openvic-simulation/scripts/ConditionScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
@@ -83,10 +84,14 @@ namespace OpenVic {
 		friend struct ModifierManager;
 
 	private:
-		// TODO - trigger condition
+		ConditionScript trigger;
 
 	protected:
-		TriggeredModifier(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon);
+		TriggeredModifier(
+			std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, ConditionScript&& new_trigger
+		);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 	public:
 		TriggeredModifier(TriggeredModifier&&) = default;
@@ -139,8 +144,12 @@ namespace OpenVic {
 		bool add_static_modifier(std::string_view identifier, ModifierValue&& values);
 		bool load_static_modifiers(ast::NodeCPtr root);
 
-		bool add_triggered_modifier(std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon);
+		bool add_triggered_modifier(
+			std::string_view identifier, ModifierValue&& values, Modifier::icon_t icon, ConditionScript&& trigger
+		);
 		bool load_triggered_modifiers(ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 		NodeTools::node_callback_t expect_validated_modifier_value_and_default(
 			NodeTools::callback_t<ModifierValue&&> modifier_callback, NodeTools::key_value_callback_t default_callback,

--- a/src/openvic-simulation/politics/Ideology.cpp
+++ b/src/openvic-simulation/politics/Ideology.cpp
@@ -9,9 +9,27 @@ IdeologyGroup::IdeologyGroup(std::string_view new_identifier) : HasIdentifier { 
 
 Ideology::Ideology(
 	std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised,
-	bool new_can_reduce_militancy, Date new_spawn_date
+	bool new_can_reduce_militancy, Date new_spawn_date, ConditionalWeight&& new_add_political_reform,
+	ConditionalWeight&& new_remove_political_reform, ConditionalWeight&& new_add_social_reform,
+	ConditionalWeight&& new_remove_social_reform, ConditionalWeight&& new_add_military_reform,
+	ConditionalWeight&& new_add_economic_reform
 ) : HasIdentifierAndColour { new_identifier, new_colour, false }, group { new_group }, uncivilised { new_uncivilised },
-	can_reduce_militancy { new_can_reduce_militancy }, spawn_date { new_spawn_date } {}
+	can_reduce_militancy { new_can_reduce_militancy }, spawn_date { new_spawn_date },
+	add_political_reform { std::move(new_add_political_reform) },
+	remove_political_reform { std::move(new_remove_political_reform) },
+	add_social_reform { std::move(new_add_social_reform) }, remove_social_reform { std::move(new_remove_social_reform) },
+	add_military_reform { std::move(new_add_military_reform) }, add_economic_reform { std::move(new_add_economic_reform) } {}
+
+bool Ideology::parse_scripts(GameManager const& game_manager) {
+	bool ret = true;
+	ret &= add_political_reform.parse_scripts(game_manager);
+	ret &= remove_political_reform.parse_scripts(game_manager);
+	ret &= add_social_reform.parse_scripts(game_manager);
+	ret &= remove_social_reform.parse_scripts(game_manager);
+	ret &= add_military_reform.parse_scripts(game_manager);
+	ret &= add_economic_reform.parse_scripts(game_manager);
+	return ret;
+}
 
 bool IdeologyManager::add_ideology_group(std::string_view identifier) {
 	if (identifier.empty()) {
@@ -24,7 +42,9 @@ bool IdeologyManager::add_ideology_group(std::string_view identifier) {
 
 bool IdeologyManager::add_ideology(
 	std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised, bool can_reduce_militancy,
-	Date spawn_date
+	Date spawn_date, ConditionalWeight&& add_political_reform, ConditionalWeight&& remove_political_reform,
+	ConditionalWeight&& add_social_reform, ConditionalWeight&& remove_social_reform, ConditionalWeight&& add_military_reform,
+	ConditionalWeight&& add_economic_reform
 ) {
 	if (identifier.empty()) {
 		Logger::error("Invalid ideology identifier - empty!");
@@ -36,7 +56,11 @@ bool IdeologyManager::add_ideology(
 		return false;
 	}
 
-	return ideologies.add_item({ identifier, colour, *group, uncivilised, can_reduce_militancy, spawn_date });
+	return ideologies.add_item({
+		identifier, colour, *group, uncivilised, can_reduce_militancy, spawn_date, std::move(add_political_reform),
+		std::move(remove_political_reform), std::move(add_social_reform), std::move(remove_social_reform),
+		std::move(add_military_reform), std::move(add_economic_reform)
+	});
 }
 
 /* REQUIREMENTS:
@@ -61,24 +85,38 @@ bool IdeologyManager::load_ideology_file(ast::NodeCPtr root) {
 			colour_t colour = colour_t::null();
 			bool uncivilised = true, can_reduce_militancy = false;
 			Date spawn_date;
+			ConditionalWeight add_political_reform, remove_political_reform, add_social_reform, remove_social_reform,
+				add_military_reform, add_economic_reform;
 
 			bool ret = expect_dictionary_keys(
 				"uncivilized", ZERO_OR_ONE, expect_bool(assign_variable_callback(uncivilised)),
 				"color", ONE_EXACTLY, expect_colour(assign_variable_callback(colour)),
 				"date", ZERO_OR_ONE, expect_date(assign_variable_callback(spawn_date)),
 				"can_reduce_militancy", ZERO_OR_ONE, expect_bool(assign_variable_callback(can_reduce_militancy)),
-				"add_political_reform", ONE_EXACTLY, success_callback,
-				"remove_political_reform", ONE_EXACTLY, success_callback,
-				"add_social_reform", ONE_EXACTLY, success_callback,
-				"remove_social_reform", ONE_EXACTLY, success_callback,
-				"add_military_reform", ZERO_OR_ONE, success_callback,
-				"add_economic_reform", ZERO_OR_ONE, success_callback
+				"add_political_reform", ONE_EXACTLY, add_political_reform.expect_conditional_weight(ConditionalWeight::BASE),
+				"remove_political_reform", ONE_EXACTLY, remove_political_reform.expect_conditional_weight(ConditionalWeight::BASE),
+				"add_social_reform", ONE_EXACTLY, add_social_reform.expect_conditional_weight(ConditionalWeight::BASE),
+				"remove_social_reform", ONE_EXACTLY, remove_social_reform.expect_conditional_weight(ConditionalWeight::BASE),
+				"add_military_reform", ZERO_OR_ONE, add_military_reform.expect_conditional_weight(ConditionalWeight::BASE),
+				"add_economic_reform", ZERO_OR_ONE, add_economic_reform.expect_conditional_weight(ConditionalWeight::BASE)
 			)(value);
-			ret &= add_ideology(key, colour, ideology_group, uncivilised, can_reduce_militancy, spawn_date);
+			ret &= add_ideology(
+				key, colour, ideology_group, uncivilised, can_reduce_militancy, spawn_date, std::move(add_political_reform),
+				std::move(remove_political_reform), std::move(add_social_reform), std::move(remove_social_reform),
+				std::move(add_military_reform), std::move(add_economic_reform)
+			);
 			return ret;
 		})(ideology_group_value);
 	})(root);
 	lock_ideologies();
 
+	return ret;
+}
+
+bool IdeologyManager::parse_scripts(GameManager const& game_manager) {
+	bool ret = true;
+	for (Ideology& ideology : ideologies.get_items()) {
+		ideology.parse_scripts(game_manager);
+	}
 	return ret;
 }

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
@@ -23,13 +24,24 @@ namespace OpenVic {
 		const bool PROPERTY_CUSTOM_PREFIX(uncivilised, is);
 		const bool PROPERTY(can_reduce_militancy);
 		const Date PROPERTY(spawn_date);
+		ConditionalWeight PROPERTY(add_political_reform);
+		ConditionalWeight PROPERTY(remove_political_reform);
+		ConditionalWeight PROPERTY(add_social_reform);
+		ConditionalWeight PROPERTY(remove_social_reform);
+		ConditionalWeight PROPERTY(add_military_reform);
+		ConditionalWeight PROPERTY(add_economic_reform);
 
 		// TODO - willingness to repeal/pass reforms (and its modifiers)
 
 		Ideology(
 			std::string_view new_identifier, colour_t new_colour, IdeologyGroup const& new_group, bool new_uncivilised,
-			bool new_can_reduce_militancy, Date new_spawn_date
+			bool new_can_reduce_militancy, Date new_spawn_date, ConditionalWeight&& new_add_political_reform,
+			ConditionalWeight&& new_remove_political_reform, ConditionalWeight&& new_add_social_reform,
+			ConditionalWeight&& new_remove_social_reform, ConditionalWeight&& new_add_military_reform,
+			ConditionalWeight&& new_add_economic_reform
 		);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 	public:
 		Ideology(Ideology&&) = default;
@@ -45,9 +57,14 @@ namespace OpenVic {
 
 		bool add_ideology(
 			std::string_view identifier, colour_t colour, IdeologyGroup const* group, bool uncivilised,
-			bool can_reduce_militancy, Date spawn_date
+			bool can_reduce_militancy, Date spawn_date, ConditionalWeight&& add_political_reform,
+			ConditionalWeight&& remove_political_reform, ConditionalWeight&& add_social_reform,
+			ConditionalWeight&& remove_social_reform, ConditionalWeight&& add_military_reform,
+			ConditionalWeight&& add_economic_reform
 		);
 
 		bool load_ideology_file(ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager const& game_manager);
 	};
 }

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "openvic-simulation/politics/Rule.hpp"
-#include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/dataloader/NodeTools.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/politics/Rule.hpp"
+#include "openvic-simulation/scripts/ConditionScript.hpp"
+#include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
@@ -76,11 +78,17 @@ namespace OpenVic {
 		ReformGroup const& PROPERTY(reform_group); // stores an already casted reference
 		const size_t PROPERTY(ordinal); // assigned by the parser to allow policy sorting
 		const tech_cost_t PROPERTY(technology_cost);
+		ConditionScript PROPERTY(allow);
+		ConditionScript PROPERTY(on_execute_trigger);
+		EffectScript PROPERTY(on_execute_effect);
 
 		Reform(
 			std::string_view new_identifier, ModifierValue&& new_values, ReformGroup const& new_group, size_t new_ordinal,
-			RuleSet&& new_rules, tech_cost_t new_technology_cost
+			RuleSet&& new_rules, tech_cost_t new_technology_cost, ConditionScript&& new_allow,
+			ConditionScript&& new_on_execute_trigger, EffectScript&& new_on_execute_effect
 		);
+
+		bool parse_scripts(GameManager& game_manager);
 
 	public:
 		Reform(Reform&&) = default;
@@ -104,16 +112,24 @@ namespace OpenVic {
 			size_t& expected_reforms, std::string_view identifier, ReformType const* type, ast::NodeCPtr node
 		);
 		bool _load_reform(
-			ModifierManager const& modifier_manager, RuleManager const& rule_manager, size_t ordinal, std::string_view identifier,
-			ReformGroup const* group, ast::NodeCPtr node
+			ModifierManager const& modifier_manager, RuleManager const& rule_manager, size_t ordinal,
+			std::string_view identifier, ReformGroup const* group, ast::NodeCPtr node
 		);
 
 	public:
 		bool add_issue_group(std::string_view identifier);
-		bool add_issue(std::string_view identifier, ModifierValue&& values, IssueGroup const* group, RuleSet&& rules, bool jingoism);
+		bool add_issue(
+			std::string_view identifier, ModifierValue&& values, IssueGroup const* group, RuleSet&& rules, bool jingoism
+		);
 		bool add_reform_type(std::string_view identifier, bool uncivilised);
 		bool add_reform_group(std::string_view identifier, ReformType const* type, bool ordered, bool administrative);
-		bool add_reform(std::string_view identifier, ModifierValue&& values, ReformGroup const* group, size_t ordinal, RuleSet&& rules, Reform::tech_cost_t technology_cost);
+		bool add_reform(
+			std::string_view identifier, ModifierValue&& values, ReformGroup const* group, size_t ordinal, RuleSet&& rules,
+			Reform::tech_cost_t technology_cost, ConditionScript&& allow, ConditionScript&& on_execute_trigger,
+			EffectScript&& on_execute_effect
+		);
 		bool load_issues_file(ModifierManager const& modifier_manager, RuleManager const& rule_manager, ast::NodeCPtr root);
+
+		bool parse_scripts(GameManager& game_manager);
 	};
 }

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
+#include "openvic-simulation/economy/Good.hpp"
+#include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/politics/Ideology.hpp"
+#include "openvic-simulation/pop/Pop.hpp"
+#include "openvic-simulation/scripts/ConditionScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
-#include "openvic-simulation/misc/Modifier.hpp"
-#include "openvic-simulation/pop/Pop.hpp"
-#include "openvic-simulation/politics/Ideology.hpp"
-#include "openvic-simulation/economy/Good.hpp"
-
-#include <optional>
 
 namespace OpenVic {
 	struct NationalFocusManager;
@@ -34,6 +33,7 @@ namespace OpenVic {
 		pop_promotion_map_t PROPERTY(encouraged_promotion);
 		party_loyalty_map_t PROPERTY(encouraged_loyalty);
 		production_map_t PROPERTY(encouraged_production);
+		ConditionScript PROPERTY(limit);
 
 		NationalFocus(
 			std::string_view new_identifier,
@@ -42,8 +42,11 @@ namespace OpenVic {
 			ModifierValue&& new_modifiers,
 			pop_promotion_map_t&& new_encouraged_promotion,
 			party_loyalty_map_t&& new_encouraged_loyalty,
-			production_map_t&& new_encouraged_production
+			production_map_t&& new_encouraged_production,
+			ConditionScript&& new_limit
 		);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 	public:
 		NationalFocus(NationalFocus&&) = default;
@@ -64,9 +67,15 @@ namespace OpenVic {
 			ModifierValue&& modifiers,
 			NationalFocus::pop_promotion_map_t&& encouraged_promotion,
 			NationalFocus::party_loyalty_map_t&& encouraged_loyalty,
-			NationalFocus::production_map_t&& encouraged_production
+			NationalFocus::production_map_t&& encouraged_production,
+			ConditionScript&& limit
 		);
 
-		bool load_national_foci_file(PopManager const& pop_manager, IdeologyManager const& ideology_manager, GoodManager const& good_manager, ModifierManager const& modifier_manager, ast::NodeCPtr root);
+		bool load_national_foci_file(
+			PopManager const& pop_manager, IdeologyManager const& ideology_manager, GoodManager const& good_manager,
+			ModifierManager const& modifier_manager, ast::NodeCPtr root
+		);
+
+		bool parse_scripts(GameManager const& game_manager);
 	};
 } // namespace OpenVic

--- a/src/openvic-simulation/politics/Rebel.hpp
+++ b/src/openvic-simulation/politics/Rebel.hpp
@@ -5,6 +5,8 @@
 #include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/politics/Government.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
+#include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
@@ -51,14 +53,27 @@ namespace OpenVic {
 		const bool PROPERTY_CUSTOM_PREFIX(smart, is);
 		const bool PROPERTY_CUSTOM_NAME(unit_transfer, will_transfer_units);
 		const fixed_point_t PROPERTY(occupation_mult);
+		ConditionalWeight PROPERTY(will_rise);
+		ConditionalWeight PROPERTY(spawn_chance);
+		ConditionalWeight PROPERTY(movement_evaluation);
+		ConditionScript PROPERTY(siege_won_trigger);
+		EffectScript PROPERTY(siege_won_effect);
+		ConditionScript PROPERTY(demands_enforced_trigger);
+		EffectScript PROPERTY(demands_enforced_effect);
 
 		RebelType(
 			std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
 			RebelType::government_map_t&& desired_governments, RebelType::defection_t defection,
 			RebelType::independence_t independence, uint16_t defect_delay, Ideology const* ideology, bool allow_all_cultures,
 			bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient,
-			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult
+			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult,
+			ConditionalWeight&& new_will_rise, ConditionalWeight&& new_spawn_chance,
+			ConditionalWeight&& new_movement_evaluation, ConditionScript&& new_siege_won_trigger,
+			EffectScript&& new_siege_won_effect, ConditionScript&& new_demands_enforced_trigger,
+			EffectScript&& new_demands_enforced_effect
 		);
+
+		bool parse_scripts(GameManager& game_manager);
 
 	public:
 		RebelType(RebelType&&) = default;
@@ -74,10 +89,15 @@ namespace OpenVic {
 			RebelType::government_map_t&& desired_governments, RebelType::defection_t defection,
 			RebelType::independence_t independence, uint16_t defect_delay, Ideology const* ideology, bool allow_all_cultures,
 			bool allow_all_culture_groups, bool allow_all_religions, bool allow_all_ideologies, bool resilient,
-			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult
+			bool reinforcing, bool general, bool smart, bool unit_transfer, fixed_point_t occupation_mult,
+			ConditionalWeight&& will_rise, ConditionalWeight&& spawn_chance, ConditionalWeight&& movement_evaluation,
+			ConditionScript&& siege_won_trigger, EffectScript&& siege_won_effect, ConditionScript&& demands_enforced_trigger,
+			EffectScript&& demands_enforced_effect
 		);
 
 		bool load_rebels_file(IdeologyManager const& ideology_manager, GovernmentTypeManager const& government_type_manager, ast::NodeCPtr root);
 		bool generate_modifiers(ModifierManager& modifier_manager) const;
+
+		bool parse_scripts(GameManager& game_manager);
 	};
 }

--- a/src/openvic-simulation/research/Invention.hpp
+++ b/src/openvic-simulation/research/Invention.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
@@ -27,12 +28,16 @@ namespace OpenVic {
 		crime_set_t PROPERTY(enabled_crimes);
 		const bool PROPERTY_CUSTOM_PREFIX(unlock_gas_attack, will);
 		const bool PROPERTY_CUSTOM_PREFIX(unlock_gas_defence, will);
+		ConditionScript PROPERTY(limit);
+		ConditionalWeight PROPERTY(chance);
 
 		Invention(
 			std::string_view new_identifier, ModifierValue&& new_values, bool new_news, unit_set_t&& new_activated_units,
 			building_set_t&& new_activated_buildings, crime_set_t&& new_enabled_crimes, bool new_unlock_gas_attack,
-			bool new_unlock_gas_defence
+			bool new_unlock_gas_defence, ConditionScript&& new_limit, ConditionalWeight&& new_chance
 		);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 	public:
 		Invention(Invention&&) = default;
@@ -45,12 +50,14 @@ namespace OpenVic {
 		bool add_invention(
 			std::string_view identifier, ModifierValue&& values, bool news, Invention::unit_set_t&& activated_units,
 			Invention::building_set_t&& activated_buildings, Invention::crime_set_t&& enabled_crimes, bool unlock_gas_attack,
-			bool unlock_gas_defence
+			bool unlock_gas_defence, ConditionScript&& limit, ConditionalWeight&& chance
 		);
 
 		bool load_inventions_file(
 			ModifierManager const& modifier_manager, UnitManager const& unit_manager,
 			BuildingTypeManager const& building_type_manager, CrimeManager const& crime_manager, ast::NodeCPtr root
 		); // inventions/*.txt
+
+		bool parse_scripts(GameManager const& game_manager);
 	};
 }

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/military/Unit.hpp"
 #include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
@@ -43,16 +44,17 @@ namespace OpenVic {
 		const fixed_point_t PROPERTY(cost);
 		const bool PROPERTY(unciv_military);
 		const uint8_t PROPERTY(unit);
-		const unit_set_t PROPERTY(activated_buildings);
-		const building_set_t PROPERTY(activated_units);
-
-		//TODO: implement rules/modifiers and ai_chance
+		unit_set_t PROPERTY(activated_buildings);
+		building_set_t PROPERTY(activated_units);
+		ConditionalWeight PROPERTY(ai_chance);
 
 		Technology(
 			std::string_view new_identifier, TechnologyArea const& new_area, Date::year_t new_year, fixed_point_t new_cost,
 			bool new_unciv_military, uint8_t new_unit, unit_set_t&& new_activated_units,
-			building_set_t&& new_activated_buildings, ModifierValue&& new_values
+			building_set_t&& new_activated_buildings, ModifierValue&& new_values, ConditionalWeight&& new_ai_chance
 		);
+
+		bool parse_scripts(GameManager const& game_manager);
 
 	public:
 		Technology(Technology&&) = default;
@@ -79,7 +81,8 @@ namespace OpenVic {
 		bool add_technology(
 			std::string_view identifier, TechnologyArea const* area, Date::year_t year, fixed_point_t cost,
 			bool unciv_military, uint8_t unit, Technology::unit_set_t&& activated_units,
-			Technology::building_set_t&& activated_buildings, ModifierValue&& values);
+			Technology::building_set_t&& activated_buildings, ModifierValue&& values, ConditionalWeight&& ai_chance
+		);
 
 		bool add_technology_school(std::string_view identifier, ModifierValue&& values);
 
@@ -90,5 +93,7 @@ namespace OpenVic {
 			BuildingTypeManager const& building_type_manager, ast::NodeCPtr root
 		); // technologies/*.txt
 		bool generate_modifiers(ModifierManager& modifier_manager) const;
+
+		bool parse_scripts(GameManager const& game_manager);
 	};
 }

--- a/src/openvic-simulation/scripts/ConditionScript.cpp
+++ b/src/openvic-simulation/scripts/ConditionScript.cpp
@@ -1,0 +1,8 @@
+#include "ConditionScript.hpp"
+
+using namespace OpenVic;
+
+bool ConditionScript::_parse_script(ast::NodeCPtr root, GameManager const& game_manager) {
+	// TODO - parse condition script
+	return true;
+}

--- a/src/openvic-simulation/scripts/ConditionScript.hpp
+++ b/src/openvic-simulation/scripts/ConditionScript.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "openvic-simulation/scripts/Script.hpp"
+
+namespace OpenVic {
+	struct GameManager;
+
+	struct ConditionScript final : Script<GameManager const&> {
+	protected:
+		bool _parse_script(ast::NodeCPtr root, GameManager const& game_manager) override;
+	};
+}

--- a/src/openvic-simulation/scripts/ConditionalWeight.cpp
+++ b/src/openvic-simulation/scripts/ConditionalWeight.cpp
@@ -1,0 +1,64 @@
+#include "ConditionalWeight.hpp"
+
+using namespace OpenVic;
+using namespace OpenVic::NodeTools;
+
+template<typename T>
+static NodeCallback auto expect_modifier(std::vector<T>& items) {
+	return [&items](ast::NodeCPtr node) -> bool {
+		fixed_point_t weight = 0;
+		bool successful = false;
+		bool ret = expect_key("factor", expect_fixed_point(assign_variable_callback(weight)), &successful)(node);
+		if (!successful) {
+			Logger::info("ConditionalWeight modifier missing factor key!");
+			return false;
+		}
+		ConditionScript condition;
+		ret &= condition.expect_script()(node);
+		items.emplace_back(std::make_pair(weight, std::move(condition)));
+		return ret;
+	};
+}
+
+node_callback_t ConditionalWeight::expect_conditional_weight(base_key_t base_key) {
+	return expect_dictionary_keys(
+		// TODO - add days and years as options with a shared expected count of ONE_EXACTLY
+		base_key_to_string(base_key), ONE_EXACTLY, expect_fixed_point(assign_variable_callback(base)),
+		"modifier", ZERO_OR_MORE, expect_modifier(condition_weight_items),
+		"group", ZERO_OR_MORE, [this](ast::NodeCPtr node) -> bool {
+			condition_weight_group_t items;
+			const bool ret = expect_dictionary_keys(
+				"modifier", ONE_OR_MORE, expect_modifier(items)
+			)(node);
+			if (!items.empty()) {
+				condition_weight_items.emplace_back(std::move(items));
+				return ret;
+			}
+			Logger::error("ConditionalWeight group must have at least one modifier!");
+			return false;
+		}
+	);
+}
+
+struct ConditionalWeight::parse_scripts_visitor_t {
+	GameManager const& game_manager;
+
+	bool operator()(condition_weight_t& condition_weight) const {
+		return condition_weight.second.parse_script(false, game_manager);
+	}
+	bool operator()(condition_weight_item_t& item) const {
+		return std::visit(*this, item);
+	}
+	template<typename T>
+	bool operator()(std::vector<T>& items) const {
+		bool ret = true;
+		for (T& item : items) {
+			ret &= (*this)(item);
+		}
+		return ret;
+	}
+};
+
+bool ConditionalWeight::parse_scripts(GameManager const& game_manager) {
+	return parse_scripts_visitor_t { game_manager }(condition_weight_items);
+}

--- a/src/openvic-simulation/scripts/ConditionalWeight.hpp
+++ b/src/openvic-simulation/scripts/ConditionalWeight.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "openvic-simulation/dataloader/NodeTools.hpp"
+#include "openvic-simulation/scripts/ConditionScript.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+
+namespace OpenVic {
+	struct ConditionalWeight {
+		using condition_weight_t = std::pair<fixed_point_t, ConditionScript>;
+		using condition_weight_group_t = std::vector<condition_weight_t>;
+		using condition_weight_item_t = std::variant<condition_weight_t, condition_weight_group_t>;
+
+		enum class base_key_t : uint8_t {
+			BASE, FACTOR, MONTHS
+		};
+		using enum base_key_t;
+
+	private:
+		fixed_point_t PROPERTY(base);
+		std::vector<condition_weight_item_t> PROPERTY(condition_weight_items);
+
+		struct parse_scripts_visitor_t;
+
+	public:
+		ConditionalWeight() = default;
+		ConditionalWeight(ConditionalWeight&&) = default;
+
+		static constexpr std::string_view base_key_to_string(base_key_t base_key) {
+			switch (base_key) {
+				case base_key_t::BASE: return "base";
+				case base_key_t::FACTOR: return "factor";
+				case base_key_t::MONTHS: return "months"; // TODO - add functionality for days or months or years
+				default: return "INVALID BASE KEY";
+			}
+		}
+
+		NodeTools::node_callback_t expect_conditional_weight(base_key_t base_key);
+
+		bool parse_scripts(GameManager const& game_manager);
+	};
+}

--- a/src/openvic-simulation/scripts/EffectScript.cpp
+++ b/src/openvic-simulation/scripts/EffectScript.cpp
@@ -1,0 +1,8 @@
+#include "EffectScript.hpp"
+
+using namespace OpenVic;
+
+bool EffectScript::_parse_script(ast::NodeCPtr root, GameManager& game_manager) {
+	// TODO - parse effect script
+	return true;
+}

--- a/src/openvic-simulation/scripts/EffectScript.hpp
+++ b/src/openvic-simulation/scripts/EffectScript.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "openvic-simulation/scripts/Script.hpp"
+
+namespace OpenVic {
+	struct GameManager;
+
+	struct EffectScript final : Script<GameManager&> {
+	protected:
+		bool _parse_script(ast::NodeCPtr root, GameManager& game_manager) override;
+	};
+}

--- a/src/openvic-simulation/scripts/Script.hpp
+++ b/src/openvic-simulation/scripts/Script.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "openvic-simulation/dataloader/NodeTools.hpp"
+
+namespace OpenVic {
+	template<typename... _Context>
+	struct Script {
+	private:
+		ast::NodeCPtr _root;
+
+	protected:
+		virtual bool _parse_script(ast::NodeCPtr root, _Context... context) = 0;
+
+	public:
+		Script() : _root { nullptr } {}
+		Script(Script&&) = default;
+
+		constexpr bool has_defines_node() const {
+			return _root != nullptr;
+		}
+
+		constexpr NodeTools::NodeCallback auto expect_script() {
+			return NodeTools::assign_variable_callback(_root);
+		}
+
+		bool parse_script(bool can_be_null, _Context... context) {
+			if (_root == nullptr) {
+				if (!can_be_null) {
+					Logger::error("Null/missing script node!");
+				}
+				return can_be_null;
+			}
+			const bool ret = _parse_script(_root, context...);
+			_root = nullptr;
+			return ret;
+		}
+	};
+}

--- a/src/openvic-simulation/types/Colour.hpp
+++ b/src/openvic-simulation/types/Colour.hpp
@@ -3,15 +3,9 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <charconv>
 #include <climits>
-#include <cmath>
-#include <compare>
 #include <cstdint>
-#include <iomanip>
 #include <limits>
-#include <span>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <tuple>


### PR DESCRIPTION
- Added base `Script` and derived `ConditionScript` and `EffectScript`, currently these just store a `NodeCPtr`.
- Added `ConditionalWeight`, implemented apart from support for `days` and `months` keys (which don't appear in vanilla), these will be added in another PR that adds support for keys with shared count limits.
- Added `Parser` cache to `Dataloader` and `parse_defines_cached`, used only for things which need to be stored for condition and effect parsing.
- Added script objects for every single script in the game, as well as code for storing each scripts' `NodeCPtr` in their object and triggering `parse_script` for every script object post-load.
- Added `allow_duplicates` argument to `NodeTools::expect_key`.
- Added some missing simple variables + code to load them from the defines.
- Minor style/format fixes (adding spaces after `if`, removing unused headers, etc.)