### PR TITLE
Added NationalFocus ModifierEffects + bool variables

### DIFF
--- a/src/openvic-simulation/economy/Good.cpp
+++ b/src/openvic-simulation/economy/Good.cpp
@@ -112,5 +112,9 @@ bool GoodManager::generate_modifiers(ModifierManager& modifier_manager) const {
 	good_modifier("rgo_goods_throughput", true);
 	good_modifier("rgo_size", true);
 
+	for (Good const& good : get_goods()) {
+		ret &= modifier_manager.add_modifier_effect(good.get_identifier(), true, ModifierEffect::format_t::PERCENTAGE_DECIMAL);
+	}
+
 	return ret;
 }

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -7,20 +7,22 @@ NationalFocusGroup::NationalFocusGroup(std::string_view new_identifier) : HasIde
 
 NationalFocus::NationalFocus(
 	std::string_view new_identifier,
-	uint8_t new_icon,
 	NationalFocusGroup const& new_group,
+	uint8_t new_icon,
+	bool new_has_flashpoint,
+	bool new_own_provinces,
+	bool new_outliner_show_as_percent,
 	ModifierValue&& new_modifiers,
-	pop_promotion_map_t&& new_encouraged_promotion,
-	production_map_t&& new_encouraged_production,
 	Ideology const* new_loyalty_ideology,
 	fixed_point_t new_loyalty_value,
 	ConditionScript&& new_limit
 ) : HasIdentifier { new_identifier },
-	icon { new_icon },
 	group { new_group },
+	icon { new_icon },
+	has_flashpoint { new_has_flashpoint },
+	own_provinces { new_own_provinces },
+	outliner_show_as_percent { new_outliner_show_as_percent },
 	modifiers { std::move(new_modifiers) },
-	encouraged_promotion { std::move(new_encouraged_promotion) },
-	encouraged_production { std::move(new_encouraged_production) },
 	loyalty_ideology { new_loyalty_ideology },
 	loyalty_value { new_loyalty_value },
 	limit { std::move(new_limit) } {}
@@ -39,11 +41,12 @@ inline bool NationalFocusManager::add_national_focus_group(std::string_view iden
 
 inline bool NationalFocusManager::add_national_focus(
 	std::string_view identifier,
-	uint8_t icon,
 	NationalFocusGroup const& group,
+	uint8_t icon,
+	bool has_flashpoint,
+	bool own_provinces,
+	bool outliner_show_as_percent,
 	ModifierValue&& modifiers,
-	NationalFocus::pop_promotion_map_t&& encouraged_promotion,
-	NationalFocus::production_map_t&& encouraged_production,
 	Ideology const* loyalty_ideology,
 	fixed_point_t loyalty_value,
 	ConditionScript&& limit
@@ -63,7 +66,7 @@ inline bool NationalFocusManager::add_national_focus(
 		);
 	}
 	return national_foci.add_item({
-		identifier, icon, group, std::move(modifiers), std::move(encouraged_promotion), std::move(encouraged_production),
+		identifier, group, icon, has_flashpoint, own_provinces, outliner_show_as_percent, std::move(modifiers),
 		loyalty_ideology, loyalty_value, std::move(limit)
 	});
 }
@@ -90,40 +93,28 @@ bool NationalFocusManager::load_national_foci_file(
 			std::string_view identifier, ast::NodeCPtr node
 		) -> bool {
 			uint8_t icon = 0;
+			bool has_flashpoint = false, own_provinces = true, outliner_show_as_percent = false;
 			ModifierValue modifiers;
-			NationalFocus::pop_promotion_map_t promotions;
-			NationalFocus::production_map_t production;
 			Ideology const* loyalty_ideology = nullptr;
 			fixed_point_t loyalty_value = 0;
-			ConditionScript limit { scope_t::PROVINCE | scope_t::COUNTRY, scope_t::PROVINCE | scope_t::COUNTRY, scope_t::NO_SCOPE };
+			ConditionScript limit {
+				scope_t::PROVINCE | scope_t::COUNTRY, scope_t::PROVINCE | scope_t::COUNTRY, scope_t::NO_SCOPE
+			};
 
-			bool ret = modifier_manager.expect_modifier_value_and_keys_and_default(
+			bool ret = modifier_manager.expect_modifier_value_and_keys(
 				move_variable_callback(modifiers),
-				[&promotions, &pop_manager, &production, &good_manager, &modifiers, &modifier_manager](
-					std::string_view key, ast::NodeCPtr value
-				) -> bool {
-					PopType const* pop_type = pop_manager.get_pop_type_by_identifier(key);
-					if (pop_type != nullptr) {
-						return expect_fixed_point(map_callback(promotions, pop_type))(value);
-					}
-					Good const* good = good_manager.get_good_by_identifier(key);
-					if (good != nullptr) {
-						return expect_fixed_point(map_callback(production, good))(value);
-					}
-					return key_value_invalid_callback(key, value);
-				},
 				"icon", ONE_EXACTLY, expect_uint(assign_variable_callback(icon)),
 				"ideology", ZERO_OR_ONE,
 					ideology_manager.expect_ideology_identifier(assign_variable_callback_pointer(loyalty_ideology)),
 				"loyalty_value", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(loyalty_value)),
 				"limit", ZERO_OR_ONE, limit.expect_script(),
-				"has_flashpoint", ZERO_OR_ONE, success_callback, // special case, include in limit
-				"own_provinces", ZERO_OR_ONE, success_callback, // special case, include in limit
-				"outliner_show_as_percent", ZERO_OR_ONE, success_callback // special case
+				"has_flashpoint", ZERO_OR_ONE, expect_bool(assign_variable_callback(has_flashpoint)),
+				"own_provinces", ZERO_OR_ONE, expect_bool(assign_variable_callback(own_provinces)),
+				"outliner_show_as_percent", ZERO_OR_ONE, expect_bool(assign_variable_callback(outliner_show_as_percent))
 			)(node);
 
 			ret &= add_national_focus(
-				identifier, icon, group, std::move(modifiers), std::move(promotions), std::move(production),
+				identifier, group, icon, has_flashpoint, own_provinces, outliner_show_as_percent, std::move(modifiers),
 				loyalty_ideology, loyalty_value, std::move(limit)
 			);
 

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -21,27 +21,25 @@ namespace OpenVic {
 	struct NationalFocus : HasIdentifier {
 		friend struct NationalFocusManager;
 
-	public:
-		using pop_promotion_map_t = fixed_point_map_t<PopType const*>;
-		using production_map_t = fixed_point_map_t<Good const*>;
-
 	private:
-		uint8_t PROPERTY(icon);
 		NationalFocusGroup const& PROPERTY(group);
+		uint8_t PROPERTY(icon);
+		bool PROPERTY(has_flashpoint);
+		bool PROPERTY(own_provinces);
+		bool PROPERTY(outliner_show_as_percent);
 		ModifierValue PROPERTY(modifiers);
-		pop_promotion_map_t PROPERTY(encouraged_promotion);
-		production_map_t PROPERTY(encouraged_production);
 		Ideology const* PROPERTY(loyalty_ideology);
 		fixed_point_t PROPERTY(loyalty_value);
 		ConditionScript PROPERTY(limit);
 
 		NationalFocus(
 			std::string_view new_identifier,
-			uint8_t new_icon,
 			NationalFocusGroup const& new_group,
+			uint8_t new_icon,
+			bool new_has_flashpoint,
+			bool new_own_provinces,
+			bool new_outliner_show_as_percent,
 			ModifierValue&& new_modifiers,
-			pop_promotion_map_t&& new_encouraged_promotion,
-			production_map_t&& new_encouraged_production,
 			Ideology const* new_loyalty_ideology,
 			fixed_point_t new_loyalty_value,
 			ConditionScript&& new_limit
@@ -63,11 +61,12 @@ namespace OpenVic {
 
 		inline bool add_national_focus(
 			std::string_view identifier,
-			uint8_t icon,
 			NationalFocusGroup const& group,
+			uint8_t icon,
+			bool has_flashpoint,
+			bool own_provinces,
+			bool outliner_show_as_percent,
 			ModifierValue&& modifiers,
-			NationalFocus::pop_promotion_map_t&& encouraged_promotion,
-			NationalFocus::production_map_t&& encouraged_production,
 			Ideology const* loyalty_ideology,
 			fixed_point_t loyalty_value,
 			ConditionScript&& limit

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -334,6 +334,11 @@ bool PopManager::generate_modifiers(ModifierManager& modifier_manager) const {
 		strata_modifier("_everyday_needs", false);
 		strata_modifier("_luxury_needs", false);
 	}
+
+	for (PopType const& pop_type : get_pop_types()) {
+		ret &= modifier_manager.add_modifier_effect(pop_type.get_identifier(), true);
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
- Added `<pop_type> = 0.2` (means 20%) and `<good> = 20` (means 20%) modifiers, replacing custom system used for them in `NationalFocus`.
- Added `has_flashpoint` (default false), `own_provinces` (default true), and `outliner_show_as_percent` (default false) bool variables to `NationalFocus`