### PR TITLE
Harmonize empty result behavior for `_search_for_game_path`

### DIFF
--- a/src/openvic-simulation/utility/StringUtils.hpp
+++ b/src/openvic-simulation/utility/StringUtils.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <string>


### PR DESCRIPTION
Fixes OpenVicProject/OpenVic#195

Enables actually searching for game path
Reports info or warning depending on why it fails

Remove StringUtils.hpp include in Vic2PathSearch.cpp
Add <cstdint> to StringUtils.hpp