### PR TITLE
Parse missing variables, Logger counting, misc cleanup

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -131,9 +131,10 @@ int main(int argc, char const* argv[]) {
 			return -1;
 		}
 	}
-	Dataloader::path_vector_t roots = { root };
+	Dataloader::path_vector_t roots { root };
 	while (argn < argc) {
-		roots.emplace_back(root / argv[argn++]);
+		static const fs::path mod_directory = "mod";
+		roots.emplace_back(root / mod_directory / argv[argn++]);
 	}
 
 	std::cout << "!!! HEADLESS SIMULATION START !!!" << std::endl;
@@ -143,6 +144,9 @@ int main(int argc, char const* argv[]) {
 	std::cout << "!!! HEADLESS SIMULATION END !!!" << std::endl;
 
 	std::cout << "\nLoad returned: " << (ret ? "SUCCESS" : "FAILURE") << std::endl;
+
+	std::cout << "\nLogger Summary: Info = " << Logger::get_info_count() << ", Warning = " << Logger::get_warning_count()
+		<< ", Error = " << Logger::get_error_count() << std::endl;
 
 	return ret ? 0 : -1;
 }

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -791,12 +791,6 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		Logger::error("Failed to load graphical culture types!");
 		ret = false;
 	}
-	if (!game_manager.get_pop_manager().get_culture_manager().load_culture_file(
-		parse_defines(lookup_file(culture_file)).get_file_node()
-	)) {
-		Logger::error("Failed to load cultures!");
-		ret = false;
-	}
 	if (!game_manager.get_pop_manager().get_religion_manager().load_religion_file(
 		parse_defines(lookup_file(religion_file)).get_file_node()
 	)) {
@@ -926,6 +920,12 @@ bool Dataloader::load_defines(GameManager& game_manager) {
 		game_manager, *this, parse_defines(lookup_file(countries_file)).get_file_node()
 	)) {
 		Logger::error("Failed to load countries!");
+		ret = false;
+	}
+	if (!game_manager.get_pop_manager().get_culture_manager().load_culture_file(
+		game_manager.get_country_manager(), parse_defines(lookup_file(culture_file)).get_file_node()
+	)) {
+		Logger::error("Failed to load cultures!");
 		ret = false;
 	}
 	if (!_load_decisions(game_manager)) {

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
@@ -57,7 +57,6 @@ namespace OpenVic {
 
 		using allowed_to_cancel_func = FunctionRef<bool(const Argument&)>;
 
-
 		static bool allowed_to_cancel_default(const Argument& argument) {
 			return true;
 		}

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -97,13 +97,13 @@ bool BuildingTypeManager::load_buildings_file(
 	lock_building_types();
 
 	for (BuildingType const& building_type : building_types.get_items()) {
-		std::string max_modifier_prefix = "max_";
-		std::string min_modifier_prefix = "min_build_";
-		modifier_manager.add_modifier_effect(
-			max_modifier_prefix.append(building_type.get_identifier()), true, ModifierEffect::format_t::INT
+		static constexpr std::string_view max_prefix = "max_";
+		static constexpr std::string_view min_prefix = "min_build_";
+		ret &= modifier_manager.add_modifier_effect(
+			StringUtils::append_string_views(max_prefix, building_type.get_identifier()), true, ModifierEffect::format_t::INT
 		);
-		modifier_manager.add_modifier_effect(
-			min_modifier_prefix.append(building_type.get_identifier()), false, ModifierEffect::format_t::INT
+		ret &= modifier_manager.add_modifier_effect(
+			StringUtils::append_string_views(min_prefix, building_type.get_identifier()), false, ModifierEffect::format_t::INT
 		);
 
 		if (building_type.is_in_province()) {

--- a/src/openvic-simulation/economy/ProductionType.hpp
+++ b/src/openvic-simulation/economy/ProductionType.hpp
@@ -21,7 +21,9 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(desired_workforce_share);
 
 		Job(
-			PopType const* new_pop_type, effect_t new_effect_type, fixed_point_t new_effect_multiplier,
+			PopType const* new_pop_type,
+			effect_t new_effect_type,
+			fixed_point_t new_effect_multiplier,
 			fixed_point_t new_desired_workforce_share
 		);
 
@@ -37,7 +39,7 @@ namespace OpenVic {
 		using bonus_t = std::pair<ConditionScript, fixed_point_t>;
 
 	private:
-		const Job PROPERTY(owner);
+		const std::optional<Job> PROPERTY(owner);
 		std::vector<Job> PROPERTY(jobs);
 		const template_type_t PROPERTY(template_type);
 		const Pop::pop_size_t PROPERTY(base_workforce_size);
@@ -54,13 +56,23 @@ namespace OpenVic {
 		const bool PROPERTY_CUSTOM_PREFIX(mine, is);
 
 		ProductionType(
-			std::string_view new_identifier, Job new_owner, std::vector<Job> new_jobs, template_type_t new_template_type,
-			Pop::pop_size_t new_base_workforce_size, Good::good_map_t&& new_input_goods, Good const* new_output_goods,
-			fixed_point_t new_base_output_quantity, std::vector<bonus_t>&& new_bonuses, Good::good_map_t&& new_efficiency, bool new_is_coastal,
-			bool new_is_farm, bool new_is_mine
+			std::string_view new_identifier,
+			std::optional<Job> new_owner,
+			std::vector<Job>&& new_jobs,
+			template_type_t new_template_type,
+			Pop::pop_size_t new_base_workforce_size,
+			Good::good_map_t&& new_input_goods,
+			Good const* new_output_goods,
+			fixed_point_t new_base_output_quantity,
+			std::vector<bonus_t>&& new_bonuses,
+			Good::good_map_t&& new_maintenance_requirements,
+			bool new_is_coastal,
+			bool new_is_farm,
+			bool new_is_mine
 		);
 
 		bool parse_scripts(GameManager const& game_manager);
+
 	public:
 		ProductionType(ProductionType&&) = default;
 	};
@@ -71,19 +83,29 @@ namespace OpenVic {
 		PopType::sprite_t PROPERTY(rgo_owner_sprite);
 
 		NodeTools::node_callback_t _expect_job(
-			GoodManager const& good_manager, PopManager const& pop_manager, NodeTools::callback_t<Job&&> cb
+			GoodManager const& good_manager, PopManager const& pop_manager, NodeTools::callback_t<Job&&> callback
 		);
 		NodeTools::node_callback_t _expect_job_list(
-			GoodManager const& good_manager, PopManager const& pop_manager, NodeTools::callback_t<std::vector<Job>&&> cb
+			GoodManager const& good_manager, PopManager const& pop_manager, NodeTools::callback_t<std::vector<Job>&&> callback
 		);
 
 	public:
 		ProductionTypeManager();
 
 		bool add_production_type(
-			std::string_view identifier, Job owner, std::vector<Job> employees, ProductionType::template_type_t template_type,
-			Pop::pop_size_t workforce, Good::good_map_t&& input_goods, Good const* output_goods, fixed_point_t value,
-			std::vector<ProductionType::bonus_t>&& bonuses, Good::good_map_t&& efficiency, bool coastal, bool farm, bool mine
+			std::string_view identifier,
+			std::optional<Job> owner,
+			std::vector<Job>&& employees,
+			ProductionType::template_type_t template_type,
+			Pop::pop_size_t workforce,
+			Good::good_map_t&& input_goods,
+			Good const* output_goods,
+			fixed_point_t value,
+			std::vector<ProductionType::bonus_t>&& bonuses,
+			Good::good_map_t&& maintenance_requirements,
+			bool coastal,
+			bool farm,
+			bool mine
 		);
 
 		bool load_production_types_file(GoodManager const& good_manager, PopManager const& pop_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -36,7 +36,11 @@ bool ProvinceHistoryMap::_load_history_entry(
 			BuildingType const* building_type = building_type_manager.get_building_type_by_identifier(key);
 			if (building_type != nullptr) {
 				if (building_type->is_in_province()) {
-					return expect_uint<BuildingType::level_t>(map_callback(entry.province_buildings, building_type))(value);
+					return expect_uint<BuildingType::level_t>(
+						/* This is set to warn to prevent vanilla from always having errors because
+						 * of a duplicate railroad entry in the 1861.1.1 history of Manchester (278). */
+						map_callback(entry.province_buildings, building_type, true)
+					)(value);
 				} else {
 					Logger::error(
 						"Attempted to add state building \"", building_type, "\" at top scope of province history for ",
@@ -68,7 +72,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 		),
 		"party_loyalty", ZERO_OR_MORE, [&ideology_manager, &entry](ast::NodeCPtr node) -> bool {
 			Ideology const* ideology = nullptr;
-			fixed_point_t amount = 0; // percent I do believe
+			fixed_point_t amount = 0; /* PERCENTAGE_DECIMAL */
 
 			bool ret = expect_dictionary_keys(
 				"ideology", ONE_EXACTLY, ideology_manager.expect_ideology_identifier(
@@ -90,7 +94,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 				"building", ONE_EXACTLY, building_type_manager.expect_building_type_identifier(
 					assign_variable_callback_pointer(building_type)
 				),
-				"upgrade", ZERO_OR_ONE, success_callback // doesn't appear to have an effect
+				"upgrade", ZERO_OR_ONE, success_callback /* Doesn't appear to have an effect */
 			)(node);
 			if (building_type != nullptr) {
 				if (!building_type->is_in_province()) {

--- a/src/openvic-simulation/military/Deployment.hpp
+++ b/src/openvic-simulation/military/Deployment.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -22,11 +21,12 @@ namespace OpenVic {
 		LeaderTrait const* PROPERTY(personality);
 		LeaderTrait const* PROPERTY(background);
 		fixed_point_t      PROPERTY(prestige);
+		std::string        PROPERTY(picture);
 
 	public:
 		Leader(
 			std::string_view new_name, Unit::type_t new_type, Date new_date, LeaderTrait const* new_personality,
-			LeaderTrait const* new_background, fixed_point_t new_prestige
+			LeaderTrait const* new_background, fixed_point_t new_prestige, std::string_view new_picture
 		);
 	};
 

--- a/src/openvic-simulation/military/Unit.cpp
+++ b/src/openvic-simulation/military/Unit.cpp
@@ -104,10 +104,10 @@ bool UnitManager::load_unit_file(GoodManager const& good_manager, ast::NodeCPtr 
 		}
 
 		key_map_t key_map;
-		// shared
+		/* Shared dictionary entries */
 		ret &= add_key_map_entries(key_map,
 			"icon", ONE_EXACTLY, expect_uint(assign_variable_callback(icon)),
-			"type", ONE_EXACTLY, success_callback,
+			"type", ONE_EXACTLY, success_callback, /* Already loaded above using expect_key */
 			"sprite", ONE_EXACTLY, expect_identifier(assign_variable_callback(sprite)),
 			"active", ZERO_OR_ONE, expect_bool(assign_variable_callback(active)),
 			"unit_type", ONE_EXACTLY, expect_identifier(assign_variable_callback(unit_type)),

--- a/src/openvic-simulation/misc/Event.cpp
+++ b/src/openvic-simulation/misc/Event.cpp
@@ -169,7 +169,7 @@ bool EventManager::load_event_file(IssueManager const& issue_manager, ast::NodeC
 					};
 
 					bool ret = expect_dictionary_keys_and_default(
-						key_value_success_callback,
+						key_value_success_callback, /* Option effects, passed to the EffectScript below */
 						"name", ONE_EXACTLY, expect_identifier_or_string(assign_variable_callback(name)),
 						"ai_chance", ZERO_OR_ONE, ai_chance.expect_conditional_weight(ConditionalWeight::FACTOR)
 					)(node);

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -366,10 +366,10 @@ bool ModifierManager::parse_scripts(GameManager const& game_manager) {
 key_value_callback_t ModifierManager::_modifier_effect_callback(
 	ModifierValue& modifier, key_value_callback_t default_callback, ModifierEffectValidator auto effect_validator
 ) const {
-	const auto add_modifier_cb = [this, &modifier,
-								  effect_validator](ModifierEffect const* effect, ast::NodeCPtr value) -> bool {
+	const auto add_modifier_cb = [this, &modifier, effect_validator](
+		ModifierEffect const* effect, ast::NodeCPtr value
+	) -> bool {
 		if (effect_validator(*effect)) {
-
 			static const case_insensitive_string_set_t no_effect_modifiers {
 				"boost_strongest_party", "poor_savings_modifier",	"local_artisan_input",	  "local_artisan_throughput",
 				"local_artisan_output",	 "artisan_input",			"artisan_throughput",	  "artisan_output",
@@ -385,8 +385,9 @@ key_value_callback_t ModifierManager::_modifier_effect_callback(
 		}
 	};
 
-	const auto add_flattened_modifier_cb =
-		[this, add_modifier_cb](std::string_view prefix, std::string_view key, ast::NodeCPtr value) -> bool {
+	const auto add_flattened_modifier_cb = [this, add_modifier_cb](
+		std::string_view prefix, std::string_view key, ast::NodeCPtr value
+	) -> bool {
 		const std::string flat_identifier = get_flat_identifier(prefix, key);
 		ModifierEffect const* effect = get_modifier_effect_by_identifier(flat_identifier);
 		if (effect != nullptr) {
@@ -397,7 +398,9 @@ key_value_callback_t ModifierManager::_modifier_effect_callback(
 		}
 	};
 
-	return [this, default_callback, add_modifier_cb, add_flattened_modifier_cb](std::string_view key, ast::NodeCPtr value) -> bool {
+	return [this, default_callback, add_modifier_cb, add_flattened_modifier_cb](
+		std::string_view key, ast::NodeCPtr value
+	) -> bool {
 		ModifierEffect const* effect = get_modifier_effect_by_identifier(key);
 		if (effect != nullptr && value->is_type<ast::IdentifierNode>()) {
 			return add_modifier_cb(effect, value);
@@ -437,6 +440,7 @@ node_callback_t ModifierManager::expect_validated_modifier_value_and_default(
 		return ret;
 	};
 }
+
 node_callback_t ModifierManager::expect_validated_modifier_value(
 	callback_t<ModifierValue&&> modifier_callback, ModifierEffectValidator auto effect_validator
 ) const {

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -4,7 +4,6 @@
 
 #include "openvic-simulation/misc/Modifier.hpp"
 
-
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -5,6 +5,8 @@
 namespace OpenVic {
 
 	struct CultureManager;
+	struct Country;
+	struct CountryManager;
 
 	struct GraphicalCultureType : HasIdentifier {
 		friend struct CultureManager;
@@ -20,15 +22,14 @@ namespace OpenVic {
 		friend struct CultureManager;
 
 	private:
-		const std::string PROPERTY(leader);
+		std::string PROPERTY(leader);
 		GraphicalCultureType const& PROPERTY(unit_graphical_culture_type);
-		const bool PROPERTY(is_overseas);
-
-		// TODO - union tag
+		bool PROPERTY(is_overseas);
+		Country const* PROPERTY(union_country);
 
 		CultureGroup(
 			std::string_view new_identifier, std::string_view new_leader,
-			GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas
+			GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas, Country const* new_union_country
 		);
 
 	public:
@@ -40,14 +41,14 @@ namespace OpenVic {
 
 	private:
 		CultureGroup const& PROPERTY(group);
-		const name_list_t PROPERTY(first_names);
-		const name_list_t PROPERTY(last_names);
-
-		// TODO - radicalism, primary tag
+		name_list_t PROPERTY(first_names);
+		name_list_t PROPERTY(last_names);
+		fixed_point_t PROPERTY(radicalism);
+		Country const* PROPERTY(primary_country);
 
 		Culture(
-			std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group,
-			name_list_t&& new_first_names, name_list_t&& new_last_names
+			std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group, name_list_t&& new_first_names,
+			name_list_t&& new_last_names, fixed_point_t new_radicalism, Country const* new_primary_country
 		);
 
 	public:
@@ -61,25 +62,29 @@ namespace OpenVic {
 		IdentifierRegistry<Culture> IDENTIFIER_REGISTRY(culture);
 
 		bool _load_culture_group(
-			size_t& total_expected_cultures, GraphicalCultureType const* default_unit_graphical_culture_type,
-			std::string_view culture_group_key, ast::NodeCPtr culture_group_node
+			CountryManager const& country_manager, size_t& total_expected_cultures,
+			GraphicalCultureType const* default_unit_graphical_culture_type, std::string_view culture_group_key,
+			ast::NodeCPtr culture_group_node
 		);
-		bool _load_culture(CultureGroup const& culture_group, std::string_view culture_key, ast::NodeCPtr node);
+		bool _load_culture(
+			CountryManager const& country_manager, CultureGroup const& culture_group, std::string_view culture_key,
+			ast::NodeCPtr node
+		);
 
 	public:
 		bool add_graphical_culture_type(std::string_view identifier);
 
 		bool add_culture_group(
 			std::string_view identifier, std::string_view leader, GraphicalCultureType const* graphical_culture_type,
-			bool is_overseas
+			bool is_overseas, Country const* union_country
 		);
 
 		bool add_culture(
 			std::string_view identifier, colour_t colour, CultureGroup const& group, name_list_t&& first_names,
-			name_list_t&& last_names
+			name_list_t&& last_names, fixed_point_t radicalism, Country const* primary_country
 		);
 
 		bool load_graphical_culture_type_file(ast::NodeCPtr root);
-		bool load_culture_file(ast::NodeCPtr root);
+		bool load_culture_file(CountryManager const& country_manager, ast::NodeCPtr root);
 	};
 }

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -1,5 +1,6 @@
 #include "Pop.hpp"
 
+#include "openvic-simulation/military/Unit.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
 #include "openvic-simulation/politics/Issue.hpp"
 #include "openvic-simulation/politics/Rebel.hpp"
@@ -8,12 +9,28 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
+using enum PopType::income_type_t;
+
 Pop::Pop(
-	PopType const& new_type, Culture const& new_culture, Religion const& new_religion, pop_size_t new_size,
-	fixed_point_t new_militancy, fixed_point_t new_consciousness, RebelType const* new_rebel_type
-) : type { new_type }, culture { new_culture }, religion { new_religion }, size { new_size }, num_grown { 0 },
-	num_promoted { 0 }, num_demoted { 0 }, num_migrated_internal { 0 }, num_migrated_external { 0 },
-	num_migrated_colonial { 0 }, militancy { new_militancy }, consciousness { new_consciousness },
+	PopType const& new_type,
+	Culture const& new_culture,
+	Religion const& new_religion,
+	pop_size_t new_size,
+	fixed_point_t new_militancy,
+	fixed_point_t new_consciousness,
+	RebelType const* new_rebel_type
+) : type { new_type },
+	culture { new_culture },
+	religion { new_religion },
+	size { new_size },
+	num_grown { 0 },
+	num_promoted { 0 },
+	num_demoted { 0 },
+	num_migrated_internal { 0 },
+	num_migrated_external { 0 },
+	num_migrated_colonial { 0 },
+	militancy { new_militancy },
+	consciousness { new_consciousness },
 	rebel_type { new_rebel_type } {
 	assert(size > 0);
 }
@@ -21,25 +38,75 @@ Pop::Pop(
 Strata::Strata(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 
 PopType::PopType(
-	std::string_view new_identifier, colour_t new_colour, Strata const& new_strata, sprite_t new_sprite,
-	Good::good_map_t&& new_life_needs, Good::good_map_t&& new_everyday_needs, Good::good_map_t&& new_luxury_needs,
-	rebel_units_t&& new_rebel_units, Pop::pop_size_t new_max_size, Pop::pop_size_t new_merge_max_size,
-	bool new_state_capital_only, bool new_demote_migrant, bool new_is_artisan, bool new_allowed_to_vote, bool new_is_slave,
-	bool new_can_be_recruited, bool new_can_reduce_consciousness, bool new_administrative_efficiency, bool new_can_build,
-	bool new_factory, bool new_can_work_factory, bool new_unemployment, ConditionalWeight&& new_country_migration_target,
-	ConditionalWeight&& new_migration_target, poptype_weight_map_t&& new_promote_to, ideology_weight_map_t&& new_ideologies,
+	std::string_view new_identifier,
+	colour_t new_colour,
+	Strata const& new_strata,
+	sprite_t new_sprite,
+	Good::good_map_t&& new_life_needs,
+	Good::good_map_t&& new_everyday_needs,
+	Good::good_map_t&& new_luxury_needs,
+	income_type_t new_life_needs_income_types,
+	income_type_t new_everyday_needs_income_types,
+	income_type_t new_luxury_needs_income_types,
+	rebel_units_t&& new_rebel_units,
+	Pop::pop_size_t new_max_size,
+	Pop::pop_size_t new_merge_max_size,
+	bool new_state_capital_only,
+	bool new_demote_migrant,
+	bool new_is_artisan,
+	bool new_allowed_to_vote,
+	bool new_is_slave,
+	bool new_can_be_recruited,
+	bool new_can_reduce_consciousness,
+	bool new_administrative_efficiency,
+	bool new_can_invest,
+	bool new_factory,
+	bool new_can_work_factory,
+	bool new_unemployment,
+	fixed_point_t new_research_points,
+	fixed_point_t new_leadership_points,
+	fixed_point_t new_research_leadership_optimum,
+	fixed_point_t new_state_administration_multiplier,
+	PopType const* new_equivalent,
+	ConditionalWeight&& new_country_migration_target,
+	ConditionalWeight&& new_migration_target,
+	poptype_weight_map_t&& new_promote_to,
+	ideology_weight_map_t&& new_ideologies,
 	issue_weight_map_t&& new_issues
-) : HasIdentifierAndColour { new_identifier, new_colour, false }, strata { new_strata }, sprite { new_sprite },
-	life_needs { std::move(new_life_needs) }, everyday_needs { std::move(new_everyday_needs) },
-	luxury_needs { std::move(new_luxury_needs) }, rebel_units { std::move(new_rebel_units) }, max_size { new_max_size },
-	merge_max_size { new_merge_max_size }, state_capital_only { new_state_capital_only },
-	demote_migrant { new_demote_migrant }, is_artisan { new_is_artisan }, allowed_to_vote { new_allowed_to_vote },
-	is_slave { new_is_slave }, can_be_recruited { new_can_be_recruited },
-	can_reduce_consciousness { new_can_reduce_consciousness }, administrative_efficiency { new_administrative_efficiency },
-	can_build { new_can_build }, factory { new_factory }, can_work_factory { new_can_work_factory },
-	unemployment { new_unemployment }, country_migration_target { std::move(new_country_migration_target) },
-	migration_target { std::move(new_migration_target) }, promote_to { std::move(new_promote_to) },
-	ideologies { std::move(new_ideologies) }, issues { std::move(new_issues) } {
+) : HasIdentifierAndColour { new_identifier, new_colour, false },
+	strata { new_strata },
+	sprite { new_sprite },
+	life_needs { std::move(new_life_needs) },
+	everyday_needs { std::move(new_everyday_needs) },
+	luxury_needs { std::move(new_luxury_needs) },
+	life_needs_income_types { std::move(new_life_needs_income_types) },
+	everyday_needs_income_types { std::move(new_everyday_needs_income_types) },
+	luxury_needs_income_types { std::move(new_luxury_needs_income_types) },
+	rebel_units { std::move(new_rebel_units) },
+	max_size { new_max_size },
+	merge_max_size { new_merge_max_size },
+	state_capital_only { new_state_capital_only },
+	demote_migrant { new_demote_migrant },
+	is_artisan { new_is_artisan },
+	allowed_to_vote { new_allowed_to_vote },
+	is_slave { new_is_slave },
+	can_be_recruited { new_can_be_recruited },
+	can_reduce_consciousness { new_can_reduce_consciousness },
+	administrative_efficiency { new_administrative_efficiency },
+	can_invest { new_can_invest },
+	factory { new_factory },
+	can_work_factory { new_can_work_factory },
+	unemployment { new_unemployment },
+	research_points { new_research_points },
+	leadership_points { new_leadership_points },
+	research_leadership_optimum { new_research_leadership_optimum },
+	state_administration_multiplier { new_state_administration_multiplier },
+	equivalent { new_equivalent },
+	country_migration_target { std::move(new_country_migration_target) },
+	migration_target { std::move(new_migration_target) },
+	promote_to { std::move(new_promote_to) },
+	ideologies { std::move(new_ideologies) },
+	issues { std::move(new_issues) } {
 	assert(sprite > 0);
 	assert(max_size >= 0);
 	assert(merge_max_size >= 0);
@@ -80,13 +147,41 @@ bool PopManager::add_strata(std::string_view identifier) {
 }
 
 bool PopManager::add_pop_type(
-	std::string_view identifier, colour_t colour, Strata const* strata, PopType::sprite_t sprite,
-	Good::good_map_t&& life_needs, Good::good_map_t&& everyday_needs, Good::good_map_t&& luxury_needs,
-	PopType::rebel_units_t&& rebel_units, Pop::pop_size_t max_size, Pop::pop_size_t merge_max_size, bool state_capital_only,
-	bool demote_migrant, bool is_artisan, bool allowed_to_vote, bool is_slave, bool can_be_recruited,
-	bool can_reduce_consciousness, bool administrative_efficiency, bool can_build, bool factory, bool can_work_factory,
-	bool unemployment, ConditionalWeight&& country_migration_target, ConditionalWeight&& migration_target,
-	ast::NodeCPtr promote_to_node, PopType::ideology_weight_map_t&& ideologies, ast::NodeCPtr issues_node
+	std::string_view identifier,
+	colour_t colour,
+	Strata const* strata,
+	PopType::sprite_t sprite,
+	Good::good_map_t&& life_needs,
+	Good::good_map_t&& everyday_needs,
+	Good::good_map_t&& luxury_needs,
+	PopType::income_type_t life_needs_income_types,
+	PopType::income_type_t everyday_needs_income_types,
+	PopType::income_type_t luxury_needs_income_types,
+	PopType::rebel_units_t&& rebel_units,
+	Pop::pop_size_t max_size,
+	Pop::pop_size_t merge_max_size,
+	bool state_capital_only,
+	bool demote_migrant,
+	bool is_artisan,
+	bool allowed_to_vote,
+	bool is_slave,
+	bool can_be_recruited,
+	bool can_reduce_consciousness,
+	bool administrative_efficiency,
+	bool can_invest,
+	bool factory,
+	bool can_work_factory,
+	bool unemployment,
+	fixed_point_t research_points,
+	fixed_point_t leadership_points,
+	fixed_point_t research_leadership_optimum,
+	fixed_point_t state_administration_multiplier,
+	ast::NodeCPtr equivalent,
+	ConditionalWeight&& country_migration_target,
+	ConditionalWeight&& migration_target,
+	ast::NodeCPtr promote_to_node,
+	PopType::ideology_weight_map_t&& ideologies,
+	ast::NodeCPtr issues_node
 ) {
 	if (identifier.empty()) {
 		Logger::error("Invalid pop type identifier - empty!");
@@ -97,27 +192,76 @@ bool PopManager::add_pop_type(
 		return false;
 	}
 	if (sprite <= 0) {
-		Logger::error("Invalid pop type sprite index for ", identifier, ": ", sprite);
+		Logger::error("Invalid pop type sprite index for ", identifier, ": ", sprite, " (must be positive)");
 		return false;
 	}
-	if (max_size < 0) {
-		Logger::error("Invalid pop type max size for ", identifier, ": ", max_size);
+	if (max_size <= 0) {
+		Logger::error("Invalid pop type max size for ", identifier, ": ", max_size, " (must be positive)");
 		return false;
 	}
-	if (merge_max_size < 0) {
-		Logger::error("Invalid pop type merge max size for ", identifier, ": ", merge_max_size);
+	if (merge_max_size <= 0) {
+		Logger::error("Invalid pop type merge max size for ", identifier, ": ", merge_max_size, " (must be positive)");
 		return false;
 	}
+
+	if (research_leadership_optimum < 0) {
+		Logger::error(
+			"Invalid pop type research/leadership optimum for ", identifier, ": ", research_leadership_optimum,
+			" (cannot be negative)"
+		);
+		return false;
+	}
+	if ((research_points != 0 || leadership_points != 0) != (research_leadership_optimum > 0)) {
+		Logger::error(
+			"Invalid pop type research/leadership points and optimum for ", identifier, ": research = ", research_points,
+			", leadership = ", leadership_points, ", optimum = ", research_leadership_optimum,
+			" (optimum is positive if and only if at least one of research and leadership is non-zero)"
+		);
+		return false;
+	}
+
 	const bool ret = pop_types.add_item({
-		identifier, colour, *strata, sprite, std::move(life_needs), std::move(everyday_needs),
-		std::move(luxury_needs), std::move(rebel_units), max_size, merge_max_size, state_capital_only,
-		demote_migrant, is_artisan, allowed_to_vote, is_slave, can_be_recruited, can_reduce_consciousness,
-		administrative_efficiency, can_build, factory, can_work_factory, unemployment, std::move(country_migration_target),
-		std::move(migration_target), {}, std::move(ideologies), {}
+		identifier,
+		colour,
+		*strata,
+		sprite,
+		std::move(life_needs),
+		std::move(everyday_needs),
+		std::move(luxury_needs),
+		life_needs_income_types,
+		everyday_needs_income_types,
+		luxury_needs_income_types,
+		std::move(rebel_units),
+		max_size,
+		merge_max_size,
+		state_capital_only,
+		demote_migrant,
+		is_artisan,
+		allowed_to_vote,
+		is_slave,
+		can_be_recruited,
+		can_reduce_consciousness,
+		administrative_efficiency,
+		can_invest,
+		factory,
+		can_work_factory,
+		unemployment,
+		research_points,
+		leadership_points,
+		research_leadership_optimum,
+		state_administration_multiplier,
+		nullptr,
+		std::move(country_migration_target),
+		std::move(migration_target),
+		{},
+		std::move(ideologies),
+		{}
 	});
+
 	if (ret) {
-		delayed_parse_promote_to_and_issues_nodes.emplace_back(promote_to_node, issues_node);
+		delayed_parse_nodes.emplace_back(equivalent, promote_to_node, issues_node);
 	}
+
 	if (slave_sprite <= 0 && ret && is_slave) {
 		/* Set slave sprite to that of the first is_slave pop type we find. */
 		slave_sprite = sprite;
@@ -132,6 +276,29 @@ bool PopManager::add_pop_type(
 void PopManager::reserve_pop_types(size_t count) {
 	stratas.reserve(stratas.size() + count);
 	pop_types.reserve(pop_types.size() + count);
+	delayed_parse_nodes.reserve(delayed_parse_nodes.size() + count);
+}
+
+static NodeCallback auto expect_needs_income(PopType::income_type_t& types) {
+	static const string_map_t<PopType::income_type_t> income_type_map {
+		{ "administration", ADMINISTRATION },
+		{ "education", EDUCATION },
+		{ "military", MILITARY },
+		{ "reforms", REFORMS }
+	};
+	return expect_dictionary_keys(
+		"type", ONE_OR_MORE, expect_identifier(expect_mapped_string(income_type_map,
+			[&types](PopType::income_type_t type) -> bool {
+				if (!share_income_type(types, type)) {
+					types |= type;
+					return true;
+				}
+				Logger::error("Duplicate income type ", type, " in pop type income types!");
+				return false;
+			}
+		)),
+		"weight", ZERO_OR_ONE, success_callback /* Has no effect in game */
+	);
 }
 
 /* REQUIREMENTS:
@@ -145,11 +312,16 @@ bool PopManager::load_pop_type_file(
 	Strata const* strata = nullptr;
 	PopType::sprite_t sprite = 0;
 	Good::good_map_t life_needs, everyday_needs, luxury_needs;
+	PopType::income_type_t life_needs_income_types = NO_INCOME_TYPE, everyday_needs_income_types = NO_INCOME_TYPE,
+		luxury_needs_income_types = NO_INCOME_TYPE;
 	PopType::rebel_units_t rebel_units;
+	Pop::pop_size_t max_size = Pop::MAX_SIZE, merge_max_size = Pop::MAX_SIZE;
 	bool state_capital_only = false, demote_migrant = false, is_artisan = false, allowed_to_vote = true, is_slave = false,
-		can_be_recruited = false, can_reduce_consciousness = false, administrative_efficiency = false, can_build = false,
+		can_be_recruited = false, can_reduce_consciousness = false, administrative_efficiency = false, can_invest = false,
 		factory = false, can_work_factory = false, unemployment = false;
-	Pop::pop_size_t max_size = 0, merge_max_size = 0;
+	fixed_point_t research_points = 0, leadership_points = 0, research_leadership_optimum = 0,
+		state_administration_multiplier = 0;
+	ast::NodeCPtr equivalent = nullptr;
 	ConditionalWeight country_migration_target { scope_t::COUNTRY, scope_t::POP, scope_t::NO_SCOPE };
 	ConditionalWeight migration_target { scope_t::PROVINCE, scope_t::POP, scope_t::NO_SCOPE };
 	ast::NodeCPtr promote_to_node = nullptr;
@@ -176,18 +348,18 @@ bool PopManager::load_pop_type_file(
 			}
 		),
 		"state_capital_only", ZERO_OR_ONE, expect_bool(assign_variable_callback(state_capital_only)),
-		"research_points", ZERO_OR_ONE, success_callback, // TODO - research points generation
-		"research_optimum", ZERO_OR_ONE, success_callback, // TODO - bonus research points generation
+		"research_points", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(research_points)),
+		"research_optimum", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(research_leadership_optimum)),
 		"rebel", ZERO_OR_ONE, unit_manager.expect_unit_decimal_map(move_variable_callback(rebel_units)),
-		"equivalent", ZERO_OR_ONE, success_callback, // TODO - worker convertability
-		"leadership", ZERO_OR_ONE, success_callback, // TODO - leadership points generation
+		"equivalent", ZERO_OR_ONE, assign_variable_callback(equivalent),
+		"leadership", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(leadership_points)),
 		"allowed_to_vote", ZERO_OR_ONE, expect_bool(assign_variable_callback(allowed_to_vote)),
 		"is_slave", ZERO_OR_ONE, expect_bool(assign_variable_callback(is_slave)),
 		"can_be_recruited", ZERO_OR_ONE, expect_bool(assign_variable_callback(can_be_recruited)),
 		"can_reduce_consciousness", ZERO_OR_ONE, expect_bool(assign_variable_callback(can_reduce_consciousness)),
-		"life_needs_income", ZERO_OR_ONE, success_callback, // TODO - incomes from national budget
-		"everyday_needs_income", ZERO_OR_ONE, success_callback,
-		"luxury_needs_income", ZERO_OR_ONE, success_callback,
+		"life_needs_income", ZERO_OR_ONE, expect_needs_income(life_needs_income_types),
+		"everyday_needs_income", ZERO_OR_ONE, expect_needs_income(everyday_needs_income_types),
+		"luxury_needs_income", ZERO_OR_ONE, expect_needs_income(luxury_needs_income_types),
 		"luxury_needs", ZERO_OR_ONE, good_manager.expect_good_decimal_map(move_variable_callback(luxury_needs)),
 		"everyday_needs", ZERO_OR_ONE, good_manager.expect_good_decimal_map(move_variable_callback(everyday_needs)),
 		"life_needs", ZERO_OR_ONE, good_manager.expect_good_decimal_map(move_variable_callback(life_needs)),
@@ -206,9 +378,9 @@ bool PopManager::load_pop_type_file(
 		"issues", ZERO_OR_ONE, assign_variable_callback(issues_node),
 		"demote_migrant", ZERO_OR_ONE, expect_bool(assign_variable_callback(demote_migrant)),
 		"administrative_efficiency", ZERO_OR_ONE, expect_bool(assign_variable_callback(administrative_efficiency)),
-		"tax_eff", ZERO_OR_ONE, success_callback, // TODO - tax collection modifier
-		"can_build", ZERO_OR_ONE, expect_bool(assign_variable_callback(can_build)),
-		"factory", ZERO_OR_ONE, expect_bool(assign_variable_callback(factory)),
+		"tax_eff", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(state_administration_multiplier)),
+		"can_build", ZERO_OR_ONE, expect_bool(assign_variable_callback(can_invest)),
+		"factory", ZERO_OR_ONE, expect_bool(assign_variable_callback(factory)), // TODO - work out what this does
 		"workplace_input", ZERO_OR_ONE, success_callback, // TODO - work out what these do
 		"workplace_output", ZERO_OR_ONE, success_callback,
 		"starter_share", ZERO_OR_ONE, success_callback,
@@ -217,10 +389,40 @@ bool PopManager::load_pop_type_file(
 	)(root);
 
 	ret &= add_pop_type(
-		filestem, colour, strata, sprite, std::move(life_needs), std::move(everyday_needs), std::move(luxury_needs),
-		std::move(rebel_units), max_size, merge_max_size, state_capital_only, demote_migrant, is_artisan, allowed_to_vote,
-		is_slave, can_be_recruited, can_reduce_consciousness, administrative_efficiency, can_build, factory, can_work_factory,
-		unemployment, std::move(country_migration_target), std::move(migration_target), promote_to_node, std::move(ideologies),
+		filestem,
+		colour,
+		strata,
+		sprite,
+		std::move(life_needs),
+		std::move(everyday_needs),
+		std::move(luxury_needs),
+		life_needs_income_types,
+		everyday_needs_income_types,
+		luxury_needs_income_types,
+		std::move(rebel_units),
+		max_size,
+		merge_max_size,
+		state_capital_only,
+		demote_migrant,
+		is_artisan,
+		allowed_to_vote,
+		is_slave,
+		can_be_recruited,
+		can_reduce_consciousness,
+		administrative_efficiency,
+		can_invest,
+		factory,
+		can_work_factory,
+		unemployment,
+		research_points,
+		leadership_points,
+		research_leadership_optimum,
+		state_administration_multiplier,
+		equivalent,
+		std::move(country_migration_target),
+		std::move(migration_target),
+		promote_to_node,
+		std::move(ideologies),
 		issues_node
 	);
 	return ret;
@@ -228,9 +430,15 @@ bool PopManager::load_pop_type_file(
 
 bool PopManager::load_delayed_parse_pop_type_data(IssueManager const& issue_manager) {
 	bool ret = true;
-	for (size_t index = 0; index < delayed_parse_promote_to_and_issues_nodes.size(); ++index) {
-		const auto [promote_to_node, issues_node] = delayed_parse_promote_to_and_issues_nodes[index];
+	for (size_t index = 0; index < delayed_parse_nodes.size(); ++index) {
+		const auto [equivalent, promote_to_node, issues_node] = delayed_parse_nodes[index];
 		PopType* pop_type = pop_types.get_item_by_index(index);
+		if (equivalent != nullptr && !expect_pop_type_identifier(
+			assign_variable_callback_pointer(pop_type->equivalent)
+		)(equivalent)) {
+			Logger::error("Errors parsing equivalent pop type for pop type ", pop_type, "!");
+			ret = false;
+		}
 		if (promote_to_node != nullptr && !expect_pop_type_dictionary_reserve_length(
 			pop_type->promote_to,
 			[pop_type](PopType const& type, ast::NodeCPtr node) -> bool {
@@ -244,7 +452,7 @@ bool PopManager::load_delayed_parse_pop_type_data(IssueManager const& issue_mana
 				return ret;
 			}
 		)(promote_to_node)) {
-			Logger::error("Errors parsing pop type ", pop_type, " promotion weights!");
+			Logger::error("Errors parsing promotion weights for pop type ", pop_type, "!");
 			ret = false;
 		}
 		if (issues_node != nullptr && !expect_dictionary_reserve_length(
@@ -264,11 +472,11 @@ bool PopManager::load_delayed_parse_pop_type_data(IssueManager const& issue_mana
 				return ret;
 			}
 		)(issues_node)) {
-			Logger::error("Errors parsing pop type ", pop_type, " issue weights!");
+			Logger::error("Errors parsing issue weights for pop type ", pop_type, "!");
 			ret = false;
 		}
 	}
-	delayed_parse_promote_to_and_issues_nodes.clear();
+	delayed_parse_nodes.clear();
 	return ret;
 }
 

--- a/src/openvic-simulation/research/Invention.cpp
+++ b/src/openvic-simulation/research/Invention.cpp
@@ -2,6 +2,7 @@
 
 #include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/map/Crime.hpp"
+#include "openvic-simulation/military/Unit.hpp"
 
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;

--- a/src/openvic-simulation/types/Colour.hpp
+++ b/src/openvic-simulation/types/Colour.hpp
@@ -147,15 +147,19 @@ namespace OpenVic {
 
 		static constexpr basic_colour_t from_integer(integer_type integer) {
 			if constexpr (colour_traits::has_alpha) {
-				return { colour_traits::red_from_integer(integer), colour_traits::green_from_integer(integer),
-						 colour_traits::blue_from_integer(integer), colour_traits::alpha_from_integer(integer) };
+				return {
+					colour_traits::red_from_integer(integer), colour_traits::green_from_integer(integer),
+					colour_traits::blue_from_integer(integer), colour_traits::alpha_from_integer(integer)
+				};
 			} else {
 				assert(
 					colour_traits::alpha_from_integer(integer) == colour_traits::null ||
 					colour_traits::alpha_from_integer(integer) == max_value
 				);
-				return { colour_traits::red_from_integer(integer), colour_traits::green_from_integer(integer),
-						 colour_traits::blue_from_integer(integer) };
+				return {
+					colour_traits::red_from_integer(integer), colour_traits::green_from_integer(integer),
+					colour_traits::blue_from_integer(integer)
+				};
 			}
 		}
 
@@ -163,8 +167,10 @@ namespace OpenVic {
 		from_floats(float r, float g, float b, float a = colour_traits::alpha_to_float(max_value))
 		requires(colour_traits::has_alpha)
 		{
-			return { colour_traits::red_from_float(r), colour_traits::green_from_float(g), colour_traits::blue_from_float(b),
-					 colour_traits::alpha_from_float(a) };
+			return {
+				colour_traits::red_from_float(r), colour_traits::green_from_float(g), colour_traits::blue_from_float(b),
+				colour_traits::alpha_from_float(a)
+			};
 		}
 
 		static constexpr basic_colour_t from_floats(float r, float g, float b)
@@ -192,13 +198,19 @@ namespace OpenVic {
 			: red(r), green(g), blue(b) {}
 
 		template<typename _ColourTraits>
-		requires(_ColourTraits::has_alpha && std::same_as<typename _ColourTraits::value_type, value_type> && std::same_as<typename _ColourTraits::integer_type, integer_type>)
+		requires(
+			_ColourTraits::has_alpha && std::same_as<typename _ColourTraits::value_type, value_type> &&
+			std::same_as<typename _ColourTraits::integer_type, integer_type>
+		)
 		explicit constexpr basic_colour_t(basic_colour_t<value_type, integer_type, _ColourTraits> const& colour)
 		requires(colour_traits::has_alpha)
 			: basic_colour_t { colour.red, colour.green, colour.blue, colour.alpha } {}
 
 		template<typename _ColourTraits>
-		requires(!_ColourTraits::has_alpha && std::same_as<typename _ColourTraits::value_type, value_type> && std::same_as<typename _ColourTraits::integer_type, integer_type>)
+		requires(
+			!_ColourTraits::has_alpha && std::same_as<typename _ColourTraits::value_type, value_type> &&
+			std::same_as<typename _ColourTraits::integer_type, integer_type>
+		)
 		explicit constexpr basic_colour_t(
 			basic_colour_t<value_type, integer_type, _ColourTraits> const& colour, value_type a = max_value
 		)
@@ -206,7 +218,10 @@ namespace OpenVic {
 			: basic_colour_t { colour.red, colour.green, colour.blue, a } {}
 
 		template<typename _ColourTraits>
-		requires(std::same_as<typename _ColourTraits::value_type, value_type> && std::same_as<typename _ColourTraits::integer_type, integer_type>)
+		requires(
+			std::same_as<typename _ColourTraits::value_type, value_type> &&
+			std::same_as<typename _ColourTraits::integer_type, integer_type>
+		)
 		explicit constexpr basic_colour_t(basic_colour_t<value_type, integer_type, _ColourTraits> const& colour)
 		requires(!colour_traits::has_alpha)
 			: basic_colour_t { colour.red, colour.green, colour.blue } {}

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -232,7 +232,7 @@ namespace OpenVic {
 			}
 		}
 
-		constexpr static NodeTools::KeyValueCallback auto key_value_invalid_callback(std::string_view name) {
+		static constexpr NodeTools::KeyValueCallback auto key_value_invalid_callback(std::string_view name) {
 			return [name](std::string_view key, ast::NodeCPtr) {
 				Logger::error("Invalid ", name, ": ", key);
 				return false;
@@ -258,13 +258,7 @@ namespace OpenVic {
 			if (item != nullptr) { \
 				return callback(*item); \
 			} \
-			if (!warn) { \
-				Logger::error("Invalid ", name, ": ", identifier); \
-				return false; \
-			} else { \
-				Logger::warning("Invalid ", name, ": ", identifier); \
-				return true; \
-			} \
+			return NodeTools::warn_or_error(warn, "Invalid ", name, ": ", identifier); \
 		}; \
 	} \
 	constexpr NodeTools::NodeCallback auto expect_item_identifier( \

--- a/src/openvic-simulation/utility/Logger.hpp
+++ b/src/openvic-simulation/utility/Logger.hpp
@@ -72,6 +72,7 @@ namespace OpenVic {
 		struct log_channel_t {
 			log_func_t func;
 			log_queue_t queue;
+			size_t message_count;
 		};
 
 		template<typename... Ts>
@@ -90,6 +91,8 @@ namespace OpenVic {
 					do {
 						log_channel.func(std::move(log_channel.queue.front()));
 						log_channel.queue.pop();
+						/* Only count printed messages, so that message_count matches what is seen in the console. */
+						log_channel.message_count++;
 					} while (!log_channel.queue.empty());
 				}
 			}
@@ -102,6 +105,9 @@ private: \
 public: \
 	static inline void set_##name##_func(log_func_t log_func) { \
 		name##_channel.func = log_func; \
+	} \
+	static inline size_t get_##name##_count() { \
+		return name##_channel.message_count; \
 	} \
 	template<typename... Ts> \
 	struct name { \

--- a/src/openvic-simulation/utility/StringUtils.hpp
+++ b/src/openvic-simulation/utility/StringUtils.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <cctype>
-#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <string_view>
+#include <type_traits>
 
 namespace OpenVic::StringUtils {
 	/* The constexpr function 'string_to_uint64' will convert a string into a uint64_t integer value.


### PR DESCRIPTION
- Removed the need to include the `mod` folder when specifying mods to be loaded in headless mode.
- Added message count tracking to `Logger`, and a summary output at the end of headless mode (useful for checking if a change increased the number of warnings or errors).
- Implemented missing parsing for some basic defines variables (and added comments explaining why others weren't being loaded):
  - Loaded `primary` and `union` countries for `Culture`s and `CultureGroup`s, which required moving culture loading to be after country loading. Also loaded `radicalism` for `Culture`.
  - Loaded `picture` string for OOB `Leader`s.
  - Loaded `PopType` incomes from national budget, research and leadership points and optimum ratio for whichever points a `PopType` generates, tax efficiency and equivalent `PopType` (used for `labourers` <-> `farmers` conversion).
- Changed set and map callbacks to support warnings or errors based on a bool argument, all using a common `warn_or_error` function which `UniqueKeyRegistry::expect_item_str` now also uses.
- Small bits of format cleanup across the repo.
- Added default map colours (so that uncolonised land isn't shown as natural terrain in the political mapmode).