### PR TITLE
Disable AllowShortCompoundRequirementOnASingleLine

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -50,7 +50,7 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortEnumsOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Empty
-AllowShortCompoundRequirementOnASingleLine: true
+# AllowShortCompoundRequirementOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
 AllowShortLoopsOnASingleLine: false
 AlignTrailingComments:


### PR DESCRIPTION
Clang 18 format options should be commented out for now because Clang 18 is not out