### PR TITLE
Add IndexedMap and use in low key count, high value density cases

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -69,7 +69,18 @@ bool InstanceManager::setup() {
 	}
 
 	bool ret = good_instance_manager.setup(definition_manager.get_economy_manager().get_good_definition_manager());
-	ret &= map_instance.setup(definition_manager.get_economy_manager().get_building_type_manager());
+	ret &= map_instance.setup(
+		definition_manager.get_economy_manager().get_building_type_manager(),
+		definition_manager.get_pop_manager().get_pop_types(),
+		definition_manager.get_politics_manager().get_ideology_manager().get_ideologies()
+	);
+	ret &= map_instance.get_state_manager().generate_states(map_instance);
+	ret &= country_instance_manager.generate_country_instances(
+		definition_manager.get_country_definition_manager(),
+		definition_manager.get_research_manager().get_technology_manager().get_technologies(),
+		definition_manager.get_research_manager().get_invention_manager().get_inventions(),
+		definition_manager.get_politics_manager().get_ideology_manager().get_ideologies()
+	);
 
 	game_instance_setup = true;
 
@@ -104,14 +115,10 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 
 	bool ret = map_instance.apply_history_to_provinces(
 		definition_manager.get_history_manager().get_province_manager(), today,
-		// TODO - the following arguments are for generating test pop attributes
-		definition_manager.get_politics_manager().get_ideology_manager(),
-		definition_manager.get_politics_manager().get_issue_manager(),
-		*definition_manager.get_country_definition_manager().get_country_definition_by_identifier("ENG")
+		// TODO - the following argument is for generating test pop attributes
+		definition_manager.get_politics_manager().get_issue_manager()
 	);
-	ret &= map_instance.get_state_manager().generate_states(map_instance);
 
-	ret &= country_instance_manager.generate_country_instances(definition_manager.get_country_definition_manager());
 	ret &= country_instance_manager.apply_history_to_countries(
 		definition_manager.get_history_manager().get_country_manager(), today, unit_instance_manager, map_instance
 	);

--- a/src/openvic-simulation/country/CountryDefinition.cpp
+++ b/src/openvic-simulation/country/CountryDefinition.cpp
@@ -25,7 +25,7 @@ CountryParty::CountryParty(
 CountryDefinition::CountryDefinition(
 	std::string_view new_identifier,
 	colour_t new_colour,
-	size_t new_index,
+	index_t new_index,
 	GraphicalCultureType const& new_graphical_culture,
 	IdentifierRegistry<CountryParty>&& new_parties,
 	unit_names_map_t&& new_unit_names,
@@ -35,7 +35,7 @@ CountryDefinition::CountryDefinition(
 	colour_t new_secondary_unit_colour,
 	colour_t new_tertiary_unit_colour
 ) : HasIdentifierAndColour { new_identifier, new_colour, false },
-	index { new_index },
+	HasIndex { new_index },
 	graphical_culture { new_graphical_culture },
 	parties { std::move(new_parties) },
 	unit_names { std::move(new_unit_names) },

--- a/src/openvic-simulation/country/CountryDefinition.hpp
+++ b/src/openvic-simulation/country/CountryDefinition.hpp
@@ -41,14 +41,13 @@ namespace OpenVic {
 	};
 
 	/* Generic information about a TAG */
-	struct CountryDefinition : HasIdentifierAndColour {
+	struct CountryDefinition : HasIdentifierAndColour, HasIndex<> {
 		friend struct CountryDefinitionManager;
 
 		using unit_names_map_t = ordered_map<UnitType const*, name_list_t>;
 		using government_colour_map_t = ordered_map<GovernmentType const*, colour_t>;
 
 	private:
-		const size_t PROPERTY(index);
 		GraphicalCultureType const& PROPERTY(graphical_culture);
 		/* Not const to allow elements to be moved, otherwise a copy is forced
 		 * which causes a compile error as the copy constructor has been deleted. */
@@ -62,7 +61,7 @@ namespace OpenVic {
 		// Unit colours not const due to being added after construction
 
 		CountryDefinition(
-			std::string_view new_identifier, colour_t new_colour, size_t new_index,
+			std::string_view new_identifier, colour_t new_colour, index_t new_index,
 			GraphicalCultureType const& new_graphical_culture, IdentifierRegistry<CountryParty>&& new_parties,
 			unit_names_map_t&& new_unit_names, bool new_dynamic_tag, government_colour_map_t&& new_alternative_colours,
 			colour_t new_primary_unit_colour, colour_t new_secondary_unit_colour, colour_t new_tertiary_unit_colour

--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -538,7 +538,10 @@ bool Dataloader::_load_history(DefinitionManager& definition_manager, bool unuse
 				}
 
 				return country_history_manager.load_country_history_file(
-					definition_manager, *this, *country, parse_defines(file).get_file_node()
+					definition_manager, *this, *country,
+					definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
+					definition_manager.get_politics_manager().get_government_type_manager().get_government_types(),
+					parse_defines(file).get_file_node()
 				);
 			}
 		);

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -12,6 +12,7 @@
 #include "openvic-simulation/types/Colour.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
+#include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/Vector.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
@@ -534,6 +535,26 @@ namespace OpenVic {
 				}
 				Logger::warn_or_error(warn, "Duplicate map entry with key: \"", key, "\"");
 				return warn;
+			};
+		}
+
+		template<typename Key, typename Value>
+		Callback<Value> auto map_callback(
+			IndexedMap<Key, Value>& map, Key const* key, bool warn = false
+		) {
+			return [&map, key, warn](Value value) -> bool {
+				if (key == nullptr) {
+					Logger::error("Null key in map_callback");
+					return false;
+				}
+				Value& map_value = map[*key];
+				bool ret = true;
+				if (map_value != Value {}) {
+					Logger::warn_or_error(warn, "Duplicate map entry with key: \"", key, "\"");
+					ret = warn;
+				}
+				map_value = std::move(value);
+				return ret;
 			};
 		}
 

--- a/src/openvic-simulation/economy/GoodDefinition.cpp
+++ b/src/openvic-simulation/economy/GoodDefinition.cpp
@@ -10,7 +10,7 @@ GoodCategory::GoodCategory(std::string_view new_identifier) : HasIdentifier { ne
 GoodDefinition::GoodDefinition(
 	std::string_view new_identifier, colour_t new_colour, index_t new_index, GoodCategory const& new_category,
 	price_t new_base_price, bool new_available_from_start, bool new_tradeable, bool new_money, bool new_overseas_penalty
-) : HasIdentifierAndColour { new_identifier, new_colour, false }, index { new_index }, category { new_category },
+) : HasIdentifierAndColour { new_identifier, new_colour, false }, HasIndex { new_index }, category { new_category },
 	base_price { new_base_price }, available_from_start { new_available_from_start }, tradeable { new_tradeable },
 	money { new_money }, overseas_penalty { new_overseas_penalty } {
 	assert(base_price > NULL_PRICE);

--- a/src/openvic-simulation/economy/GoodDefinition.hpp
+++ b/src/openvic-simulation/economy/GoodDefinition.hpp
@@ -28,10 +28,8 @@ namespace OpenVic {
 	 * ECON-238, ECON-239, ECON-240, ECON-241, ECON-242, ECON-243, ECON-244, ECON-245, ECON-246, ECON-247, ECON-248, ECON-249,
 	 * ECON-250, ECON-251, ECON-252, ECON-253, ECON-254, ECON-255, ECON-256, ECON-257, ECON-258, ECON-259, ECON-260, ECON-261
 	 */
-	struct GoodDefinition : HasIdentifierAndColour {
+	struct GoodDefinition : HasIdentifierAndColour, HasIndex<> {
 		friend struct GoodDefinitionManager;
-
-		using index_t = size_t;
 
 		using price_t = fixed_point_t;
 		static constexpr price_t NULL_PRICE = fixed_point_t::_0();
@@ -39,7 +37,6 @@ namespace OpenVic {
 		using good_definition_map_t = fixed_point_map_t<GoodDefinition const*>;
 
 	private:
-		const index_t PROPERTY(index);
 		GoodCategory const& PROPERTY(category);
 		const price_t PROPERTY(base_price);
 		const bool PROPERTY_CUSTOM_PREFIX(available_from_start, is);

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -49,7 +49,11 @@ ProvinceDefinition::index_t MapInstance::get_selected_province_index() const {
 		: ProvinceDefinition::NULL_INDEX;
 }
 
-bool MapInstance::setup(BuildingTypeManager const& building_type_manager) {
+bool MapInstance::setup(
+	BuildingTypeManager const& building_type_manager,
+	decltype(ProvinceInstance::pop_type_distribution)::keys_t const& pop_type_keys,
+	decltype(ProvinceInstance::ideology_distribution)::keys_t const& ideology_keys
+) {
 	if (province_instances_are_locked()) {
 		Logger::error("Cannot setup map - province instances are locked!");
 		return false;
@@ -64,7 +68,7 @@ bool MapInstance::setup(BuildingTypeManager const& building_type_manager) {
 	province_instances.reserve(map_definition.get_province_definition_count());
 
 	for (ProvinceDefinition const& province : map_definition.get_province_definitions()) {
-		ret &= province_instances.add_item({ province });
+		ret &= province_instances.add_item({ province, pop_type_keys, ideology_keys });
 	}
 
 	province_instances.lock();
@@ -85,8 +89,7 @@ bool MapInstance::setup(BuildingTypeManager const& building_type_manager) {
 }
 
 bool MapInstance::apply_history_to_provinces(
-	ProvinceHistoryManager const& history_manager, Date date, IdeologyManager const& ideology_manager,
-	IssueManager const& issue_manager, CountryDefinition const& country
+	ProvinceHistoryManager const& history_manager, Date date, IssueManager const& issue_manager
 ) {
 	bool ret = true;
 
@@ -109,7 +112,7 @@ bool MapInstance::apply_history_to_provinces(
 				if (pop_history_entry != nullptr) {
 					province.add_pop_vec(pop_history_entry->get_pops());
 
-					province.setup_pop_test_values(ideology_manager, issue_manager, country);
+					province.setup_pop_test_values(issue_manager);
 				}
 			}
 		}

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -10,9 +10,7 @@ namespace OpenVic {
 	struct MapDefinition;
 	struct BuildingTypeManager;
 	struct ProvinceHistoryManager;
-	struct IdeologyManager;
 	struct IssueManager;
-	struct CountryDefinition;
 
 	/* REQUIREMENTS:
 	 * MAP-4
@@ -44,10 +42,13 @@ namespace OpenVic {
 		ProvinceInstance* get_selected_province();
 		ProvinceDefinition::index_t get_selected_province_index() const;
 
-		bool setup(BuildingTypeManager const& building_type_manager);
+		bool setup(
+			BuildingTypeManager const& building_type_manager,
+			decltype(ProvinceInstance::pop_type_distribution)::keys_t const& pop_type_keys,
+			decltype(ProvinceInstance::ideology_distribution)::keys_t const& ideology_keys
+		);
 		bool apply_history_to_provinces(
-			ProvinceHistoryManager const& history_manager, Date date, IdeologyManager const& ideology_manager,
-			IssueManager const& issue_manager, CountryDefinition const& country
+			ProvinceHistoryManager const& history_manager, Date date, IssueManager const& issue_manager
 		);
 
 		void update_gamestate(Date today);

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -14,7 +14,7 @@ using namespace OpenVic::colour_literals;
 
 Mapmode::Mapmode(
 	std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func
-) : HasIdentifier { new_identifier }, index { new_index }, colour_func { new_colour_func } {
+) : HasIdentifier { new_identifier }, HasIndex { new_index }, colour_func { new_colour_func } {
 	assert(colour_func != nullptr);
 }
 

--- a/src/openvic-simulation/map/Mapmode.hpp
+++ b/src/openvic-simulation/map/Mapmode.hpp
@@ -11,7 +11,7 @@ namespace OpenVic {
 	struct MapInstance;
 	struct ProvinceInstance;
 
-	struct Mapmode : HasIdentifier {
+	struct Mapmode : HasIdentifier, HasIndex<> {
 		friend struct MapmodeManager;
 
 		/* Bottom 32 bits are the base colour, top 32 are the stripe colour, both in ARGB format with the alpha channels
@@ -24,10 +24,8 @@ namespace OpenVic {
 			constexpr base_stripe_t(colour_argb_t both) : base_stripe_t { both, both } {}
 		};
 		using colour_func_t = std::function<base_stripe_t(MapInstance const&, ProvinceInstance const&)>;
-		using index_t = size_t;
 
 	private:
-		const index_t PROPERTY(index);
 		const colour_func_t colour_func;
 
 		Mapmode(std::string_view new_identifier, index_t new_index, colour_func_t new_colour_func);

--- a/src/openvic-simulation/map/ProvinceDefinition.cpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.cpp
@@ -9,7 +9,7 @@ using namespace OpenVic::NodeTools;
 
 ProvinceDefinition::ProvinceDefinition(
 	std::string_view new_identifier, colour_t new_colour, index_t new_index
-) : HasIdentifierAndColour { new_identifier, new_colour, true }, index { new_index }, region { nullptr },
+) : HasIdentifierAndColour { new_identifier, new_colour, true }, HasIndex { new_index }, region { nullptr },
 	climate { nullptr }, continent { nullptr }, on_map { false }, water { false }, coastal { false },
 	port { false }, port_adjacent_province { nullptr }, default_terrain_type { nullptr }, adjacencies {}, centre {},
 	positions {} {
@@ -22,7 +22,7 @@ bool ProvinceDefinition::operator==(ProvinceDefinition const& other) const {
 
 std::string ProvinceDefinition::to_string() const {
 	std::stringstream stream;
-	stream << "(#" << std::to_string(index) << ", " << get_identifier() << ", 0x" << get_colour() << ")";
+	stream << "(#" << std::to_string(get_index()) << ", " << get_identifier() << ", 0x" << get_colour() << ")";
 	return stream.str();
 }
 

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -24,10 +24,9 @@ namespace OpenVic {
 	 * MAP-5, MAP-7, MAP-8, MAP-43, MAP-47
 	 * POP-22
 	 */
-	struct ProvinceDefinition : HasIdentifierAndColour {
+	struct ProvinceDefinition : HasIdentifierAndColour, HasIndex<uint16_t> {
 		friend struct MapDefinition;
 
-		using index_t = uint16_t;
 		using distance_t = fixed_point_t; // should this go inside adjacency_t?
 
 		struct adjacency_t {
@@ -84,7 +83,6 @@ namespace OpenVic {
 
 	private:
 		/* Immutable attributes (unchanged after initial game load) */
-		const index_t PROPERTY(index);
 		Region const* PROPERTY(region);
 		Climate const* PROPERTY(climate);
 		Continent const* PROPERTY(continent);

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -21,7 +21,6 @@ namespace OpenVic {
 	struct Religion;
 	struct BuildingTypeManager;
 	struct ProvinceHistoryEntry;
-	struct IdeologyManager;
 	struct IssueManager;
 
 	template<UnitType::branch_t>
@@ -61,12 +60,15 @@ namespace OpenVic {
 
 		std::vector<Pop> PROPERTY(pops);
 		Pop::pop_size_t PROPERTY(total_population);
-		fixed_point_map_t<PopType const*> PROPERTY(pop_type_distribution);
-		fixed_point_map_t<Ideology const*> PROPERTY(ideology_distribution);
+		IndexedMap<PopType, fixed_point_t> PROPERTY(pop_type_distribution);
+		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
 		fixed_point_map_t<Religion const*> PROPERTY(religion_distribution);
 
-		ProvinceInstance(ProvinceDefinition const& new_province_definition);
+		ProvinceInstance(
+			ProvinceDefinition const& new_province_definition, decltype(pop_type_distribution)::keys_t const& pop_type_keys,
+			decltype(ideology_distribution)::keys_t const& ideology_keys
+		);
 
 		void _add_pop(Pop&& pop);
 		void _update_pops();
@@ -116,8 +118,6 @@ namespace OpenVic {
 		bool setup(BuildingTypeManager const& building_type_manager);
 		bool apply_history_to_province(ProvinceHistoryEntry const* entry);
 
-		void setup_pop_test_values(
-			IdeologyManager const& ideology_manager, IssueManager const& issue_manager, CountryDefinition const& country
-		);
+		void setup_pop_test_values(IssueManager const& issue_manager);
 	};
 }

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -1,5 +1,7 @@
 #include "NationalFocus.hpp"
 
+#include "openvic-simulation/politics/Ideology.hpp"
+
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
@@ -16,13 +18,12 @@ NationalFocus::NationalFocus(
 	Ideology const* new_loyalty_ideology,
 	fixed_point_t new_loyalty_value,
 	ConditionScript&& new_limit
-) : HasIdentifier { new_identifier },
+) : Modifier { new_identifier, std::move(new_modifiers), 0 },
 	group { new_group },
 	icon { new_icon },
 	has_flashpoint { new_has_flashpoint },
 	own_provinces { new_own_provinces },
 	outliner_show_as_percent { new_outliner_show_as_percent },
-	modifiers { std::move(new_modifiers) },
 	loyalty_ideology { new_loyalty_ideology },
 	loyalty_value { new_loyalty_value },
 	limit { std::move(new_limit) } {}

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/economy/GoodDefinition.hpp"
 #include "openvic-simulation/misc/Modifier.hpp"
-#include "openvic-simulation/politics/Ideology.hpp"
-#include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/scripts/ConditionScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
@@ -18,7 +15,9 @@ namespace OpenVic {
 		NationalFocusGroup(std::string_view new_identifier);
 	};
 
-	struct NationalFocus : HasIdentifier {
+	struct Ideology;
+
+	struct NationalFocus : Modifier {
 		friend struct NationalFocusManager;
 
 	private:
@@ -27,7 +26,6 @@ namespace OpenVic {
 		bool PROPERTY(has_flashpoint);
 		bool PROPERTY(own_provinces);
 		bool PROPERTY(outliner_show_as_percent);
-		ModifierValue PROPERTY(modifiers);
 		Ideology const* PROPERTY(loyalty_ideology);
 		fixed_point_t PROPERTY(loyalty_value);
 		ConditionScript PROPERTY(limit);
@@ -50,6 +48,10 @@ namespace OpenVic {
 	public:
 		NationalFocus(NationalFocus&&) = default;
 	};
+
+	struct PopManager;
+	struct IdeologyManager;
+	struct GoodDefinitionManager;
 
 	struct NationalFocusManager {
 	private:

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -10,6 +10,7 @@
 #include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/types/EnumBitfield.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/IndexedMap.hpp"
 
 namespace OpenVic {
 
@@ -68,9 +69,9 @@ namespace OpenVic {
 
 		fixed_point_t PROPERTY(literacy);
 
-		fixed_point_map_t<Ideology const*> PROPERTY(ideologies);
+		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideologies);
 		fixed_point_map_t<Issue const*> PROPERTY(issues);
-		fixed_point_map_t<CountryParty const*> PROPERTY(votes);
+		IndexedMap<CountryParty, fixed_point_t> PROPERTY(votes);
 
 		fixed_point_t PROPERTY(unemployment);
 		fixed_point_t PROPERTY(cash);
@@ -81,7 +82,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(everyday_needs_fulfilled);
 		fixed_point_t PROPERTY(luxury_needs_fulfilled);
 
-		Pop(PopBase const& pop_base);
+		Pop(PopBase const& pop_base, decltype(ideologies)::keys_t const& ideology_keys);
 
 	public:
 		Pop(Pop const&) = delete;
@@ -89,9 +90,7 @@ namespace OpenVic {
 		Pop& operator=(Pop const&) = delete;
 		Pop& operator=(Pop&&) = delete;
 
-		void setup_pop_test_values(
-			IdeologyManager const& ideology_manager, IssueManager const& issue_manager, CountryDefinition const& country
-		);
+		void setup_pop_test_values(IssueManager const& issue_manager);
 
 		void set_location(ProvinceInstance const& new_location);
 	};

--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -85,4 +85,22 @@ namespace OpenVic {
 
 	using HasIdentifierAndColour = _HasIdentifierAndColour<colour_t>;
 	using HasIdentifierAndAlphaColour = _HasIdentifierAndColour<colour_argb_t>;
+
+	template<std::unsigned_integral T = size_t>
+	class HasIndex {
+	public:
+		using index_t = T;
+
+	private:
+		const index_t PROPERTY(index);
+
+	protected:
+		HasIndex(index_t new_index) : index { new_index } {}
+		HasIndex(HasIndex const&) = default;
+
+	public:
+		HasIndex(HasIndex&&) = default;
+		HasIndex& operator=(HasIndex const&) = delete;
+		HasIndex& operator=(HasIndex&&) = delete;
+	};
 }

--- a/src/openvic-simulation/types/IndexedMap.hpp
+++ b/src/openvic-simulation/types/IndexedMap.hpp
@@ -1,0 +1,220 @@
+#pragma once
+
+#include <concepts>
+#include <vector>
+
+#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
+#include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/Logger.hpp"
+
+namespace OpenVic {
+
+	template<typename Key, typename Value>
+	struct IndexedMap : private std::vector<Value> {
+		using container_t = std::vector<Value>;
+		using key_t = Key;
+		using value_t = Value;
+		using keys_t = std::vector<key_t>;
+
+		using container_t::operator[];
+		using container_t::size;
+		using container_t::begin;
+		using container_t::end;
+
+	private:
+		keys_t const* PROPERTY(keys);
+
+	public:
+		constexpr IndexedMap(keys_t const* new_keys) : keys { nullptr } {
+			set_keys(new_keys);
+		}
+
+		IndexedMap(IndexedMap const&) = default;
+		IndexedMap(IndexedMap&&) = default;
+		IndexedMap& operator=(IndexedMap const&) = default;
+		IndexedMap& operator=(IndexedMap&&) = default;
+
+		constexpr void fill(value_t const& value) {
+			std::fill(container_t::begin(), container_t::end(), value);
+		}
+
+		constexpr void clear() {
+			fill({});
+		}
+
+		constexpr bool has_keys() const {
+			return keys != nullptr;
+		}
+
+		constexpr void set_keys(keys_t const* new_keys) {
+			if (keys != new_keys) {
+				keys = new_keys;
+
+				container_t::resize(keys != nullptr ? keys->size() : 0);
+				clear();
+			}
+		}
+
+		constexpr size_t get_index_from_item(key_t const& key) const {
+			if (has_keys() && keys->data() <= &key && &key <= &keys->back()) {
+				return std::distance(keys->data(), &key);
+			} else {
+				return 0;
+			}
+		}
+
+		constexpr value_t* get_item_by_key(key_t const& key) {
+			const size_t index = get_index_from_item(key);
+			if (index < container_t::size()) {
+				return &container_t::operator[](index);
+			}
+			return nullptr;
+		}
+
+		constexpr value_t const* get_item_by_key(key_t const& key) const {
+			const size_t index = get_index_from_item(key);
+			if (index < container_t::size()) {
+				return &container_t::operator[](index);
+			}
+			return nullptr;
+		}
+
+		constexpr key_t const& operator()(size_t index) const {
+			return (*keys)[index];
+		}
+
+		constexpr key_t const* get_key_by_index(size_t index) const {
+			if (keys != nullptr && index < keys->size()) {
+				return &(*this)(index);
+			} else {
+				return nullptr;
+			}
+		}
+
+		constexpr value_t& operator[](key_t const& key) {
+			return container_t::operator[](get_index_from_item(key));
+		}
+
+		constexpr value_t const& operator[](key_t const& key) const {
+			return container_t::operator[](get_index_from_item(key));
+		}
+
+		constexpr IndexedMap& operator+=(IndexedMap const& other) {
+			const size_t count = std::min(container_t::size(), other.size());
+			for (size_t index = 0; index < count; ++index) {
+				container_t::operator[](index) += other[index];
+			}
+			return *this;
+		}
+
+		constexpr IndexedMap& operator*=(value_t factor) {
+			for (value_t& value : *this) {
+				value *= factor;
+			}
+			return *this;
+		}
+
+		constexpr IndexedMap& operator/=(value_t divisor) {
+			for (value_t& value : *this) {
+				value /= divisor;
+			}
+			return *this;
+		}
+
+		constexpr IndexedMap operator+(IndexedMap const& other) const {
+			IndexedMap ret = *this;
+			ret += other;
+			return ret;
+		}
+
+		constexpr IndexedMap operator*(value_t factor) const {
+			IndexedMap ret = *this;
+			ret *= factor;
+			return ret;
+		}
+
+		constexpr IndexedMap operator/(value_t divisor) const {
+			IndexedMap ret = *this;
+			ret /= divisor;
+			return ret;
+		}
+
+		constexpr value_t get_total() const {
+			value_t total {};
+			for (value_t const& value : *this) {
+				total += value;
+			}
+			return total;
+		}
+
+		constexpr IndexedMap& normalise() {
+			const value_t total = get_total();
+			if (total > 0) {
+				*this /= total;
+			}
+			return *this;
+		}
+
+		constexpr bool copy(IndexedMap const& other) {
+			if (keys != other.keys) {
+				Logger::error(
+					"Trying to copy IndexedMaps with different keys with sizes: from ", other.size(), " to ",
+					container_t::size()
+				);
+				return false;
+			}
+			static_cast<container_t&>(*this) = other;
+			return true;
+		}
+
+		fixed_point_map_t<key_t const *> to_fixed_point_map() const
+		requires(std::same_as<value_t, fixed_point_t>)
+		{
+			fixed_point_map_t<key_t const *> result;
+
+			for (size_t index = 0; index < container_t::size(); index++) {
+				fixed_point_t const& value = container_t::operator[](index);
+				if (value != 0) {
+					result[&(*this)(index)] = value;
+				}
+			}
+
+			return result;
+		}
+	};
+
+	template<typename FPMKey, std::derived_from<FPMKey> IMKey>
+	constexpr fixed_point_map_t<FPMKey const*>& operator+=(
+		fixed_point_map_t<FPMKey const*>& lhs, IndexedMap<IMKey, fixed_point_t> const& rhs
+	) {
+		for (size_t index = 0; index < rhs.size(); index++) {
+			fixed_point_t const& value = rhs[index];
+			if (value != 0) {
+				lhs[&rhs(index)] += value;
+			}
+		}
+		return lhs;
+	}
+
+	/* Result is determined by comparing the first pair of unequal values,
+	 * iterating from the highest index downward. */
+	template<typename Key, typename Value>
+	constexpr bool sorted_indexed_map_less_than(
+		IndexedMap<Key, Value> const& lhs, IndexedMap<Key, Value> const& rhs
+	) {
+		if (lhs.get_keys() != rhs.get_keys() || lhs.size() != rhs.size()) {
+			Logger::error("Trying to compare IndexedMaps with different keys/sizes: ", lhs.size(), " vs ", rhs.size());
+			return false;
+		}
+
+		for (size_t index = lhs.size(); index > 0;) {
+			index--;
+			const std::strong_ordering value_cmp = lhs[index] <=> rhs[index];
+			if (value_cmp != std::strong_ordering::equal) {
+				return value_cmp == std::strong_ordering::less;
+			}
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
There are probably more places we can switch to using IndexedMap, e.g. for a Pop's Reform/Issue support distribution (although their current setup using separate registries/indexing means they can't be stored in a single IndexedMap), but I'll leave those for future PRs.