### PR TITLE
Support culture restrictions for units

### DIFF
--- a/src/openvic-simulation/military/Unit.hpp
+++ b/src/openvic-simulation/military/Unit.hpp
@@ -17,7 +17,7 @@
 	Good::good_map_t&& build_cost, fixed_point_t supply_consumption, Good::good_map_t&& supply_cost
 
 #define LAND_PARAMS \
-	bool primary_culture, std::string_view sprite_override, std::string_view sprite_mount, \
+	LandUnit::allowed_cultures_t allowed_cultures, std::string_view sprite_override, std::string_view sprite_mount, \
 	std::string_view sprite_mount_attach_node, fixed_point_t reconnaissance, fixed_point_t attack, fixed_point_t defence, \
 	fixed_point_t discipline, fixed_point_t support, fixed_point_t maneuver, fixed_point_t siege
 
@@ -64,8 +64,10 @@ namespace OpenVic {
 	struct LandUnit : Unit {
 		friend struct UnitManager;
 
+		enum struct allowed_cultures_t { ALL_CULTURES, ACCEPTED_CULTURES, PRIMARY_CULTURE };
+
 	private:
-		const bool PROPERTY_CUSTOM_PREFIX(primary_culture, is);
+		const allowed_cultures_t PROPERTY(allowed_cultures);
 		const std::string PROPERTY(sprite_override);
 		const std::string PROPERTY(sprite_mount);
 		const std::string PROPERTY(sprite_mount_attach_node);


### PR DESCRIPTION
Victoria 2 has 3 options to restrict cultures for units.

1. Only primary culture
2. All accepted cultures
3. All cultures

The restriction is determined by a combination of `primary_culture = [yes/no]` & `accepted_culture = [yes/no]`.
The default value for both is no/false. `accepted_culture` overrules `primary_culture`.

This leaves 3 code paths:

1. primary_culture && !accepted_culture => Only primary culture
2. accepted_culture => All accepted cultures
3. !primary_culture && !accepted_culture => All cultures