### PR TITLE
More impassable adjacencies + WVPM mod fixes

### DIFF
--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -206,13 +206,13 @@ bool GameManager::load_hardcoded_defines() {
 						colour_argb_t::integer_type base_int;
 						switch (adj->get_type()) {
 							using enum Province::adjacency_t::type_t;
-						case LAND:		 base_int = 0x00FF00; break;
-						case WATER:		 base_int = 0x0000FF; break;
-						case COASTAL:	 base_int = 0xF9D199; break;
+						case LAND:       base_int = 0x00FF00; break;
+						case WATER:      base_int = 0x0000FF; break;
+						case COASTAL:    base_int = 0xF9D199; break;
 						case IMPASSABLE: base_int = 0x8B4513; break;
-						case STRAIT:	 base_int = 0x00FFFF; break;
-						case CANAL:		 base_int = 0x888888; break;
-						default:		 base_int = 0xFF0000; break;
+						case STRAIT:     base_int = 0x00FFFF; break;
+						case CANAL:      base_int = 0x888888; break;
+						default:         base_int = 0xFF0000; break;
 						}
 						base = colour_argb_t::from_integer(base_int).with_alpha(ALPHA_VALUE);
 						stripe = base;

--- a/src/openvic-simulation/history/CountryHistory.cpp
+++ b/src/openvic-simulation/history/CountryHistory.cpp
@@ -141,7 +141,7 @@ bool CountryHistoryMap::_load_history_entry(
 		"nonstate_consciousness", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(entry.nonstate_consciousness)),
 		"is_releasable_vassal", ZERO_OR_ONE, expect_bool(assign_variable_callback(entry.releasable_vassal)),
 		"decision", ZERO_OR_MORE, decision_manager.expect_decision_identifier(set_callback_pointer(entry.decisions)),
-		"govt_flag", ZERO_OR_ONE, [&entry, &politics_manager](ast::NodeCPtr value) -> bool {
+		"govt_flag", ZERO_OR_MORE, [&entry, &politics_manager](ast::NodeCPtr value) -> bool {
 			GovernmentTypeManager const& government_type_manager = politics_manager.get_government_type_manager();
 			GovernmentType const* government_type = nullptr;
 			bool flag_expected = false;

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -141,17 +141,6 @@ std::string_view Province::adjacency_t::get_type_name(type_t type) {
 	}
 }
 
-Province::adjacency_t* Province::get_adjacency_to(Province const* province) {
-	const std::vector<adjacency_t>::iterator it = std::find_if(adjacencies.begin(), adjacencies.end(),
-		[province](adjacency_t const& adj) -> bool { return adj.get_to() == province; }
-	);
-	if (it != adjacencies.end()) {
-		return &*it;
-	} else {
-		return nullptr;
-	}
-}
-
 Province::adjacency_t const* Province::get_adjacency_to(Province const* province) const {
 	const std::vector<adjacency_t>::const_iterator it = std::find_if(adjacencies.begin(), adjacencies.end(),
 		[province](adjacency_t const& adj) -> bool { return adj.get_to() == province; }

--- a/src/openvic-simulation/map/Province.hpp
+++ b/src/openvic-simulation/map/Province.hpp
@@ -146,10 +146,6 @@ namespace OpenVic {
 		void update_gamestate(Date today);
 		void tick(Date today);
 
-	private:
-		adjacency_t* get_adjacency_to(Province const* province);
-
-	public:
 		adjacency_t const* get_adjacency_to(Province const* province) const;
 		bool is_adjacent_to(Province const* province) const;
 		std::vector<adjacency_t const*> get_adjacencies_going_through(Province const* province) const;

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -96,8 +96,8 @@ bool RebelManager::load_rebels_file(
 			RebelType::icon_t icon = 0;
 			RebelType::area_t area = RebelType::area_t::ALL;
 			RebelType::government_map_t desired_governments;
-			RebelType::defection_t defection = RebelType::defection_t::ANY;
-			RebelType::independence_t independence = RebelType::independence_t::ANY;
+			RebelType::defection_t defection = RebelType::defection_t::NONE;
+			RebelType::independence_t independence = RebelType::independence_t::NONE;
 			uint16_t defect_delay = 0;
 			Ideology const* ideology = nullptr;
 			bool break_alliance_on_win = false, allow_all_cultures = true, allow_all_culture_groups = true,
@@ -127,9 +127,9 @@ bool RebelManager::load_rebels_file(
 						)(value);
 					}
 				),
-				"defection", ONE_EXACTLY,
+				"defection", ZERO_OR_ONE,
 					expect_identifier(expect_mapped_string(defection_map, assign_variable_callback(defection))),
-				"independence", ONE_EXACTLY,
+				"independence", ZERO_OR_ONE,
 					expect_identifier(expect_mapped_string(independence_map, assign_variable_callback(independence))),
 				"defect_delay", ONE_EXACTLY, expect_uint(assign_variable_callback(defect_delay)),
 				"ideology", ZERO_OR_ONE,


### PR DESCRIPTION
- Allow coastal and water adjacencies to be made impassable (they just get deleted rather than having an impassable adjacency saved, as we don't need them registered for blue borders like we do with impassable land adjacencies).
- Allow country history government flag overrides to appear in multiple blocks.
- Make rebel independence and defection non-mandatory and change defaults to `NONE`.