### PR TITLE
Added StringMapCase and case insensitive expect_dictionary_keys

### DIFF
--- a/src/openvic-simulation/economy/ProductionType.cpp
+++ b/src/openvic-simulation/economy/ProductionType.cpp
@@ -230,7 +230,7 @@ bool ProductionTypeManager::load_production_types_file(
 				{ "factory", FACTORY }, { "rgo", RGO }, { "artisan", ARTISAN }
 			};
 
-			const auto parse_node = expect_dictionary_keys(
+			auto parse_node = expect_dictionary_keys(
 				"template", ZERO_OR_ONE, success_callback, /* Already parsed using expect_key in Pass #1 above. */
 				"bonus", ZERO_OR_MORE, [&bonuses](ast::NodeCPtr bonus_node) -> bool {
 					ConditionScript trigger { scope_t::STATE, scope_t::NO_SCOPE, scope_t::NO_SCOPE };

--- a/src/openvic-simulation/interface/GFX.cpp
+++ b/src/openvic-simulation/interface/GFX.cpp
@@ -26,11 +26,10 @@ node_callback_t Sprite::expect_sprites(length_callback_t length_callback, callba
 
 TextureSprite::TextureSprite() : texture_file {}, no_of_frames { NO_FRAMES } {}
 
-bool TextureSprite::_fill_key_map(key_map_t& key_map) {
+bool TextureSprite::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map,
 		"texturefile", ZERO_OR_ONE, expect_string(assign_variable_callback_string(texture_file)),
-		"textureFile", ZERO_OR_ONE, expect_string(assign_variable_callback_string(texture_file)),
 		"noOfFrames", ZERO_OR_ONE, expect_uint(assign_variable_callback(no_of_frames)),
 
 		"norefcount", ZERO_OR_ONE, success_callback,
@@ -45,7 +44,7 @@ bool TextureSprite::_fill_key_map(key_map_t& key_map) {
 
 TileTextureSprite::TileTextureSprite() : texture_file {}, size {} {}
 
-bool TileTextureSprite::_fill_key_map(key_map_t& key_map) {
+bool TileTextureSprite::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map,
 		"texturefile", ZERO_OR_ONE, expect_string(assign_variable_callback_string(texture_file)),
@@ -59,7 +58,7 @@ bool TileTextureSprite::_fill_key_map(key_map_t& key_map) {
 
 ProgressBar::ProgressBar() : back_colour {}, progress_colour {} {}
 
-bool ProgressBar::_fill_key_map(key_map_t& key_map) {
+bool ProgressBar::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map,
 		"color", ONE_EXACTLY, expect_colour(assign_variable_callback(progress_colour)),
@@ -78,7 +77,7 @@ bool ProgressBar::_fill_key_map(key_map_t& key_map) {
 
 PieChart::PieChart() : size {} {}
 
-bool PieChart::_fill_key_map(key_map_t& key_map) {
+bool PieChart::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map, "size", ONE_EXACTLY, expect_uint(assign_variable_callback(size)));
 	return ret;
@@ -86,7 +85,7 @@ bool PieChart::_fill_key_map(key_map_t& key_map) {
 
 LineChart::LineChart() : size {}, linewidth {} {}
 
-bool LineChart::_fill_key_map(key_map_t& key_map) {
+bool LineChart::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map,
 		"size", ONE_EXACTLY, expect_ivec2(assign_variable_callback(size)),
@@ -98,7 +97,7 @@ bool LineChart::_fill_key_map(key_map_t& key_map) {
 
 MaskedFlag::MaskedFlag() : overlay_file {}, mask_file {} {}
 
-bool MaskedFlag::_fill_key_map(key_map_t& key_map) {
+bool MaskedFlag::_fill_key_map(case_insensitive_key_map_t& key_map) {
 	bool ret = Sprite::_fill_key_map(key_map);
 	ret &= add_key_map_entries(key_map,
 		"textureFile1", ONE_EXACTLY, expect_string(assign_variable_callback_string(overlay_file)),

--- a/src/openvic-simulation/interface/GFX.hpp
+++ b/src/openvic-simulation/interface/GFX.hpp
@@ -52,7 +52,7 @@ namespace OpenVic::GFX {
 	protected:
 		TextureSprite();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		TextureSprite(TextureSprite&&) = default;
@@ -70,7 +70,7 @@ namespace OpenVic::GFX {
 	protected:
 		TileTextureSprite();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		TileTextureSprite(TileTextureSprite&&) = default;
@@ -93,7 +93,7 @@ namespace OpenVic::GFX {
 	protected:
 		ProgressBar();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		ProgressBar(ProgressBar&&) = default;
@@ -110,7 +110,7 @@ namespace OpenVic::GFX {
 	protected:
 		PieChart();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		PieChart(PieChart&&) = default;
@@ -128,7 +128,7 @@ namespace OpenVic::GFX {
 	protected:
 		LineChart();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		LineChart(LineChart&&) = default;
@@ -146,7 +146,7 @@ namespace OpenVic::GFX {
 	protected:
 		MaskedFlag();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map) override;
 
 	public:
 		MaskedFlag(MaskedFlag&&) = default;

--- a/src/openvic-simulation/interface/GUI.cpp
+++ b/src/openvic-simulation/interface/GUI.cpp
@@ -8,7 +8,7 @@ using namespace OpenVic::NodeTools;
 
 Element::Element() : position {}, orientation { orientation_t::UPPER_LEFT } {}
 
-bool Element::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Element::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Named::_fill_key_map(key_map, ui_manager);
 	using enum orientation_t;
 	static const string_map_t<orientation_t> orientation_map = {
@@ -18,14 +18,13 @@ bool Element::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_m
 	};
 	ret &= add_key_map_entries(key_map,
 		"position", ONE_EXACTLY, expect_fvec2(assign_variable_callback(position)),
-		"orientation", ZERO_OR_ONE, expect_string(expect_mapped_string(orientation_map, assign_variable_callback(orientation))),
-		"Orientation", ZERO_OR_ONE, expect_string(expect_mapped_string(orientation_map, assign_variable_callback(orientation)))
+		"orientation", ZERO_OR_ONE, expect_string(expect_mapped_string(orientation_map, assign_variable_callback(orientation)))
 	);
 	return ret;
 }
 
 bool Element::_fill_elements_key_map(
-	NodeTools::key_map_t& key_map, callback_t<std::unique_ptr<Element>&&> callback, UIManager const& ui_manager
+	NodeTools::case_insensitive_key_map_t& key_map, callback_t<std::unique_ptr<Element>&&> callback, UIManager const& ui_manager
 ) {
 	bool ret = true;
 	ret &= add_key_map_entries(key_map,
@@ -42,7 +41,7 @@ bool Element::_fill_elements_key_map(
 	return ret;
 }
 
-bool Scene::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Scene::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	return Element::_fill_elements_key_map(key_map, [this](std::unique_ptr<Element>&& element) -> bool {
 		return scene_elements.add_item(std::move(element));
 	}, ui_manager);
@@ -59,7 +58,7 @@ node_callback_t Scene::expect_scene(
 
 Window::Window() : moveable { false }, fullscreen { false } {}
 
-bool Window::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Window::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_elements_key_map(key_map, [this](std::unique_ptr<Element>&& element) -> bool {
 		return window_elements.add_item(std::move(element));
 	}, ui_manager);
@@ -78,7 +77,7 @@ bool Window::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_ma
 
 Icon::Icon() : sprite { nullptr }, frame { GFX::NO_FRAMES } {}
 
-bool Icon::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Icon::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"spriteType", ONE_EXACTLY, expect_string(ui_manager.expect_sprite_str(assign_variable_callback_pointer(sprite))),
@@ -89,7 +88,7 @@ bool Icon::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_mana
 
 BaseButton::BaseButton() : sprite { nullptr } {}
 
-bool BaseButton::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool BaseButton::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	// look up sprite registry for texture sprite with name...
 	ret &= add_key_map_entries(key_map,
@@ -104,7 +103,7 @@ bool BaseButton::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& u
 
 Button::Button() : text {}, font { nullptr} {}
 
-bool Button::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Button::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = BaseButton::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"buttonText", ZERO_OR_ONE, expect_string(assign_variable_callback_string(text), true),
@@ -118,14 +117,14 @@ bool Button::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_ma
 	return ret;
 }
 
-bool Checkbox::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Checkbox::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = BaseButton::_fill_key_map(key_map, ui_manager);
 	return ret;
 }
 
 AlignedElement::AlignedElement() : format { format_t::left } {}
 
-bool AlignedElement::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool AlignedElement::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	using enum format_t;
 	static const string_map_t<format_t> format_map = {
@@ -139,7 +138,7 @@ bool AlignedElement::_fill_key_map(NodeTools::key_map_t& key_map, UIManager cons
 
 Text::Text() : text {}, font { nullptr } {}
 
-bool Text::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool Text::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = AlignedElement::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"text", ZERO_OR_ONE, expect_string(assign_variable_callback_string(text), true),
@@ -158,7 +157,7 @@ bool Text::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_mana
 
 OverlappingElementsBox::OverlappingElementsBox() : size {} {}
 
-bool OverlappingElementsBox::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool OverlappingElementsBox::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = AlignedElement::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"size", ONE_EXACTLY, expect_fvec2(assign_variable_callback(size)),
@@ -169,7 +168,7 @@ bool OverlappingElementsBox::_fill_key_map(NodeTools::key_map_t& key_map, UIMana
 
 ListBox::ListBox() : size {} {}
 
-bool ListBox::_fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) {
+bool ListBox::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
 		"backGround", ZERO_OR_ONE, success_callback,

--- a/src/openvic-simulation/interface/GUI.hpp
+++ b/src/openvic-simulation/interface/GUI.hpp
@@ -23,9 +23,9 @@ namespace OpenVic::GUI {
 	protected:
 		Element();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 		static bool _fill_elements_key_map(
-			NodeTools::key_map_t& key_map, NodeTools::callback_t<std::unique_ptr<Element>&&> callback,
+			NodeTools::case_insensitive_key_map_t& key_map, NodeTools::callback_t<std::unique_ptr<Element>&&> callback,
 			UIManager const& ui_manager
 		);
 
@@ -45,7 +45,7 @@ namespace OpenVic::GUI {
 	protected:
 		Scene() = default;
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Scene(Scene&&) = default;
@@ -72,7 +72,7 @@ namespace OpenVic::GUI {
 	protected:
 		Window();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Window(Window&&) = default;
@@ -90,7 +90,7 @@ namespace OpenVic::GUI {
 	protected:
 		Icon();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Icon(Icon&&) = default;
@@ -106,7 +106,7 @@ namespace OpenVic::GUI {
 	protected:
 		BaseButton();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		BaseButton(BaseButton&&) = default;
@@ -126,7 +126,7 @@ namespace OpenVic::GUI {
 	protected:
 		Button();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Button(Button&&) = default;
@@ -141,7 +141,7 @@ namespace OpenVic::GUI {
 	protected:
 		Checkbox() = default;
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Checkbox(Checkbox&&) = default;
@@ -162,7 +162,7 @@ namespace OpenVic::GUI {
 	protected:
 		AlignedElement();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		AlignedElement(AlignedElement&&) = default;
@@ -183,7 +183,7 @@ namespace OpenVic::GUI {
 	protected:
 		Text();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		Text(Text&&) = default;
@@ -201,7 +201,7 @@ namespace OpenVic::GUI {
 	protected:
 		OverlappingElementsBox();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		OverlappingElementsBox(OverlappingElementsBox&&) = default;
@@ -220,7 +220,7 @@ namespace OpenVic::GUI {
 	protected:
 		ListBox();
 
-		bool _fill_key_map(NodeTools::key_map_t& key_map, UIManager const& ui_manager) override;
+		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
 		ListBox(ListBox&&) = default;

--- a/src/openvic-simulation/interface/LoadBase.hpp
+++ b/src/openvic-simulation/interface/LoadBase.hpp
@@ -10,14 +10,14 @@ namespace OpenVic {
 	protected:
 		LoadBase() = default;
 
-		virtual bool _fill_key_map(NodeTools::key_map_t&, Context...) = 0;
+		virtual bool _fill_key_map(NodeTools::case_insensitive_key_map_t&, Context...) = 0;
 
 	public:
 		LoadBase(LoadBase&&) = default;
 		virtual ~LoadBase() = default;
 
 		bool load(ast::NodeCPtr node, Context... context) {
-			NodeTools::key_map_t key_map;
+			NodeTools::case_insensitive_key_map_t key_map;
 			bool ret = _fill_key_map(key_map, context...);
 			ret &= NodeTools::expect_dictionary_key_map(std::move(key_map))(node);
 			return ret;
@@ -45,7 +45,7 @@ namespace OpenVic {
 	protected:
 		Named() = default;
 
-		virtual bool _fill_key_map(NodeTools::key_map_t& key_map, Context...) override {
+		virtual bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, Context...) override {
 			using namespace OpenVic::NodeTools;
 			return add_key_map_entries(key_map, "name", ONE_EXACTLY, expect_string(assign_variable_callback_string(name)));
 		}

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -1,7 +1,5 @@
 #include "TerrainType.hpp"
 
-#include <limits>
-
 #include "openvic-simulation/types/Colour.hpp"
 
 using namespace OpenVic;
@@ -132,7 +130,9 @@ TerrainTypeMapping::index_t TerrainTypeManager::get_terrain_texture_limit() cons
 bool TerrainTypeManager::load_terrain_types(ModifierManager const& modifier_manager, ast::NodeCPtr root) {
 	const bool ret = expect_dictionary_keys_reserve_length_and_default(
 		terrain_type_mappings,
-		std::bind_front(&TerrainTypeManager::_load_terrain_type_mapping, this),
+		[this](std::string_view key, ast::NodeCPtr value) -> bool {
+			return _load_terrain_type_mapping(key, value);
+		},
 		"terrain", ONE_EXACTLY, expect_uint(assign_variable_callback(terrain_texture_limit)),
 		"categories", ONE_EXACTLY, _load_terrain_type_categories(modifier_manager)
 	)(root);

--- a/src/openvic-simulation/utility/Utility.hpp
+++ b/src/openvic-simulation/utility/Utility.hpp
@@ -81,6 +81,14 @@ namespace OpenVic::utility {
 	template<typename T, template<typename...> class Z>
 	inline constexpr bool is_specialization_of_v = is_specialization_of<T, Z>::value;
 
+	template <template<typename...> class Template, typename... Args>
+	void _derived_from_specialization_impl(const Template<Args...>&);
+
+	template <typename T, template<typename...> class Template>
+	concept is_derived_from_specialization_of = requires(const T& t) {
+		_derived_from_specialization_impl<Template>(t);
+	};
+
 	inline constexpr auto three_way(auto&& left, auto&& right) {
 		// This is Apple's fault again
 		#if __cpp_lib_three_way_comparison >= 201907L


### PR DESCRIPTION
- Added `StringMapCase`s, combining case [in]sensitive string hash and equal types, together with an intermediate struct that remembers the `StringMapCase` to help with template deduction for `string_map_t`s and `string_set_t`s.
- Replaced `IdentifierRegistry`'s `RegistryIdentifierMapInfo` with `StringMapCase` (the same concept restrictions, but now applied directly to the internal string map instead of being decomposed into hash and equal types).
- Made `expect_dictionary_keys` functions take a `StringMapCase` template argument,  so that they can also be case insensitive (used in GUI and GFX loading). This involved moving lots of functions from `NodeTools.cpp` to `NodeTools.hpp`, the only changes to them are adding the template parameters and replacing `*_callback_t` with `*Callback auto`.