### PR TITLE
Mutually exclusive rule groups + modded building rules

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -780,10 +780,6 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		Logger::error("Failed to set up modifier effects!");
 		ret = false;
 	}
-	if (!game_manager.get_politics_manager().get_rule_manager().setup_rules()) {
-		Logger::error("Failed to set up rules!");
-		ret = false;
-	}
 	if (!game_manager.get_define_manager().load_defines_file(parse_lua_defines(lookup_file(defines_file)).get_file_node())) {
 		Logger::error("Failed to load defines!");
 		ret = false;
@@ -830,19 +826,6 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		Logger::error("Failed to load pop types!");
 		ret = false;
 	}
-	if (!game_manager.get_politics_manager().load_issues_file(
-		game_manager.get_modifier_manager(),
-		parse_defines_cached(lookup_file(issues_file)).get_file_node()
-	)) {
-		Logger::error("Failed to load issues and reforms!");
-		ret = false;
-	}
-	if (!game_manager.get_pop_manager().load_delayed_parse_pop_type_data(
-		game_manager.get_politics_manager().get_issue_manager()
-	)) {
-		Logger::error("Failed to load delayed parse pop type data (promotion and issue weights)!");
-		ret = false;
-	}
 	if (!game_manager.get_economy_manager().load_production_types_file(game_manager.get_pop_manager(),
 		parse_defines_cached(lookup_file(production_types_file)).get_file_node()
 	)) {
@@ -860,6 +843,25 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		ret = false;
 	}
 	if (!_load_technologies(game_manager)) {
+		ret = false;
+	}
+	if (!game_manager.get_politics_manager().get_rule_manager().setup_rules(
+		game_manager.get_economy_manager().get_building_type_manager()
+	)) {
+		Logger::error("Failed to set up rules!");
+		ret = false;
+	}
+	if (!game_manager.get_politics_manager().load_issues_file(
+		game_manager.get_modifier_manager(),
+		parse_defines_cached(lookup_file(issues_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load issues and reforms!");
+		ret = false;
+	}
+	if (!game_manager.get_pop_manager().load_delayed_parse_pop_type_data(
+		game_manager.get_politics_manager().get_issue_manager()
+	)) {
+		Logger::error("Failed to load delayed parse pop type data (promotion and issue weights)!");
 		ret = false;
 	}
 	if (!game_manager.get_politics_manager().load_national_foci_file(

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -22,6 +22,8 @@ bool BuildingTypeManager::add_building_type(std::string_view identifier, ARGS) {
 		return false;
 	}
 
+	building_type_types.emplace(type);
+
 	return building_types.add_item({
 		identifier, type, std::move(modifier), on_completion, completion_size, max_level, std::move(goods_cost),
 		cost, build_time, visibility, on_map, default_enabled, production_type, pop_build_factory, strategic_factory,

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -74,6 +74,7 @@ namespace OpenVic {
 
 	private:
 		IdentifierRegistry<BuildingType> IDENTIFIER_REGISTRY(building_type);
+		string_set_t PROPERTY(building_type_types);
 		std::vector<BuildingType const*> PROPERTY(province_building_types);
 		BuildingType const* PROPERTY(port_building_type);
 

--- a/src/openvic-simulation/economy/Good.cpp
+++ b/src/openvic-simulation/economy/Good.cpp
@@ -93,25 +93,24 @@ bool GoodManager::load_goods_file(ast::NodeCPtr root) {
 bool GoodManager::generate_modifiers(ModifierManager& modifier_manager) const {
 	bool ret = true;
 
-	const auto good_modifier = [this, &modifier_manager, &ret](std::string_view name) -> void {
+	const auto good_modifier = [this, &modifier_manager, &ret](std::string_view name, bool positive_good) -> void {
 		ret &= modifier_manager.register_complex_modifier(name);
 		for (Good const& good : get_goods()) {
 			ret &= modifier_manager.add_modifier_effect(
-				StringUtils::append_string_views(name, "_", good.get_identifier()), true
+				StringUtils::append_string_views(name, "_", good.get_identifier()), positive_good
 			);
 		}
 	};
 
-	good_modifier("artisan_goods_input");
-	good_modifier("artisan_goods_output");
-	good_modifier("artisan_goods_throughput");
-	good_modifier("factory_goods_input");
-	good_modifier("factory_goods_output");
-	good_modifier("factory_goods_throughput");
-	good_modifier("rgo_goods_input");
-	good_modifier("rgo_goods_output");
-	good_modifier("rgo_goods_throughput");
-	good_modifier("rgo_size");
+	good_modifier("artisan_goods_input", false);
+	good_modifier("artisan_goods_output", true);
+	good_modifier("artisan_goods_throughput", true);
+	good_modifier("factory_goods_input", false);
+	good_modifier("factory_goods_output", true);
+	good_modifier("factory_goods_throughput", true);
+	good_modifier("rgo_goods_output", true);
+	good_modifier("rgo_goods_throughput", true);
+	good_modifier("rgo_size", true);
 
 	return ret;
 }

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -845,7 +845,7 @@ bool Map::load_climate_file(ModifierManager const& modifier_manager, ast::NodeCP
 					} else {
 						Logger::warning(
 							"Province with id ", province.get_identifier(),
-							"defined twice in climate ", identifier
+							" defined twice in climate ", identifier
 						);
 					}
 					return true;

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -111,6 +111,9 @@ bool ModifierManager::setup_modifier_effects() {
 	/* Country Modifier Effects */
 	ret &= add_modifier_effect("administrative_efficiency", true);
 	ret &= add_modifier_effect("administrative_efficiency_modifier", true);
+	ret &= add_modifier_effect("artisan_input", false);
+	ret &= add_modifier_effect("artisan_output", true);
+	ret &= add_modifier_effect("artisan_throughput", true);
 	ret &= add_modifier_effect("badboy", false, RAW_DECIMAL);
 	ret &= add_modifier_effect("cb_creation_speed", true); //seemingly works the same way as cb_generation_speed_modifier
 	ret &= add_modifier_effect("cb_generation_speed_modifier", true);
@@ -127,6 +130,7 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= add_modifier_effect("education_efficiency_modifier", true);
 	ret &= add_modifier_effect("factory_cost", false);
 	ret &= add_modifier_effect("factory_input", false);
+	ret &= add_modifier_effect("factory_maintenance", false);
 	ret &= add_modifier_effect("factory_output", true);
 	ret &= add_modifier_effect("factory_owner_cost", false);
 	ret &= add_modifier_effect("factory_throughput", true);
@@ -226,10 +230,10 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= add_modifier_effect("immigrant_attract", true);
 	ret &= add_modifier_effect("immigrant_push", false);
 	ret &= add_modifier_effect("life_rating", true);
-	ret &= add_modifier_effect("local_artisan_input", true);
+	ret &= add_modifier_effect("local_artisan_input", false);
 	ret &= add_modifier_effect("local_artisan_output", true);
 	ret &= add_modifier_effect("local_artisan_throughput", true);
-	ret &= add_modifier_effect("local_factory_input", true);
+	ret &= add_modifier_effect("local_factory_input", false);
 	ret &= add_modifier_effect("local_factory_output", true);
 	ret &= add_modifier_effect("local_factory_throughput", true);
 	ret &= add_modifier_effect("local_repair", true);

--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -95,8 +95,19 @@ bool IssueManager::add_reform(
 	}
 
 	if (group->get_type().is_uncivilised()) {
-		if (technology_cost <= 0) {
-			Logger::warning("Non-positive technology cost ", technology_cost, " found in uncivilised reform ", identifier, "!");
+		if (ordinal == 0) {
+			if (technology_cost != 0) {
+				Logger::warning(
+					"Non-zero technology cost ", technology_cost, " found in ordinal 0 uncivilised reform ", identifier, "!"
+				);
+			}
+		} else {
+			if (technology_cost <= 0) {
+				Logger::warning(
+					"Non-positive technology cost ", technology_cost, " found in ordinal ", ordinal,
+					" uncivilised reform ", identifier, "!"
+				);
+			}
 		}
 	} else if (technology_cost != 0) {
 		Logger::warning("Non-zero technology cost ", technology_cost, " found in civilised reform ", identifier, "!");
@@ -184,8 +195,11 @@ bool IssueManager::load_issues_file(ModifierManager const& modifier_manager, Rul
 			if (key == "party_issues") {
 				return expect_length(add_variable_callback(expected_issue_groups))(value);
 			} else {
+				static const string_set_t uncivilised_reform_groups {
+					"economic_reforms", "education_reforms", "military_reforms"
+				};
 				return expect_length(add_variable_callback(expected_reform_groups))(value)
-					& add_reform_type(key, key == "economic_reforms" || key == "education_reforms" || key == "military_reforms");
+					& add_reform_type(key, uncivilised_reform_groups.contains(key));
 			}
 		}
 	)(root);


### PR DESCRIPTION
- Rules now have a group, if that group is mutually exclusive then `trim_and_resolve_conflicts` removes disabled rules in that group as well as any enabled rules beyond the one with the lowest index (from order of definiton).
- Added `build_*` rules for every building type type (i.e. the `type` identifier of `BuildingType`s), with a special case for `railroad` which has type `infrastructure` but rule `build_railway`.
- Fixed reform tech cost warnings.
- Moved issue&reform and delayed poptype loading until after rules setup, which has itself been moved to after building type loading.
- Added some missing modifiers (for TGC compatibility), changed artisan/factory input modifiers not to be `positive_good` and removed RGO input modifiers.