### PR TITLE
Menu reqs: country index, flag type set, province set total population

### DIFF
--- a/src/openvic-simulation/country/Country.cpp
+++ b/src/openvic-simulation/country/Country.cpp
@@ -26,6 +26,7 @@ CountryParty::CountryParty(
 Country::Country(
 	std::string_view new_identifier,
 	colour_t new_colour,
+	size_t new_index,
 	GraphicalCultureType const& new_graphical_culture,
 	IdentifierRegistry<CountryParty>&& new_parties,
 	unit_names_map_t&& new_unit_names,
@@ -34,8 +35,8 @@ Country::Country(
 	colour_t new_primary_unit_colour,
 	colour_t new_secondary_unit_colour,
 	colour_t new_tertiary_unit_colour
-) : HasIdentifierAndColour {
-	new_identifier, new_colour, false },
+) : HasIdentifierAndColour { new_identifier, new_colour, false },
+	index { new_index },
 	graphical_culture { new_graphical_culture },
 	parties { std::move(new_parties) },
 	unit_names { std::move(new_unit_names) },
@@ -68,8 +69,8 @@ bool CountryManager::add_country(
 	static constexpr colour_t default_colour = colour_t::fill_as(colour_t::max_value);
 
 	return countries.add_item({
-		identifier, colour, *graphical_culture, std::move(parties), std::move(unit_names), dynamic_tag,
-		std::move(alternative_colours),
+		identifier, colour, countries.size(), *graphical_culture, std::move(parties), std::move(unit_names),
+		dynamic_tag, std::move(alternative_colours),
 		/* Default to country colour for the chest and grey for the others. Update later if necessary. */
 		colour, default_colour, default_colour
 	});

--- a/src/openvic-simulation/country/Country.hpp
+++ b/src/openvic-simulation/country/Country.hpp
@@ -48,6 +48,7 @@ namespace OpenVic {
 		using government_colour_map_t = ordered_map<GovernmentType const*, colour_t>;
 
 	private:
+		const size_t PROPERTY(index);
 		GraphicalCultureType const& PROPERTY(graphical_culture);
 		/* Not const to allow elements to be moved, otherwise a copy is forced
 		 * which causes a compile error as the copy constructor has been deleted. */
@@ -61,9 +62,9 @@ namespace OpenVic {
 		// Unit colours not const due to being added after construction
 
 		Country(
-			std::string_view new_identifier, colour_t new_colour, GraphicalCultureType const& new_graphical_culture,
-			IdentifierRegistry<CountryParty>&& new_parties, unit_names_map_t&& new_unit_names, bool new_dynamic_tag,
-			government_colour_map_t&& new_alternative_colours,
+			std::string_view new_identifier, colour_t new_colour, size_t new_index,
+			GraphicalCultureType const& new_graphical_culture, IdentifierRegistry<CountryParty>&& new_parties,
+			unit_names_map_t&& new_unit_names, bool new_dynamic_tag, government_colour_map_t&& new_alternative_colours,
 			colour_t new_primary_unit_colour, colour_t new_secondary_unit_colour, colour_t new_tertiary_unit_colour
 		);
 

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -95,12 +95,18 @@ ProvinceSet::provinces_t const& ProvinceSet::get_provinces() const {
 	return provinces;
 }
 
-Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_meta)
-	: HasIdentifierAndColour { new_identifier, new_colour, false }, meta { new_meta } {}
+Pop::pop_size_t ProvinceSet::calculate_total_population() const {
+	Pop::pop_size_t total_population = 0;
+
+	for (Province const* province : provinces) {
+		total_population += province->get_total_population();
+	}
+
+	return total_population;
+}
 
 ProvinceSetModifier::ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values)
 	: Modifier { new_identifier, std::move(new_values), 0 } {}
 
-bool Region::get_meta() const {
-	return meta;
-}
+Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_meta)
+	: HasIdentifierAndColour { new_identifier, new_colour, false }, meta { new_meta } {}

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -26,6 +26,7 @@ namespace OpenVic {
 		void reserve_more(size_t size);
 		bool contains_province(Province const* province) const;
 		provinces_t const& get_provinces() const;
+		Pop::pop_size_t calculate_total_population() const;
 	};
 
 	struct ProvinceSetModifier : Modifier, ProvinceSet {
@@ -47,13 +48,11 @@ namespace OpenVic {
 		 * Any region containing a province already listed in a
 		 * previously defined region is considered a meta region.
 		 */
-		const bool meta;
+		const bool PROPERTY(meta);
 
 		Region(std::string_view new_identifier, colour_t new_colour, bool new_meta);
 
 	public:
 		Region(Region&&) = default;
-
-		bool get_meta() const;
 	};
 }

--- a/src/openvic-simulation/politics/Government.cpp
+++ b/src/openvic-simulation/politics/Government.cpp
@@ -38,8 +38,8 @@ bool GovernmentTypeManager::add_government_type(
 	});
 
 	/* flag_type can be empty here for default/non-ideological flag */
-	if (ret && std::find(flag_types.begin(), flag_types.end(), flag_type) == flag_types.end()) {
-		flag_types.emplace_back(flag_type);
+	if (ret) {
+		flag_types.emplace(flag_type);
 	}
 
 	return ret;

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -29,7 +29,7 @@ namespace OpenVic {
 	struct GovernmentTypeManager {
 	private:
 		IdentifierRegistry<GovernmentType> IDENTIFIER_REGISTRY(government_type);
-		std::vector<std::string> PROPERTY(flag_types);
+		string_set_t PROPERTY(flag_types);
 
 	public:
 		bool add_government_type(

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -610,7 +610,7 @@ private:
 		return registry.expect_item_string(callback, allow_empty, warn); \
 	} \
 	constexpr NodeTools::NodeCallback auto expect_##singular##_identifier_or_string( \
-		NodeTools::Callback<decltype(registry)::external_value_type const_kw&> auto callback,bool allow_empty = false, \
+		NodeTools::Callback<decltype(registry)::external_value_type const_kw&> auto callback, bool allow_empty = false, \
 		bool warn = false \
 	) const_kw { \
 		return registry.expect_item_identifier_or_string(callback, allow_empty, warn); \


### PR DESCRIPTION
Small additions needed for main repo menu stuff:
- country index - to map countries to their flags in the flag sheet.
- `ProvinceSet::calculate_total_population` - to display the population of `Region`s in the population menu (later this will be changed to `State` populations, using the same function as states will be `ProvinceSet`s).

Minor tweaks:
- flag types are now stored in a `string_set_t` which handles the uniqueness checks for us.
- `Region::get_meta` is now created by the `PROPERTY` macro.
- whitespace/newline fixes in `IdentifierRegistry.hpp` and `Country.cpp`.