### PR TITLE
Reworked `UniqueKeyRegistry` template params

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -836,8 +836,10 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		ret = false;
 	}
 	if (!_load_technologies(game_manager)) {
+		Logger::error("Failed to load technologies!");
 		ret = false;
 	}
+	game_manager.get_modifier_manager().lock_modifier_effects();
 	if (!game_manager.get_politics_manager().get_rule_manager().setup_rules(
 		game_manager.get_economy_manager().get_building_type_manager()
 	)) {

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -98,9 +98,7 @@ bool ModifierManager::add_modifier_effect(std::string_view identifier, bool posi
 		Logger::error("Invalid modifier effect identifier - empty!");
 		return false;
 	}
-	return modifier_effects.add_item(
-		std::make_unique<ModifierEffect>(std::move(identifier), std::move(positive_good), std::move(format))
-	);
+	return modifier_effects.add_item({ std::move(identifier), positive_good, format });
 }
 
 bool ModifierManager::setup_modifier_effects() {


### PR DESCRIPTION
`UniqueKeyRegistry` now has 4 concept-validated template paramters:
- `ValueInfo` - contains the type being registered + a unique identifier string getter function. Currently implemented for `HasIdentifier` (used where the string and other attributes are known beforehand) and `Named` (used where the string and other attributes are loaded post-construction via a chain of key-callback adding virtual functions).
- `_ItemInfo` - contains the type the `Value`s are actually stored in, so either `Value` itself of `std::unique_ptr<Value>`. as well as item->value [const] reference conversion functions.
- `_StorageInfo` - contains the container the items are put in, either `std::vector` or `std::deque`, as well as an index type used in the string-index lookup map together with functions to get the back item's index and to turn an index into an item. For `std::vector` this uses the integer index, but for `std::deque` it is a pointer to the item, as the pointer is safe from reallocation and integer index lookup requires two dereferences for `std::deque`.
- `IdentifierMapInfo` - holds the hash and key-equals types for `ordered_map`, used for choosing between case sensitive and case insensitive string lookup.