### PR TITLE
Added map_callback and expect_item_dictionary_reserve_length

### DIFF
--- a/src/openvic-simulation/country/Country.hpp
+++ b/src/openvic-simulation/country/Country.hpp
@@ -51,7 +51,7 @@ namespace OpenVic {
 	struct Country : HasIdentifierAndColour {
 		friend struct CountryManager;
 
-		using unit_names_map_t = ordered_map<Unit const*, std::vector<std::string>>;
+		using unit_names_map_t = ordered_map<Unit const*, name_list_t>;
 		using government_colour_map_t = ordered_map<GovernmentType const*, colour_t>;
 
 	private:

--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -2,7 +2,6 @@
 
 #include <openvic-dataloader/csv/Parser.hpp>
 #include <openvic-dataloader/v2script/Parser.hpp>
-#include <unordered_map> //keep this here or mac builds will fail
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 

--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -400,15 +400,26 @@ node_callback_t NodeTools::expect_dictionary_key_map(key_map_t key_map) {
 	);
 }
 
-node_callback_t NodeTools::name_list_callback(callback_t<std::vector<std::string>&&> callback) {
+node_callback_t NodeTools::name_list_callback(callback_t<name_list_t&&> callback) {
 	return [callback](ast::NodeCPtr node) -> bool {
-		std::vector<std::string> list;
+		name_list_t list;
 		bool ret = expect_list_reserve_length(
 			list, expect_identifier_or_string(vector_callback<std::string_view>(list))
 		)(node);
 		ret &= callback(std::move(list));
 		return ret;
 	};
+}
+
+std::ostream& OpenVic::operator<<(std::ostream& stream, name_list_t const& name_list) {
+	stream << '[';
+	if (!name_list.empty()) {
+		stream << name_list.front();
+		std::for_each(name_list.begin() + 1, name_list.end(), [&stream](std::string const& name) -> void {
+			stream << ", " << name;
+		});
+	}
+	return stream << ']';
 }
 
 callback_t<std::string_view> NodeTools::assign_variable_callback_string(std::string& var) {

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
@@ -9,12 +9,11 @@
 using namespace OpenVic;
 
 DiplomaticActionType::DiplomaticActionType(DiplomaticActionType::Initializer&& initializer)
-	: commit_action_caller { std::move(initializer.commit) },
-	  allowed_to_commit { std::move(initializer.allowed) }, get_acceptance { std::move(initializer.get_acceptance) } {}
+  : commit_action_caller { std::move(initializer.commit) },
+	allowed_to_commit { std::move(initializer.allowed) }, get_acceptance { std::move(initializer.get_acceptance) } {}
 
 CancelableDiplomaticActionType::CancelableDiplomaticActionType(CancelableDiplomaticActionType::Initializer&& initializer)
 	: allowed_to_cancel{std::move(initializer.allowed_cancel)}, DiplomaticActionType(std::move(initializer)) {}
-
 
 DiplomaticActionManager::DiplomaticActionManager() {}
 
@@ -49,7 +48,7 @@ DiplomaticActionTickCache DiplomaticActionManager::create_diplomatic_action_tick
 			result.acceptance = type.get_acceptance(result.argument);
 		}
 	});
-	
+
 	return result;
 }
 
@@ -78,38 +77,38 @@ bool DiplomaticActionManager::setup_diplomatic_actions() {
 		}
 	);
 	result &= add_diplomatic_action(
-		"give_military_access", 
+		"give_military_access",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"increase_relations", 
+		"increase_relations",
 		{
 			.commit = [](Argument& arg) {},
 			.allowed = [](const Argument& arg) { return false; },
 		}
 	);
 	result &= add_diplomatic_action(
-		"decrease_relations", 
+		"decrease_relations",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"war_subsidies", 
+		"war_subsidies",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"declare_war", 
+		"declare_war",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"offer_peace", 
+		"offer_peace",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"command_units", 
+		"command_units",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(
-		"discredit", 
+		"discredit",
 		{ [](Argument& arg) {} }
 	);
 	result &= add_diplomatic_action(

--- a/src/openvic-simulation/map/Map.cpp
+++ b/src/openvic-simulation/map/Map.cpp
@@ -893,6 +893,8 @@ bool Map::load_continent_file(ModifierManager const& modifier_manager, ast::Node
 				[&prov_list](Province const& province) -> bool {
 					if (province.continent == nullptr) {
 						prov_list.emplace_back(&province);
+					} else {
+						Logger::warning("Province ", province, " found in multiple continents");
 					}
 					return true;
 				}

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -36,12 +36,10 @@ bool Province::load_positions(BuildingTypeManager const& building_type_manager, 
 		"factory", ZERO_OR_ONE, expect_fvec2(assign_variable_callback(positions.factory)),
 		"building_construction", ZERO_OR_ONE, expect_fvec2(assign_variable_callback(positions.building_construction)),
 		"military_construction", ZERO_OR_ONE, expect_fvec2(assign_variable_callback(positions.military_construction)),
-		"building_position", ZERO_OR_ONE, building_type_manager.expect_building_type_dictionary(
+		"building_position", ZERO_OR_ONE, building_type_manager.expect_building_type_dictionary_reserve_length(
+			positions.building_position,
 			[this](BuildingType const& type, ast::NodeCPtr value) -> bool {
-				return expect_fvec2([this, &type](fvec2_t position) -> bool {
-					positions.building_position.emplace(&type, std::move(position));
-					return true;
-				})(value);
+				return expect_fvec2(map_callback(positions.building_position, &type))(value);
 			}
 		),
 		"building_rotation", ZERO_OR_ONE, building_type_manager.expect_building_type_decimal_map(

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -122,10 +122,15 @@ bool WargoalTypeManager::load_wargoal_file(ast::NodeCPtr root) {
 					};
 					const decltype(peace_modifier_map)::const_iterator it = peace_modifier_map.find(key);
 					if (it != peace_modifier_map.end()) {
-						return expect_fixed_point([&modifiers, peace_modifier = it->second](fixed_point_t val) -> bool {
-							modifiers[peace_modifier] = val;
-							return true;
-						})(value);
+						return expect_fixed_point(
+							[&modifiers, &identifier, &key, peace_modifier = it->second](fixed_point_t val) -> bool {
+								if (modifiers.emplace(peace_modifier, val).second) {
+									return true;
+								}
+								Logger::error("Duplicate peace modifier ", key, " in wargoal ", identifier, "!");
+								return false;
+							}
+						)(value);
 					}
 
 					Logger::error("Modifier ", key, " in wargoal ", identifier, " is invalid.");

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -23,7 +23,6 @@ namespace OpenVic {
 
 	public:
 		using pop_promotion_map_t = fixed_point_map_t<PopType const*>;
-		using party_loyalty_map_t = fixed_point_map_t<Ideology const*>;
 		using production_map_t = fixed_point_map_t<Good const*>;
 
 	private:
@@ -31,8 +30,9 @@ namespace OpenVic {
 		NationalFocusGroup const& PROPERTY(group);
 		ModifierValue PROPERTY(modifiers);
 		pop_promotion_map_t PROPERTY(encouraged_promotion);
-		party_loyalty_map_t PROPERTY(encouraged_loyalty);
 		production_map_t PROPERTY(encouraged_production);
+		Ideology const* PROPERTY(loyalty_ideology);
+		fixed_point_t PROPERTY(loyalty_value);
 		ConditionScript PROPERTY(limit);
 
 		NationalFocus(
@@ -41,8 +41,9 @@ namespace OpenVic {
 			NationalFocusGroup const& new_group,
 			ModifierValue&& new_modifiers,
 			pop_promotion_map_t&& new_encouraged_promotion,
-			party_loyalty_map_t&& new_encouraged_loyalty,
 			production_map_t&& new_encouraged_production,
+			Ideology const* new_loyalty_ideology,
+			fixed_point_t new_loyalty_value,
 			ConditionScript&& new_limit
 		);
 
@@ -66,8 +67,9 @@ namespace OpenVic {
 			NationalFocusGroup const& group,
 			ModifierValue&& modifiers,
 			NationalFocus::pop_promotion_map_t&& encouraged_promotion,
-			NationalFocus::party_loyalty_map_t&& encouraged_loyalty,
 			NationalFocus::production_map_t&& encouraged_production,
+			Ideology const* loyalty_ideology,
+			fixed_point_t loyalty_value,
 			ConditionScript&& limit
 		);
 

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -115,17 +115,14 @@ bool RebelManager::load_rebels_file(
 				"icon", ONE_EXACTLY, expect_uint(assign_variable_callback(icon)),
 				"area", ONE_EXACTLY, expect_identifier(expect_mapped_string(area_map, assign_variable_callback(area))),
 				"break_alliance_on_win", ZERO_OR_ONE, expect_bool(assign_variable_callback(break_alliance_on_win)),
-				"government", ONE_EXACTLY, government_type_manager.expect_government_type_dictionary(
-					[this, &government_type_manager, &desired_governments](GovernmentType const& from,
-						ast::NodeCPtr value) -> bool {
-						if (desired_governments.contains(&from)) {
-							Logger::error("Duplicate \"from\" government type in rebel type: ", from.get_identifier());
-							return false;
-						}
+				"government", ONE_EXACTLY, government_type_manager.expect_government_type_dictionary_reserve_length(
+					desired_governments,
+					[this, &government_type_manager, &desired_governments](
+						GovernmentType const& from, ast::NodeCPtr value
+					) -> bool {
 						return government_type_manager.expect_government_type_identifier(
 							[&desired_governments, &from](GovernmentType const& to) -> bool {
-								desired_governments.emplace(&from, &to);
-								return true;
+								return map_callback(desired_governments, &from)(&to);
 							}
 						)(value);
 					}

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -16,7 +16,7 @@ CultureGroup::CultureGroup(
 
 Culture::Culture(
 	std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group,
-	std::vector<std::string>&& new_first_names, std::vector<std::string>&& new_last_names
+	name_list_t&& new_first_names, name_list_t&& new_last_names
 ) : HasIdentifierAndColour { new_identifier, new_colour, false }, group { new_group },
 	first_names { std::move(new_first_names) }, last_names { std::move(new_last_names) } {}
 
@@ -51,8 +51,8 @@ bool CultureManager::add_culture_group(
 }
 
 bool CultureManager::add_culture(
-	std::string_view identifier, colour_t colour, CultureGroup const& group, std::vector<std::string>&& first_names,
-	std::vector<std::string>&& last_names
+	std::string_view identifier, colour_t colour, CultureGroup const& group, name_list_t&& first_names,
+	name_list_t&& last_names
 ) {
 	if (!culture_groups.is_locked()) {
 		Logger::error("Cannot register cultures until culture groups are locked!");
@@ -99,7 +99,7 @@ bool CultureManager::_load_culture(
 ) {
 
 	colour_t colour = colour_t::null();
-	std::vector<std::string> first_names, last_names;
+	name_list_t first_names, last_names;
 
 	bool ret = expect_dictionary_keys(
 		"color", ONE_EXACTLY, expect_colour(assign_variable_callback(colour)),

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -40,14 +40,14 @@ namespace OpenVic {
 
 	private:
 		CultureGroup const& PROPERTY(group);
-		const std::vector<std::string> PROPERTY(first_names);
-		const std::vector<std::string> PROPERTY(last_names);
+		const name_list_t PROPERTY(first_names);
+		const name_list_t PROPERTY(last_names);
 
 		// TODO - radicalism, primary tag
 
 		Culture(
 			std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group,
-			std::vector<std::string>&& new_first_names, std::vector<std::string>&& new_last_names
+			name_list_t&& new_first_names, name_list_t&& new_last_names
 		);
 
 	public:
@@ -75,8 +75,8 @@ namespace OpenVic {
 		);
 
 		bool add_culture(
-			std::string_view identifier, colour_t colour, CultureGroup const& group, std::vector<std::string>&& first_names,
-			std::vector<std::string>&& last_names
+			std::string_view identifier, colour_t colour, CultureGroup const& group, name_list_t&& first_names,
+			name_list_t&& last_names
 		);
 
 		bool load_graphical_culture_type_file(ast::NodeCPtr root);

--- a/src/openvic-simulation/scripts/Condition.cpp
+++ b/src/openvic-simulation/scripts/Condition.cpp
@@ -721,7 +721,7 @@ node_callback_t ConditionManager::expect_condition_node_list(
 		};
 
 		bool ret = conditions.expect_item_dictionary_and_default(
-			expect_node, top_scope ? top_scope_fallback : key_value_invalid_callback
+			top_scope ? top_scope_fallback : key_value_invalid_callback, expect_node
 		)(node);
 		if (!ret) {
 			Logger::error("Error parsing condition node:\n", node);

--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <ostream>
+
+#include "openvic-simulation/types/Colour.hpp"
+#include "openvic-simulation/utility/Getters.hpp"
+
+namespace OpenVic {
+	constexpr bool valid_basic_identifier_char(char c) {
+		return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_';
+	}
+	constexpr bool valid_basic_identifier(std::string_view identifier) {
+		return std::all_of(identifier.begin(), identifier.end(), valid_basic_identifier_char);
+	}
+	constexpr std::string_view extract_basic_identifier_prefix(std::string_view identifier) {
+		size_t len = 0;
+		while (len < identifier.size() && valid_basic_identifier_char(identifier[len])) {
+			++len;
+		}
+		return { identifier.data(), len };
+	}
+
+	/*
+	 * Base class for objects with a non-empty string identifier. Uniquely named instances of a type derived from this class
+	 * can be entered into an IdentifierRegistry instance.
+	 */
+	class HasIdentifier {
+		const std::string PROPERTY(identifier);
+
+	protected:
+		HasIdentifier(std::string_view new_identifier): identifier { new_identifier } {
+			assert(!identifier.empty());
+		}
+
+	public:
+		HasIdentifier(HasIdentifier const&) = delete;
+		HasIdentifier(HasIdentifier&&) = default;
+		HasIdentifier& operator=(HasIdentifier const&) = delete;
+		HasIdentifier& operator=(HasIdentifier&&) = delete;
+	};
+
+	inline std::ostream& operator<<(std::ostream& stream, HasIdentifier const& obj) {
+		return stream << obj.get_identifier();
+	}
+	inline std::ostream& operator<<(std::ostream& stream, HasIdentifier const* obj) {
+		return obj != nullptr ? stream << *obj : stream << "<NULL>";
+	}
+
+	/*
+	 * Base class for objects with associated colour information.
+	 */
+	template<IsColour ColourT>
+	class _HasColour {
+		const ColourT PROPERTY(colour);
+
+	protected:
+		_HasColour(ColourT new_colour, bool cannot_be_null): colour { new_colour } {
+			assert(!cannot_be_null || !colour.is_null());
+		}
+
+	public:
+		_HasColour(_HasColour const&) = delete;
+		_HasColour(_HasColour&&) = default;
+		_HasColour& operator=(_HasColour const&) = delete;
+		_HasColour& operator=(_HasColour&&) = delete;
+	};
+
+	/*
+	 * Base class for objects with a unique string identifier and associated colour information.
+	 */
+	template<IsColour ColourT>
+	class _HasIdentifierAndColour : public HasIdentifier, public _HasColour<ColourT> {
+	protected:
+		_HasIdentifierAndColour(std::string_view new_identifier, ColourT new_colour, bool cannot_be_null)
+			: HasIdentifier { new_identifier }, _HasColour<ColourT> { new_colour, cannot_be_null } {}
+
+	public:
+		_HasIdentifierAndColour(_HasIdentifierAndColour const&) = delete;
+		_HasIdentifierAndColour(_HasIdentifierAndColour&&) = default;
+		_HasIdentifierAndColour& operator=(_HasIdentifierAndColour const&) = delete;
+		_HasIdentifierAndColour& operator=(_HasIdentifierAndColour&&) = delete;
+	};
+
+	using HasIdentifierAndColour = _HasIdentifierAndColour<colour_t>;
+	using HasIdentifierAndAlphaColour = _HasIdentifierAndColour<colour_argb_t>;
+}

--- a/src/openvic-simulation/types/OrderedContainers.hpp
+++ b/src/openvic-simulation/types/OrderedContainers.hpp
@@ -146,7 +146,7 @@ namespace OpenVic {
 	template<class Key, class T, class Allocator = std::allocator<std::pair<Key, T>>, class IndexType = std::uint_least32_t>
 	using case_insensitive_deque_ordered_map =
 		deque_ordered_map<Key, T, case_insensitive_string_hash, case_insensitive_string_equal, Allocator, IndexType>;
-	
+
 	template<class Key, class T, class Allocator = std::allocator<std::pair<Key, T>>, class IndexType = std::uint_least32_t>
 	using case_insensitive_ordered_map = case_insensitive_vector_ordered_map<Key, T, Allocator, IndexType>;
 


### PR DESCRIPTION
- Added `map_callback`, which includes a check for duplicates, and used it in dataloading code.
- Added more `expect_item_dictionary` variants, including `and_length` and `reserve_length` variants.