### PR TITLE
Added reserve_more, expect_dictionary_key[s|_map]_reserve_length[_and_default]

### DIFF
--- a/src/openvic-simulation/economy/Good.cpp
+++ b/src/openvic-simulation/economy/Good.cpp
@@ -64,7 +64,7 @@ bool GoodManager::load_goods_file(ast::NodeCPtr root) {
 		}
 	)(root);
 	lock_good_categories();
-	goods.reserve(goods.size() + total_expected_goods);
+	reserve_more_goods(total_expected_goods);
 	ret &= expect_good_category_dictionary([this](GoodCategory const& good_category, ast::NodeCPtr good_category_value) -> bool {
 		return expect_dictionary([this, &good_category](std::string_view key, ast::NodeCPtr value) -> bool {
 			colour_t colour = colour_t::null();

--- a/src/openvic-simulation/economy/ProductionType.cpp
+++ b/src/openvic-simulation/economy/ProductionType.cpp
@@ -204,7 +204,7 @@ bool ProductionTypeManager::load_production_types_file(
 	)(root);
 
 	/* Pass #3: actually load production types */
-	production_types.reserve(production_types.size() + expected_types);
+	reserve_more_production_types(expected_types);
 	ret &= expect_dictionary(
 		[this, &good_manager, &pop_manager, &template_target_map, &template_node_map](
 			std::string_view key, ast::NodeCPtr node) -> bool {

--- a/src/openvic-simulation/history/Bookmark.cpp
+++ b/src/openvic-simulation/history/Bookmark.cpp
@@ -23,27 +23,30 @@ bool BookmarkManager::add_bookmark(
 }
 
 bool BookmarkManager::load_bookmark_file(ast::NodeCPtr root) {
-	const bool ret = expect_dictionary([this](std::string_view key, ast::NodeCPtr value) -> bool {
-		if (key != "bookmark") {
-			Logger::error("Invalid bookmark declaration ", key);
-			return false;
+	const bool ret = expect_dictionary_reserve_length(
+		bookmarks,
+		[this](std::string_view key, ast::NodeCPtr value) -> bool {
+			if (key != "bookmark") {
+				Logger::error("Invalid bookmark declaration ", key);
+				return false;
+			}
+
+			std::string_view name, description;
+			Date date;
+			uint32_t initial_camera_x, initial_camera_y;
+
+			bool ret = expect_dictionary_keys(
+				"name", ONE_EXACTLY, expect_string(assign_variable_callback(name)),
+				"desc", ONE_EXACTLY, expect_string(assign_variable_callback(description)),
+				"date", ONE_EXACTLY, expect_date(assign_variable_callback(date)),
+				"cameraX", ONE_EXACTLY, expect_uint(assign_variable_callback(initial_camera_x)),
+				"cameraY", ONE_EXACTLY, expect_uint(assign_variable_callback(initial_camera_y))
+			)(value);
+
+			ret &= add_bookmark(name, description, date, initial_camera_x, initial_camera_y);
+			return ret;
 		}
-
-		std::string_view name, description;
-		Date date;
-		uint32_t initial_camera_x, initial_camera_y;
-
-		bool ret = expect_dictionary_keys(
-			"name", ONE_EXACTLY, expect_string(assign_variable_callback(name)),
-			"desc", ONE_EXACTLY, expect_string(assign_variable_callback(description)),
-			"date", ONE_EXACTLY, expect_date(assign_variable_callback(date)),
-			"cameraX", ONE_EXACTLY, expect_uint(assign_variable_callback(initial_camera_x)),
-			"cameraY", ONE_EXACTLY, expect_uint(assign_variable_callback(initial_camera_y))
-		)(value);
-
-		ret &= add_bookmark(name, description, date, initial_camera_x, initial_camera_y);
-		return ret;
-	})(root);
+	)(root);
 	lock_bookmarks();
 
 	return ret;

--- a/src/openvic-simulation/history/CountryHistory.cpp
+++ b/src/openvic-simulation/history/CountryHistory.cpp
@@ -180,6 +180,14 @@ bool CountryHistoryMap::_load_history_entry(
 	)(root);
 }
 
+void CountryHistoryManager::reserve_more_country_histories(size_t size) {
+	if (locked) {
+		Logger::error("Failed to reserve space for ", size, " countries in CountryHistoryManager - already locked!");
+	} else {
+		reserve_more(country_histories, size);
+	}
+}
+
 void CountryHistoryManager::lock_country_histories() {
 	Logger::info("Locked country history registry after registering ", country_histories.size(), " items");
 	locked = true;

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <map>
 #include <optional>
 
 #include "openvic-simulation/country/Country.hpp"
-#include "openvic-simulation/history/Bookmark.hpp"
 #include "openvic-simulation/history/HistoryMap.hpp"
 #include "openvic-simulation/map/Province.hpp"
 #include "openvic-simulation/military/Deployment.hpp"
@@ -17,7 +15,6 @@
 #include "openvic-simulation/pop/Religion.hpp"
 #include "openvic-simulation/research/Invention.hpp"
 #include "openvic-simulation/research/Technology.hpp"
-#include "openvic-simulation/types/Colour.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
@@ -88,6 +85,7 @@ namespace OpenVic {
 	public:
 		CountryHistoryManager() = default;
 
+		void reserve_more_country_histories(size_t size);
 		void lock_country_histories();
 		bool is_locked() const;
 

--- a/src/openvic-simulation/history/DiplomaticHistory.cpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.cpp
@@ -47,6 +47,14 @@ SubjectHistory::SubjectHistory(
 	const Period new_period
 ) : overlord { new_overlord }, subject { new_subject }, type { new_type }, period {new_period} {}
 
+void DiplomaticHistoryManager::reserve_more_wars(size_t size) {
+	if (locked) {
+		Logger::error("Failed to reserve space for ", size, " wars in DiplomaticHistoryManager - already locked!");
+	} else {
+		reserve_more(wars, size);
+	}
+}
+
 void DiplomaticHistoryManager::lock_diplomatic_history() {
 	Logger::info("Locked diplomacy history registry after registering ", alliances.size() + subjects.size() + wars.size(), " items");
 	locked = true;
@@ -184,7 +192,7 @@ bool DiplomaticHistoryManager::load_diplomacy_history_file(CountryManager const&
 }
 
 bool DiplomaticHistoryManager::load_war_history_file(GameManager const& game_manager, ast::NodeCPtr root) {
-	std::string name = "";
+	std::string_view name {};
 	std::vector<WarHistory::war_participant_t> attackers {};
 	std::vector<WarHistory::war_participant_t> defenders {};
 	std::vector<WarHistory::added_wargoal_t> wargoals {};
@@ -270,7 +278,7 @@ bool DiplomaticHistoryManager::load_war_history_file(GameManager const& game_man
 			)(node);
 			return ret;
 		},
-		"name", ZERO_OR_ONE, expect_string(assign_variable_callback_string(name))
+		"name", ZERO_OR_ONE, expect_string(assign_variable_callback(name))
 	)(root);
 
 	wars.push_back({ name, std::move(attackers), std::move(defenders), std::move(wargoals) });

--- a/src/openvic-simulation/history/DiplomaticHistory.hpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <bitset>
 #include <vector>
-#include <map>
 #include <optional>
 
 #include "openvic-simulation/country/Country.hpp"
@@ -100,6 +98,7 @@ namespace OpenVic {
 	public:
 		DiplomaticHistoryManager() {}
 
+		void reserve_more_wars(size_t size);
 		void lock_diplomatic_history();
 		bool is_locked() const;
 

--- a/src/openvic-simulation/history/HistoryManager.hpp
+++ b/src/openvic-simulation/history/HistoryManager.hpp
@@ -2,9 +2,8 @@
 
 #include "openvic-simulation/history/Bookmark.hpp"
 #include "openvic-simulation/history/CountryHistory.hpp"
-#include "openvic-simulation/history/ProvinceHistory.hpp"
 #include "openvic-simulation/history/DiplomaticHistory.hpp"
-#include "openvic-simulation/types/IdentifierRegistry.hpp"
+#include "openvic-simulation/history/ProvinceHistory.hpp"
 
 namespace OpenVic {
 	struct HistoryManager {

--- a/src/openvic-simulation/history/HistoryMap.hpp
+++ b/src/openvic-simulation/history/HistoryMap.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <memory>
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -112,6 +112,14 @@ bool ProvinceHistoryMap::_load_history_entry(
 	)(root);
 }
 
+void ProvinceHistoryManager::reserve_more_province_histories(size_t size) {
+	if (locked) {
+		Logger::error("Failed to reserve space for ", size, " provinces in ProvinceHistoryManager - already locked!");
+	} else {
+		reserve_more(province_histories, size);
+	}
+}
+
 void ProvinceHistoryManager::lock_province_histories(Map const& map, bool detailed_errors) {
 	std::vector<bool> province_checklist(map.get_province_count());
 	for (decltype(province_histories)::value_type const& entry : province_histories) {

--- a/src/openvic-simulation/history/ProvinceHistory.hpp
+++ b/src/openvic-simulation/history/ProvinceHistory.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
-#include <bitset>
-#include <map>
 #include <vector>
 
 #include "openvic-simulation/country/Country.hpp"
 #include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/economy/Good.hpp"
-#include "openvic-simulation/history/Bookmark.hpp"
 #include "openvic-simulation/history/HistoryMap.hpp"
 #include "openvic-simulation/map/Province.hpp"
 #include "openvic-simulation/map/TerrainType.hpp"
@@ -63,7 +60,7 @@ namespace OpenVic {
 
 	struct ProvinceHistoryManager {
 	private:
-		ordered_map<Province const*, ProvinceHistoryMap> PROPERTY(province_histories);
+		ordered_map<Province const*, ProvinceHistoryMap> province_histories;
 		bool locked = false;
 
 		ProvinceHistoryMap* _get_or_make_province_history(Province const& province);
@@ -71,6 +68,7 @@ namespace OpenVic {
 	public:
 		ProvinceHistoryManager() = default;
 
+		void reserve_more_province_histories(size_t size);
 		void lock_province_histories(Map const& map, bool detailed_errors);
 		bool is_locked() const;
 

--- a/src/openvic-simulation/interface/GFX.cpp
+++ b/src/openvic-simulation/interface/GFX.cpp
@@ -7,8 +7,9 @@ using namespace OpenVic::NodeTools;
 Font::Font(std::string_view new_identifier, colour_argb_t new_colour, std::string_view new_fontname)
 	: HasIdentifierAndAlphaColour { new_identifier, new_colour, false }, fontname { new_fontname } {}
 
-node_callback_t Sprite::expect_sprite(callback_t<std::unique_ptr<Sprite>&&> callback) {
-	return expect_dictionary_keys(
+node_callback_t Sprite::expect_sprites(length_callback_t length_callback, callback_t<std::unique_ptr<Sprite>&&> callback) {
+	return expect_dictionary_keys_and_length(
+		length_callback,
 		"spriteType", ZERO_OR_MORE, _expect_instance<Sprite, TextureSprite>(callback),
 		"progressbartype", ZERO_OR_MORE, _expect_instance<Sprite, ProgressBar>(callback),
 		"PieChartType", ZERO_OR_MORE, _expect_instance<Sprite, PieChart>(callback),

--- a/src/openvic-simulation/interface/GFX.hpp
+++ b/src/openvic-simulation/interface/GFX.hpp
@@ -36,7 +36,9 @@ namespace OpenVic::GFX {
 		OV_DETAIL_GET_BASE_TYPE(Sprite)
 		OV_DETAIL_GET_TYPE
 
-		static NodeTools::node_callback_t expect_sprite(NodeTools::callback_t<std::unique_ptr<Sprite>&&> callback);
+		static NodeTools::node_callback_t expect_sprites(
+			NodeTools::length_callback_t length_callback, NodeTools::callback_t<std::unique_ptr<Sprite>&&> callback
+		);
 	};
 
 	class TextureSprite final : public Sprite {

--- a/src/openvic-simulation/interface/UI.cpp
+++ b/src/openvic-simulation/interface/UI.cpp
@@ -39,7 +39,8 @@ bool UIManager::_load_font(ast::NodeCPtr node) {
 
 bool UIManager::load_gfx_file(ast::NodeCPtr root) {
 	return expect_dictionary_keys(
-		"spriteTypes", ZERO_OR_ONE, Sprite::expect_sprite(
+		"spriteTypes", ZERO_OR_ONE, Sprite::expect_sprites(
+			NodeTools::reserve_length_callback(sprites),
 			[this](std::unique_ptr<Sprite>&& sprite) -> bool {
 				/* TODO - more checks on duplicates (the false here reduces them from
 				 * errors to warnings). The repeats in vanilla are identical (simple
@@ -64,7 +65,8 @@ bool UIManager::load_gfx_file(ast::NodeCPtr root) {
 				return sprites.add_item(std::move(sprite), duplicate_warning_callback);
 			}
 		),
-		"bitmapfonts", ZERO_OR_ONE, expect_dictionary(
+		"bitmapfonts", ZERO_OR_ONE, expect_dictionary_reserve_length(
+			fonts,
 			[this](std::string_view key, ast::NodeCPtr node) -> bool {
 				if (key != "bitmapfont") {
 					Logger::error("Invalid bitmapfonts key: ", key);

--- a/src/openvic-simulation/map/Province.cpp
+++ b/src/openvic-simulation/map/Province.cpp
@@ -77,7 +77,7 @@ bool Province::add_pop(Pop&& pop) {
 
 bool Province::add_pop_vec(std::vector<Pop> const& pop_vec) {
 	if (!is_water()) {
-		pops.reserve(pops.size() + pop_vec.size());
+		reserve_more(pops, pop_vec.size());
 		for (Pop const& pop : pop_vec) {
 			pops.push_back(pop);
 		}

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -83,6 +83,10 @@ void ProvinceSet::reserve(size_t size) {
 	}
 }
 
+void ProvinceSet::reserve_more(size_t size) {
+	OpenVic::reserve_more(*this, size);
+}
+
 bool ProvinceSet::contains_province(Province const* province) const {
 	return province && std::find(provinces.begin(), provinces.end(), province) != provinces.end();
 }

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -23,6 +23,7 @@ namespace OpenVic {
 		bool empty() const;
 		size_t size() const;
 		void reserve(size_t size);
+		void reserve_more(size_t size);
 		bool contains_province(Province const* province) const;
 		provinces_t const& get_provinces() const;
 	};

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -130,11 +130,8 @@ TerrainTypeMapping::index_t TerrainTypeManager::get_terrain_texture_limit() cons
 }
 
 bool TerrainTypeManager::load_terrain_types(ModifierManager const& modifier_manager, ast::NodeCPtr root) {
-	const bool ret = expect_dictionary_keys_and_length_and_default(
-		[this](size_t size) -> size_t {
-			terrain_type_mappings.reserve(size - 2);
-			return size;
-		},
+	const bool ret = expect_dictionary_keys_reserve_length_and_default(
+		terrain_type_mappings,
 		std::bind_front(&TerrainTypeManager::_load_terrain_type_mapping, this),
 		"terrain", ONE_EXACTLY, expect_uint(assign_variable_callback(terrain_texture_limit)),
 		"categories", ONE_EXACTLY, _load_terrain_type_categories(modifier_manager)

--- a/src/openvic-simulation/military/LeaderTrait.cpp
+++ b/src/openvic-simulation/military/LeaderTrait.cpp
@@ -26,20 +26,33 @@ bool LeaderTraitManager::add_leader_trait(
 }
 
 bool LeaderTraitManager::load_leader_traits_file(ModifierManager const& modifier_manager, ast::NodeCPtr root) {
-	using enum LeaderTrait::trait_type_t;
-	const auto trait_callback = [this, &modifier_manager](LeaderTrait::trait_type_t type) -> key_value_callback_t {
-		return [this, &modifier_manager, type](std::string_view trait_identifier, ast::NodeCPtr value) -> bool {
-			ModifierValue modifiers;
-			bool ret =
-				modifier_manager.expect_whitelisted_modifier_value(move_variable_callback(modifiers), allowed_modifiers)(value);
-			ret &= add_leader_trait(trait_identifier, type, std::move(modifiers));
-			return ret;
-		};
+	const auto trait_callback = [this, &modifier_manager](LeaderTrait::trait_type_t type) -> NodeCallback auto {
+		return expect_dictionary_reserve_length(
+			leader_traits,
+			[this, &modifier_manager, type](std::string_view trait_identifier, ast::NodeCPtr value) -> bool {
+				static const string_set_t allowed_modifiers = {
+					"attack", "defence", "morale", "organisation", "reconnaissance",
+					"speed", "attrition", "experience", "reliability"
+				};
+
+				ModifierValue modifiers;
+				bool ret = modifier_manager.expect_whitelisted_modifier_value(
+					move_variable_callback(modifiers), allowed_modifiers
+				)(value);
+
+				ret &= add_leader_trait(trait_identifier, type, std::move(modifiers));
+				return ret;
+			}
+		);
 	};
+
+	using enum LeaderTrait::trait_type_t;
+
 	const bool ret = expect_dictionary_keys(
-		"personality", ONE_EXACTLY, expect_dictionary(trait_callback(PERSONALITY)),
-		"background", ONE_EXACTLY, expect_dictionary(trait_callback(BACKGROUND))
+		"personality", ONE_EXACTLY, trait_callback(PERSONALITY),
+		"background", ONE_EXACTLY, trait_callback(BACKGROUND)
 	)(root);
+
 	lock_leader_traits();
 
 	return ret;

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -44,9 +44,6 @@ namespace OpenVic {
 	struct LeaderTraitManager {
 	private:
 		IdentifierRegistry<LeaderTrait> IDENTIFIER_REGISTRY(leader_trait);
-		static inline const string_set_t allowed_modifiers = {
-			"attack", "defence", "morale", "organisation", "reconnaissance", "speed", "attrition", "experience", "reliability"
-		};
 
 	public:
 		bool add_leader_trait(std::string_view identifier, LeaderTrait::trait_type_t type, ModifierValue&& modifiers);

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -69,7 +69,8 @@ bool WargoalTypeManager::add_wargoal_type(
 }
 
 bool WargoalTypeManager::load_wargoal_file(ast::NodeCPtr root) {
-	bool ret = expect_dictionary(
+	bool ret = expect_dictionary_reserve_length(
+		wargoal_types,
 		[this](std::string_view identifier, ast::NodeCPtr value) -> bool {
 			if (identifier == "peace_order") {
 				return true;

--- a/src/openvic-simulation/misc/Decision.cpp
+++ b/src/openvic-simulation/misc/Decision.cpp
@@ -52,7 +52,8 @@ bool DecisionManager::add_decision(
 
 bool DecisionManager::load_decision_file(ast::NodeCPtr root) {
 	return expect_dictionary_keys(
-		"political_decisions", ZERO_OR_ONE, expect_dictionary(
+		"political_decisions", ZERO_OR_ONE, expect_dictionary_reserve_length(
+			decisions,
 			[this](std::string_view identifier, ast::NodeCPtr node) -> bool {
 				bool alert = true, news = false;
 				std::string_view news_title, news_desc_long, news_desc_medium, news_desc_short, picture;

--- a/src/openvic-simulation/misc/Define.cpp
+++ b/src/openvic-simulation/misc/Define.cpp
@@ -30,6 +30,10 @@ uint64_t Define::get_value_as_uint() const {
 }
 
 bool DefineManager::add_define(std::string_view name, std::string&& value, Define::Type type) {
+	if (name.empty()) {
+		Logger::error("Invalid define identifier - empty!");
+		return false;
+	}
 	return defines.add_item({ name, std::move(value), type }, duplicate_warning_callback);
 }
 
@@ -55,62 +59,53 @@ bool DefineManager::add_date_define(std::string_view name, Date date) {
 	} else if (name == "end_date") {
 		end_date = date;
 	} else {
+		Logger::error("Invalid date define identifier - \"", name, "\" (must be start_date or end_date)");
 		return false;
 	}
-	return defines.add_item({ name, date.to_string(), Define::Type::None });
+	return defines.add_item({ name, date.to_string(), Define::Type::Date });
 }
 
 bool DefineManager::load_defines_file(ast::NodeCPtr root) {
 	bool ret = expect_dictionary_keys(
 		"defines", ONE_EXACTLY, expect_dictionary([this](std::string_view key, ast::NodeCPtr value) -> bool {
-			if (key == "country" || key == "economy" || key == "military" || key == "diplomacy" ||
-				key == "pops" || key == "ai" || key == "graphics") {
-				return expect_dictionary([this, &key](std::string_view inner_key, ast::NodeCPtr value) -> bool {
-					std::string str_val;
+			using enum Define::Type;
+			static const string_map_t<Define::Type> type_map {
+				{ "country",   Country },
+				{ "economy",   Economy },
+				{ "military",  Military },
+				{ "diplomacy", Diplomacy },
+				{ "pops",      Pops },
+				{ "ai",        Ai },
+				{ "graphics",  Graphics },
+			};
 
-					bool ret = expect_identifier_or_string(assign_variable_callback_string(str_val))(value);
+			const string_map_t<Define::Type>::const_iterator type_it = type_map.find(key);
 
-					Define::Type type;
-					switch (key[0]) {
-						using enum Define::Type;
-					case 'c': // country
-						type = Country;
-						break;
-					case 'e': // economy
-						type = Economy;
-						break;
-					case 'm': // military
-						type = Military;
-						break;
-					case 'd': // diplomacy
-						type = Diplomacy;
-						break;
-					case 'p': // pops
-						type = Pops;
-						break;
-					case 'a': // ai
-						type = Ai;
-						break;
-					case 'g': // graphics
-						type = Graphics;
-						break;
-					default:
-						Logger::error("Unknown define type ", key, " found in defines!");
-						return false;
+			if (type_it != type_map.end()) {
+
+				return expect_dictionary_reserve_length(
+					defines,
+					[this, &key, type = type_it->second](std::string_view inner_key, ast::NodeCPtr value) -> bool {
+						std::string str_val;
+						bool ret = expect_identifier_or_string(assign_variable_callback_string(str_val))(value);
+						ret &= add_define(inner_key, std::move(str_val), type);
+						return ret;
 					}
+				)(value);
 
-					ret &= add_define(inner_key, std::move(str_val), type);
-					return ret;
-				})(value);
 			} else if (key == "start_date" || key == "end_date") {
-				return expect_identifier_or_string(expect_date_str([this, &key](Date date) -> bool {
-					return add_date_define(key, date);
-				}))(value);
+
+				return expect_identifier_or_string(expect_date_str(
+					std::bind_front(&DefineManager::add_date_define, this, key)
+				))(value);
+
 			} else {
 				return false;
 			}
 		})
 	)(root);
+
 	lock_defines();
+
 	return ret;
 }

--- a/src/openvic-simulation/misc/Define.hpp
+++ b/src/openvic-simulation/misc/Define.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <concepts>
 #include <optional>
 
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
@@ -12,7 +11,7 @@ namespace OpenVic {
 	struct Define : HasIdentifier {
 		friend struct DefineManager;
 
-		enum class Type : unsigned char { None, Country, Economy, Military, Diplomacy, Pops, Ai, Graphics };
+		enum class Type : unsigned char { Date, Country, Economy, Military, Diplomacy, Pops, Ai, Graphics };
 
 	private:
 		const std::string PROPERTY(value);

--- a/src/openvic-simulation/misc/Event.cpp
+++ b/src/openvic-simulation/misc/Event.cpp
@@ -116,7 +116,8 @@ bool EventManager::add_on_action(std::string_view identifier, OnAction::weight_m
 }
 
 bool EventManager::load_event_file(IssueManager const& issue_manager, ast::NodeCPtr root) {
-	return expect_dictionary(
+	return expect_dictionary_reserve_length(
+		events,
 		[this, &issue_manager](std::string_view key, ast::NodeCPtr value) -> bool {
 			Event::event_type_t type;
 			scope_t initial_scope;

--- a/src/openvic-simulation/politics/Government.cpp
+++ b/src/openvic-simulation/politics/Government.cpp
@@ -47,7 +47,8 @@ bool GovernmentTypeManager::add_government_type(
 
 /* REQUIREMENTS: FS-525, SIM-27 */
 bool GovernmentTypeManager::load_government_types_file(IdeologyManager const& ideology_manager, ast::NodeCPtr root) {
-	bool ret = expect_dictionary_reserve_length(government_types,
+	bool ret = expect_dictionary_reserve_length(
+		government_types,
 		[this, &ideology_manager](std::string_view government_type_identifier, ast::NodeCPtr government_type_value) -> bool {
 			std::vector<Ideology const*> ideologies;
 			bool elections = false, appoint_ruling_party = false;

--- a/src/openvic-simulation/politics/Ideology.cpp
+++ b/src/openvic-simulation/politics/Ideology.cpp
@@ -68,7 +68,8 @@ bool IdeologyManager::add_ideology(
  */
 bool IdeologyManager::load_ideology_file(ast::NodeCPtr root) {
 	size_t expected_ideologies = 0;
-	bool ret = expect_dictionary_reserve_length(ideology_groups,
+	bool ret = expect_dictionary_reserve_length(
+		ideology_groups,
 		[this, &expected_ideologies](std::string_view key, ast::NodeCPtr value) -> bool {
 			bool ret = expect_length(add_variable_callback(expected_ideologies))(value);
 			ret &= add_ideology_group(key);
@@ -77,7 +78,7 @@ bool IdeologyManager::load_ideology_file(ast::NodeCPtr root) {
 	)(root);
 	lock_ideology_groups();
 
-	ideologies.reserve(ideologies.size() + expected_ideologies);
+	reserve_more_ideologies(expected_ideologies);
 	ret &= expect_dictionary([this](std::string_view ideology_group_key, ast::NodeCPtr ideology_group_value) -> bool {
 		IdeologyGroup const* ideology_group = get_ideology_group_by_identifier(ideology_group_key);
 

--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -191,7 +191,8 @@ bool IssueManager::_load_reform(
 bool IssueManager::load_issues_file(ModifierManager const& modifier_manager, RuleManager const& rule_manager, ast::NodeCPtr root) {
 	size_t expected_issue_groups = 0;
 	size_t expected_reform_groups = 0;
-	bool ret = expect_dictionary_reserve_length(reform_types,
+	bool ret = expect_dictionary_reserve_length(
+		reform_types,
 		[this, &expected_issue_groups, &expected_reform_groups](std::string_view key, ast::NodeCPtr value) -> bool {
 			if (key == "party_issues") {
 				return expect_length(add_variable_callback(expected_issue_groups))(value);
@@ -206,12 +207,12 @@ bool IssueManager::load_issues_file(ModifierManager const& modifier_manager, Rul
 	)(root);
 	lock_reform_types();
 
-	issue_groups.reserve(issue_groups.size() + expected_issue_groups);
-	reform_groups.reserve(reform_groups.size() + expected_reform_groups);
+	reserve_more_issue_groups(expected_issue_groups);
+	reserve_more_reform_groups(expected_reform_groups);
 
 	size_t expected_issues = 0;
 	size_t expected_reforms = 0;
-	ret &= expect_dictionary_reserve_length(issue_groups,
+	ret &= expect_dictionary(
 		[this, &expected_issues, &expected_reforms](std::string_view type_key, ast::NodeCPtr type_value) -> bool {
 			if (type_key == "party_issues") {
 				return expect_dictionary([this, &expected_issues](std::string_view key, ast::NodeCPtr value) -> bool {
@@ -230,28 +231,36 @@ bool IssueManager::load_issues_file(ModifierManager const& modifier_manager, Rul
 	lock_issue_groups();
 	lock_reform_groups();
 
-	issues.reserve(issues.size() + expected_issues);
-	reforms.reserve(reforms.size() + expected_reforms);
+	reserve_more_issues(expected_issues);
+	reserve_more_reforms(expected_reforms);
 
-	ret &= expect_dictionary([this, &modifier_manager, &rule_manager](std::string_view type_key, ast::NodeCPtr type_value) -> bool {
-		return expect_dictionary([this, &modifier_manager, &rule_manager, type_key](std::string_view group_key, ast::NodeCPtr group_value) -> bool {
-			if (type_key == "party_issues") {
-				IssueGroup const* issue_group = get_issue_group_by_identifier(group_key);
-				return expect_dictionary([this, &modifier_manager, &rule_manager, issue_group](std::string_view key, ast::NodeCPtr value) -> bool {
-					return _load_issue(modifier_manager, rule_manager, key, issue_group, value);
-				})(group_value);
-			} else {
-				ReformGroup const* reform_group = get_reform_group_by_identifier(group_key);
-				size_t ordinal = 0;
-				return expect_dictionary([this, &modifier_manager, &rule_manager, reform_group, &ordinal](std::string_view key, ast::NodeCPtr value) -> bool {
-					if (key == "next_step_only" || key == "administrative") {
-						return true;
-					}
-					return _load_reform(modifier_manager, rule_manager, ordinal++, key, reform_group, value);
-				})(group_value);
-			}
-		})(type_value);
-	})(root);
+	ret &= expect_dictionary(
+		[this, &modifier_manager, &rule_manager](std::string_view type_key, ast::NodeCPtr type_value) -> bool {
+			return expect_dictionary([this, &modifier_manager, &rule_manager, type_key](
+				std::string_view group_key, ast::NodeCPtr group_value
+			) -> bool {
+				if (type_key == "party_issues") {
+					IssueGroup const* issue_group = get_issue_group_by_identifier(group_key);
+					return expect_dictionary([this, &modifier_manager, &rule_manager, issue_group](
+						std::string_view key, ast::NodeCPtr value
+					) -> bool {
+						return _load_issue(modifier_manager, rule_manager, key, issue_group, value);
+					})(group_value);
+				} else {
+					ReformGroup const* reform_group = get_reform_group_by_identifier(group_key);
+					size_t ordinal = 0;
+					return expect_dictionary([this, &modifier_manager, &rule_manager, reform_group, &ordinal](
+						std::string_view key, ast::NodeCPtr value
+					) -> bool {
+						if (key == "next_step_only" || key == "administrative") {
+							return true;
+						}
+						return _load_reform(modifier_manager, rule_manager, ordinal++, key, reform_group, value);
+					})(group_value);
+				}
+			})(type_value);
+		}
+	)(root);
 	lock_issues();
 	lock_reforms();
 

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -84,7 +84,7 @@ bool NationalFocusManager::load_national_foci_file(
 	)(root);
 	lock_national_focus_groups();
 
-	national_foci.reserve(expected_national_foci);
+	reserve_more_national_foci(expected_national_foci);
 
 	ret &= expect_national_focus_group_dictionary([this, &pop_manager, &ideology_manager, &good_manager, &modifier_manager](
 		NationalFocusGroup const& group, ast::NodeCPtr group_node

--- a/src/openvic-simulation/politics/NationalValue.cpp
+++ b/src/openvic-simulation/politics/NationalValue.cpp
@@ -16,7 +16,8 @@ bool NationalValueManager::add_national_value(std::string_view identifier, Modif
 }
 
 bool NationalValueManager::load_national_values_file(ModifierManager const& modifier_manager, ast::NodeCPtr root) {
-	bool ret = expect_dictionary(
+	bool ret = expect_dictionary_reserve_length(
+		national_values,
 		[this, &modifier_manager](std::string_view national_value_identifier, ast::NodeCPtr value) -> bool {
 			ModifierValue modifiers;
 
@@ -26,6 +27,7 @@ bool NationalValueManager::load_national_values_file(ModifierManager const& modi
 			return ret;
 		}
 	)(root);
+
 	lock_national_values();
 
 	return ret;

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -95,7 +95,8 @@ bool RebelManager::load_rebels_file(
 		{ "any", RebelType::independence_t::ANY }
 	};
 
-	bool ret = expect_dictionary(
+	bool ret = expect_dictionary_reserve_length(
+		rebel_types,
 		[this, &ideology_manager, &government_type_manager](std::string_view identifier, ast::NodeCPtr node) -> bool {
 			RebelType::icon_t icon = 0;
 			RebelType::area_t area = RebelType::area_t::ALL;

--- a/src/openvic-simulation/politics/Rule.cpp
+++ b/src/openvic-simulation/politics/Rule.cpp
@@ -161,7 +161,7 @@ bool RuleManager::setup_rules(BuildingTypeManager const& building_type_manager) 
 	for (auto const& [group, rule_list] : hardcoded_rules) {
 		rule_count += rule_list.size();
 	}
-	rules.reserve(rule_count);
+	reserve_more_rules(rule_count);
 
 	for (auto const& [group, rule_list] : hardcoded_rules) {
 		for (std::string_view const& rule : rule_list) {

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -74,7 +74,8 @@ bool CultureManager::add_culture(
 }
 
 bool CultureManager::load_graphical_culture_type_file(ast::NodeCPtr root) {
-	const bool ret = expect_list_reserve_length(graphical_culture_types,
+	const bool ret = expect_list_reserve_length(
+		graphical_culture_types,
 		expect_identifier(std::bind_front(&CultureManager::add_graphical_culture_type, this))
 	)(root);
 	lock_graphical_culture_types();
@@ -169,7 +170,7 @@ bool CultureManager::load_culture_file(CountryManager const& country_manager, as
 		}
 	)(root);
 	lock_culture_groups();
-	cultures.reserve(cultures.size() + total_expected_cultures);
+	reserve_more_cultures(total_expected_cultures);
 
 	ret &= expect_culture_group_dictionary(
 		[this, &country_manager](CultureGroup const& culture_group, ast::NodeCPtr culture_group_value) -> bool {

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -273,10 +273,19 @@ bool PopManager::add_pop_type(
 	return ret;
 }
 
-void PopManager::reserve_pop_types(size_t count) {
-	stratas.reserve(stratas.size() + count);
-	pop_types.reserve(pop_types.size() + count);
-	delayed_parse_nodes.reserve(delayed_parse_nodes.size() + count);
+void PopManager::reserve_all_pop_types(size_t size) {
+	reserve_more_stratas(size);
+	if (pop_types_are_locked()) {
+		Logger::error("Failed to reserve space for ", size, " pop types in PopManager - already locked!");
+	} else {
+		reserve_more_pop_types(size);
+		reserve_more(delayed_parse_nodes, size);
+	}
+}
+
+void PopManager::lock_all_pop_types() {
+	lock_stratas();
+	lock_pop_types();
 }
 
 static NodeCallback auto expect_needs_income(PopType::income_type_t& types) {

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -286,7 +286,8 @@ namespace OpenVic {
 			ast::NodeCPtr issues_node
 		);
 
-		void reserve_pop_types(size_t count);
+		void reserve_all_pop_types(size_t size);
+		void lock_all_pop_types();
 
 		bool load_pop_type_file(
 			std::string_view filestem, UnitManager const& unit_manager, GoodManager const& good_manager,

--- a/src/openvic-simulation/utility/BMP.cpp
+++ b/src/openvic-simulation/utility/BMP.cpp
@@ -1,7 +1,6 @@
 #include "BMP.hpp"
 
 #include <cstring>
-#include <set>
 
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/utility/Logger.hpp"


### PR DESCRIPTION
- Added `reserve_more` (reserve on top of existing size), switched to using it throughout most of the repo
- Added more `reserve_length` expect functions
- Reorganised `Dataloader::_load_history`
- Cleaned up various files, mostly formatting but some more significant changes to `Define`s loading
- Removed unused includes