### PR TITLE
Cleanup: inheritance, const movable variables, code formatting

### DIFF
--- a/src/openvic-simulation/country/CountryDefinition.cpp
+++ b/src/openvic-simulation/country/CountryDefinition.cpp
@@ -121,7 +121,7 @@ bool CountryDefinitionManager::load_countries(
 	return ret;
 }
 
-bool CountryDefinitionManager::load_country_colours(ast::NodeCPtr root){
+bool CountryDefinitionManager::load_country_colours(ast::NodeCPtr root) {
 	return country_definitions.expect_item_dictionary([](CountryDefinition& country, ast::NodeCPtr colour_node) -> bool {
 		return expect_dictionary_keys(
 			"color1", ONE_EXACTLY, expect_colour(assign_variable_callback(country.primary_unit_colour)),

--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -104,7 +104,6 @@ static NodeCallback auto _expect_string(Callback<ovdl::symbol<char>> auto callba
 	return _expect_type<ast::StringValue>(_abstract_symbol_node_callback<ast::StringValue>(callback, allow_empty));
 }
 
-
 node_callback_t NodeTools::expect_identifier_or_string(callback_t<std::string_view> callback, bool allow_empty) {
 	return [callback, allow_empty](ast::NodeCPtr node) -> bool {
 		if (node != nullptr) {

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -25,7 +25,7 @@
 namespace OpenVic {
 	namespace ast {
 		using namespace ovdl::v2script::ast;
-		using NodeCPtr = const Node*;
+		using NodeCPtr = Node const*;
 
 		constexpr std::string_view get_type_name(NodeKind kind) {
 #define NODE_CASE(Node) \

--- a/src/openvic-simulation/dataloader/Vic2PathSearch.cpp
+++ b/src/openvic-simulation/dataloader/Vic2PathSearch.cpp
@@ -42,7 +42,7 @@ static constexpr bool path_equals(std::string_view lhs, std::string_view rhs) {
 template<typename T>
 concept is_filename = std::same_as<T, std::filesystem::path> || std::convertible_to<T, std::string_view>;
 
-static bool filename_equals(const is_filename auto& lhs, const is_filename auto& rhs) {
+static bool filename_equals(is_filename auto const& lhs, is_filename auto const& rhs) {
 	auto left = [&lhs] {
 		if constexpr (std::same_as<std::decay_t<decltype(lhs)>, std::filesystem::path>) {
 			return lhs.filename().string();
@@ -230,7 +230,7 @@ static fs::path _search_for_game_path(fs::path hint_path = {}) {
 		// Array of strings contain "0" to std::to_string(max_amount_of_steam_libraries - 1)
 		static constexpr auto library_indexes = OpenVic::ConstexprIntToStr::make_itosv_array<max_amount_of_steam_libraries>();
 
-		for (const auto& index : library_indexes) {
+		for (auto const& index : library_indexes) {
 			decltype(current_node) node = std::nullopt;
 
 			auto it = current_node.value().find(index);
@@ -336,7 +336,7 @@ static fs::path _search_for_game_path(fs::path hint_path = {}) {
 
 fs::path Dataloader::search_for_game_path(fs::path hint_path) {
 	struct fshash {
-		size_t operator()(const std::filesystem::path& p) const noexcept {
+		size_t operator()(std::filesystem::path const& p) const noexcept {
 			return std::filesystem::hash_value(p);
 		}
 	};

--- a/src/openvic-simulation/dataloader/Vic2PathSearch_Windows.hpp
+++ b/src/openvic-simulation/dataloader/Vic2PathSearch_Windows.hpp
@@ -55,7 +55,7 @@ namespace OpenVic::Windows {
 
 	template<typename T>
 	concept has_data = requires(T t) {
-		{ t.data() } -> std::convertible_to<const typename T::value_type*>;
+		{ t.data() } -> std::convertible_to<typename T::value_type const*>;
 	};
 
 	class RegistryKey {
@@ -116,7 +116,7 @@ namespace OpenVic::Windows {
 			DWORD data_size;
 			DWORD type;
 
-			const auto& wide_value = [&value_name]() -> has_data auto {
+			auto const& wide_value = [&value_name]() -> has_data auto {
 				if constexpr (std::is_same_v<CHAR_T, char>) {
 					return convert(value_name);
 				} else {
@@ -161,7 +161,7 @@ namespace OpenVic::Windows {
 	}
 
 	template<either_char_type RCHAR_T, either_char_type CHAR_T, either_char_type CHAR_T2>
-	std::basic_string<RCHAR_T> ReadRegValue(HKEY root, const CHAR_T* key, const CHAR_T2* name) {
+	std::basic_string<RCHAR_T> ReadRegValue(HKEY root, CHAR_T const* key, CHAR_T2 const* name) {
 		auto key_sv = std::basic_string_view(key);
 		auto name_sv = std::basic_string_view(name);
 

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
@@ -13,9 +13,7 @@ DiplomaticActionType::DiplomaticActionType(DiplomaticActionType::Initializer&& i
 	get_acceptance { std::move(initializer.get_acceptance) } {}
 
 CancelableDiplomaticActionType::CancelableDiplomaticActionType(CancelableDiplomaticActionType::Initializer&& initializer)
-	: allowed_to_cancel { std::move(initializer.allowed_cancel) }, DiplomaticActionType(std::move(initializer)) {}
-
-DiplomaticActionManager::DiplomaticActionManager() {}
+	: allowed_to_cancel { std::move(initializer.allowed_cancel) }, DiplomaticActionType { std::move(initializer) } {}
 
 bool DiplomaticActionManager::add_diplomatic_action(
 	std::string_view identifier, DiplomaticActionType::Initializer&& initializer

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
@@ -123,7 +123,7 @@ namespace OpenVic {
 		IdentifierRegistry<DiplomaticActionTypeStorage> IDENTIFIER_REGISTRY(diplomatic_action_type);
 
 	public:
-		DiplomaticActionManager();
+		DiplomaticActionManager() = default;
 
 		bool add_diplomatic_action(std::string_view identifier, DiplomaticActionType::Initializer&& initializer);
 		bool add_cancelable_diplomatic_action(

--- a/src/openvic-simulation/economy/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/ResourceGatheringOperation.cpp
@@ -3,14 +3,19 @@
 using namespace OpenVic;
 
 ResourceGatheringOperation::ResourceGatheringOperation(
-	ProductionType const& new_production_type, const fixed_point_t new_size_multiplier,
-	const fixed_point_t new_revenue_yesterday, const fixed_point_t new_output_quantity_yesterday,
-	const fixed_point_t new_unsold_quantity_yesterday, ordered_map<Pop*, Pop::pop_size_t>&& new_employees
-)
-	: production_type { new_production_type }, revenue_yesterday { new_revenue_yesterday },
-	  output_quantity_yesterday { new_output_quantity_yesterday }, unsold_quantity_yesterday { new_unsold_quantity_yesterday },
-	  size_multiplier { new_size_multiplier }, employees { std::move(new_employees) } {}
+	ProductionType const& new_production_type,
+	fixed_point_t new_size_multiplier,
+	fixed_point_t new_revenue_yesterday,
+	fixed_point_t new_output_quantity_yesterday,
+	fixed_point_t new_unsold_quantity_yesterday,
+	ordered_map<Pop*, Pop::pop_size_t>&& new_employees
+) : production_type { new_production_type },
+	revenue_yesterday { new_revenue_yesterday },
+	output_quantity_yesterday { new_output_quantity_yesterday },
+	unsold_quantity_yesterday { new_unsold_quantity_yesterday },
+	size_multiplier { new_size_multiplier },
+	employees { std::move(new_employees) } {}
+
 ResourceGatheringOperation::ResourceGatheringOperation(
-	ProductionType const& new_production_type, const fixed_point_t new_size_multiplier
-)
-	: ResourceGatheringOperation(new_production_type, new_size_multiplier, 0, 0, 0, {}) {}
+	ProductionType const& new_production_type, fixed_point_t new_size_multiplier
+) : ResourceGatheringOperation { new_production_type, new_size_multiplier, 0, 0, 0, {} } {}

--- a/src/openvic-simulation/economy/ResourceGatheringOperation.hpp
+++ b/src/openvic-simulation/economy/ResourceGatheringOperation.hpp
@@ -16,10 +16,13 @@ namespace OpenVic {
 
 	public:
 		ResourceGatheringOperation(
-			ProductionType const& new_production_type, const fixed_point_t new_size_multiplier,
-			const fixed_point_t new_revenue_yesterday, const fixed_point_t new_output_quantity_yesterday,
-			const fixed_point_t new_unsold_quantity_yesterday, ordered_map<Pop*, Pop::pop_size_t>&& new_employees
+			ProductionType const& new_production_type,
+			fixed_point_t new_size_multiplier,
+			fixed_point_t new_revenue_yesterday,
+			fixed_point_t new_output_quantity_yesterday,
+			fixed_point_t new_unsold_quantity_yesterday,
+			ordered_map<Pop*, Pop::pop_size_t>&& new_employees
 		);
-		ResourceGatheringOperation(ProductionType const& new_production_type, const fixed_point_t new_size_multiplier);
+		ResourceGatheringOperation(ProductionType const& new_production_type, fixed_point_t new_size_multiplier);
 	};
 }

--- a/src/openvic-simulation/history/Bookmark.cpp
+++ b/src/openvic-simulation/history/Bookmark.cpp
@@ -11,10 +11,19 @@ using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
 Bookmark::Bookmark(
-	size_t new_index, std::string_view new_name, std::string_view new_description, Date new_date, uint32_t new_initial_camera_x,
+	index_t new_index,
+	std::string_view new_name,
+	std::string_view new_description,
+	Date new_date,
+	uint32_t new_initial_camera_x,
 	uint32_t new_initial_camera_y
-) : HasIdentifier { std::to_string(new_index) }, name { new_name }, description { new_description }, date { new_date },
-	initial_camera_x { new_initial_camera_x }, initial_camera_y { new_initial_camera_y } {}
+) : HasIdentifier { std::to_string(new_index) },
+	HasIndex { new_index },
+	name { new_name },
+	description { new_description },
+	date { new_date },
+	initial_camera_x { new_initial_camera_x },
+	initial_camera_y { new_initial_camera_y } {}
 
 bool BookmarkManager::add_bookmark(
 	std::string_view name, std::string_view description, Date date, uint32_t initial_camera_x, uint32_t initial_camera_y

--- a/src/openvic-simulation/history/Bookmark.hpp
+++ b/src/openvic-simulation/history/Bookmark.hpp
@@ -9,19 +9,23 @@
 namespace OpenVic {
 	struct BookmarkManager;
 
-	struct Bookmark : HasIdentifier {
+	struct Bookmark : HasIdentifier, HasIndex<> {
 		friend struct BookmarkManager;
 
 	private:
-		const std::string PROPERTY(name);
-		const std::string PROPERTY(description);
+		std::string PROPERTY(name);
+		std::string PROPERTY(description);
 		const Date PROPERTY(date);
 		const uint32_t PROPERTY(initial_camera_x);
 		const uint32_t PROPERTY(initial_camera_y);
 
 		Bookmark(
-			size_t new_index, std::string_view new_name, std::string_view new_description, Date new_date,
-			uint32_t new_initial_camera_x, uint32_t new_initial_camera_y
+			index_t new_index,
+			std::string_view new_name,
+			std::string_view new_description,
+			Date new_date,
+			uint32_t new_initial_camera_x,
+			uint32_t new_initial_camera_y
 		);
 
 	public:

--- a/src/openvic-simulation/history/Period.cpp
+++ b/src/openvic-simulation/history/Period.cpp
@@ -5,15 +5,15 @@
 using namespace OpenVic;
 
 Period::Period(
-	const Date new_start_date,
-	const std::optional<Date> new_end_date
+	Date new_start_date,
+	std::optional<Date> new_end_date
 ) : start_date { new_start_date }, end_date { new_end_date } {}
 
-bool Period::is_date_in_period(const Date date) const {
+bool Period::is_date_in_period(Date date) const {
 	return start_date <= date && (!end_date.has_value() || end_date.value() >= date);
 }
 
-bool Period::try_set_end(const Date date) {
+bool Period::try_set_end(Date date) {
 	if (end_date.has_value()) {
 		Logger::error("Period already has end date ", end_date.value());
 		return false;

--- a/src/openvic-simulation/history/Period.hpp
+++ b/src/openvic-simulation/history/Period.hpp
@@ -11,8 +11,9 @@ namespace OpenVic {
 		std::optional<Date> end_date;
 
 	public:
-		Period(const Date new_start_date, const std::optional<Date> new_end_date);
-		bool is_date_in_period(const Date date) const;
-		bool try_set_end(const Date date);
+		Period(Date new_start_date, std::optional<Date> new_end_date);
+
+		bool is_date_in_period(Date date) const;
+		bool try_set_end(Date date);
 	};
 }

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -85,7 +85,7 @@ bool ProvinceSet::contains_province(ProvinceDefinition const* province) const {
 }
 
 ProvinceSetModifier::ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values)
-	: Modifier { new_identifier, std::move(new_values), 0 } {}
+	: Modifier { new_identifier, std::move(new_values) } {}
 
 Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_meta)
 	: HasIdentifierAndColour { new_identifier, new_colour, false }, meta { new_meta } {}

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -7,8 +7,7 @@ using namespace OpenVic::NodeTools;
 
 TerrainType::TerrainType(
 	std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_modifier, bool new_is_water
-) : HasIdentifierAndColour { new_identifier, new_colour, false }, modifier { std::move(new_modifier) },
-	is_water { new_is_water } {}
+) : Modifier { new_identifier, std::move(new_modifier) }, HasColour { new_colour, false }, is_water { new_is_water } {}
 
 TerrainTypeMapping::TerrainTypeMapping(
 	std::string_view new_identifier, TerrainType const& new_type, std::vector<index_t>&& new_terrain_indicies,

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -6,11 +6,13 @@
 namespace OpenVic {
 	struct TerrainTypeManager;
 
-	struct TerrainType : HasIdentifierAndColour {
+	// Using HasColour rather than HasIdentifierAndColour to avoid needing virtual inheritance
+	// (extending Modifier is more useful than extending HasIdentifierAndColour).
+	struct TerrainType : Modifier, HasColour {
 		friend struct TerrainTypeManager;
 
 	private:
-		const ModifierValue PROPERTY(modifier);
+		ModifierValue PROPERTY(modifier);
 		const bool PROPERTY(is_water);
 
 		TerrainType(std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_modifier, bool new_is_water);
@@ -26,7 +28,7 @@ namespace OpenVic {
 
 	private:
 		TerrainType const& PROPERTY(type);
-		const std::vector<index_t> PROPERTY(terrain_indices);
+		std::vector<index_t> PROPERTY(terrain_indices);
 		const index_t PROPERTY(priority);
 		const bool PROPERTY(has_texture);
 
@@ -42,6 +44,7 @@ namespace OpenVic {
 	struct TerrainTypeManager {
 	private:
 		using terrain_type_mappings_map_t = ordered_map<TerrainTypeMapping::index_t, size_t>;
+
 		IdentifierRegistry<TerrainType> IDENTIFIER_REGISTRY(terrain_type);
 		IdentifierRegistry<TerrainTypeMapping> IDENTIFIER_REGISTRY(terrain_type_mapping);
 		terrain_type_mappings_map_t terrain_type_mappings_map;

--- a/src/openvic-simulation/military/LeaderTrait.cpp
+++ b/src/openvic-simulation/military/LeaderTrait.cpp
@@ -4,7 +4,7 @@ using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
 LeaderTrait::LeaderTrait(std::string_view new_identifier, trait_type_t new_type, ModifierValue&& new_modifiers)
-	: HasIdentifier { new_identifier }, trait_type { new_type }, modifiers { std::move(new_modifiers) } {}
+	: Modifier { new_identifier, std::move(new_modifiers) }, trait_type { new_type } {}
 
 bool LeaderTrait::is_personality_trait() const {
 	return trait_type == trait_type_t::PERSONALITY;

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -1,23 +1,22 @@
 #pragma once
 
-#include <cstdint>
 #include <string_view>
 
 #include "openvic-simulation/misc/Modifier.hpp"
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
-#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 
 namespace OpenVic {
 	struct LeaderTraitManager;
 
-	struct LeaderTrait : HasIdentifier {
+	struct LeaderTrait : Modifier {
 		friend struct LeaderTraitManager;
 
 		enum class trait_type_t { PERSONALITY, BACKGROUND };
 
 	private:
 		const trait_type_t PROPERTY(trait_type);
+
 		/*
 		 * Allowed modifiers for leaders:
 		 * attack - integer
@@ -30,7 +29,6 @@ namespace OpenVic {
 		 * experience - %
 		 * reliability - decimal, mil gain or loss for associated POPs
 		 */
-		const ModifierValue PROPERTY(modifiers);
 
 		LeaderTrait(std::string_view new_identifier, trait_type_t new_type, ModifierValue&& new_modifiers);
 

--- a/src/openvic-simulation/misc/Define.hpp
+++ b/src/openvic-simulation/misc/Define.hpp
@@ -14,7 +14,7 @@ namespace OpenVic {
 		enum class Type : unsigned char { Date, Country, Economy, Military, Diplomacy, Pops, Ai, Graphics };
 
 	private:
-		const std::string PROPERTY(value);
+		std::string PROPERTY(value);
 		const Type PROPERTY(type);
 
 		Define(std::string_view new_identifier, std::string&& new_value, Type new_type);

--- a/src/openvic-simulation/misc/Modifier.cpp
+++ b/src/openvic-simulation/misc/Modifier.cpp
@@ -276,7 +276,7 @@ bool ModifierManager::register_complex_modifier(std::string_view identifier) {
 }
 
 std::string ModifierManager::get_flat_identifier(
-	const std::string_view complex_modifier_identifier, const std::string_view variant_identifier
+	std::string_view complex_modifier_identifier, std::string_view variant_identifier
 ) {
 	return StringUtils::append_string_views(complex_modifier_identifier, " ", variant_identifier);
 }

--- a/src/openvic-simulation/misc/Modifier.hpp
+++ b/src/openvic-simulation/misc/Modifier.hpp
@@ -74,7 +74,7 @@ namespace OpenVic {
 		const icon_t PROPERTY(icon);
 
 	protected:
-		Modifier(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon);
+		Modifier(std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon = 0);
 
 	public:
 		Modifier(Modifier&&) = default;
@@ -135,8 +135,9 @@ namespace OpenVic {
 		);
 
 		bool register_complex_modifier(std::string_view identifier);
-		static std::string
-		get_flat_identifier(const std::string_view complex_modifier_identifier, const std::string_view variant_identifier);
+		static std::string get_flat_identifier(
+			std::string_view complex_modifier_identifier, std::string_view variant_identifier
+		);
 
 		bool setup_modifier_effects();
 

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -9,11 +9,11 @@ namespace OpenVic {
 		friend struct GovernmentTypeManager;
 
 	private:
-		const std::vector<Ideology const*> PROPERTY(ideologies);
+		std::vector<Ideology const*> PROPERTY(ideologies);
 		const bool PROPERTY_CUSTOM_PREFIX(elections, holds);
 		const bool PROPERTY_CUSTOM_PREFIX(appoint_ruling_party, can);
 		const Timespan PROPERTY(term_duration);
-		const std::string PROPERTY_CUSTOM_NAME(flag_type_identifier, get_flag_type);
+		std::string PROPERTY_CUSTOM_NAME(flag_type_identifier, get_flag_type);
 
 		GovernmentType(
 			std::string_view new_identifier, std::vector<Ideology const*>&& new_ideologies, bool new_elections,

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -26,7 +26,7 @@ namespace OpenVic {
 
 	private:
 		IssueGroup const& PROPERTY(group);
-		const RuleSet PROPERTY(rules);
+		RuleSet PROPERTY(rules);
 		const bool PROPERTY_CUSTOM_PREFIX(jingoism, is);
 
 	protected:

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -18,7 +18,7 @@ NationalFocus::NationalFocus(
 	Ideology const* new_loyalty_ideology,
 	fixed_point_t new_loyalty_value,
 	ConditionScript&& new_limit
-) : Modifier { new_identifier, std::move(new_modifiers), 0 },
+) : Modifier { new_identifier, std::move(new_modifiers) },
 	group { new_group },
 	icon { new_icon },
 	has_flashpoint { new_has_flashpoint },

--- a/src/openvic-simulation/politics/NationalValue.cpp
+++ b/src/openvic-simulation/politics/NationalValue.cpp
@@ -4,7 +4,7 @@ using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
 NationalValue::NationalValue(std::string_view new_identifier, ModifierValue&& new_modifiers)
-	: HasIdentifier { new_identifier }, modifiers { std::move(new_modifiers) } {}
+	: Modifier { new_identifier, std::move(new_modifiers) } {}
 
 bool NationalValueManager::add_national_value(std::string_view identifier, ModifierValue&& modifiers) {
 	if (identifier.empty()) {

--- a/src/openvic-simulation/politics/NationalValue.hpp
+++ b/src/openvic-simulation/politics/NationalValue.hpp
@@ -6,12 +6,10 @@
 namespace OpenVic {
 	struct NationalValueManager;
 
-	struct NationalValue : HasIdentifier {
+	struct NationalValue : Modifier {
 		friend struct NationalValueManager;
 
 	private:
-		const ModifierValue PROPERTY(modifiers);
-
 		NationalValue(std::string_view new_identifier, ModifierValue&& new_modifiers);
 
 	public:
@@ -27,4 +25,4 @@ namespace OpenVic {
 
 		bool load_national_values_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};
-} // namespace OpenVic
+}

--- a/src/openvic-simulation/politics/Rule.cpp
+++ b/src/openvic-simulation/politics/Rule.cpp
@@ -6,8 +6,8 @@
 using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
-Rule::Rule(std::string_view new_identifier, rule_group_t new_group, size_t new_index)
-  : HasIdentifier { new_identifier }, group { new_group }, index { new_index } {}
+Rule::Rule(std::string_view new_identifier, rule_group_t new_group, index_t new_index)
+  : HasIdentifier { new_identifier }, HasIndex { new_index }, group { new_group } {}
 
 RuleSet::RuleSet(rule_group_map_t&& new_rule_groups) : rule_groups { std::move(new_rule_groups) } {}
 

--- a/src/openvic-simulation/politics/Rule.hpp
+++ b/src/openvic-simulation/politics/Rule.hpp
@@ -7,7 +7,8 @@ namespace OpenVic {
 	struct RuleManager;
 	struct BuildingTypeManager;
 
-	struct Rule : HasIdentifier {
+	/* The index of the Rule within its group, used to determine precedence in mutually exclusive rule groups. */
+	struct Rule : HasIdentifier, HasIndex<> {
 		friend struct RuleManager;
 
 		enum class rule_group_t : uint8_t {
@@ -27,10 +28,8 @@ namespace OpenVic {
 
 	private:
 		const rule_group_t PROPERTY(group);
-		/* The index of the Rule within its group, used to determine precedence in mutually exclusive rule groups. */
-		const size_t PROPERTY(index);
 
-		Rule(std::string_view new_identifier, rule_group_t new_group, size_t new_index);
+		Rule(std::string_view new_identifier, rule_group_t new_group, index_t new_index);
 
 	public:
 		Rule(Rule&&) = default;

--- a/src/openvic-simulation/research/Invention.cpp
+++ b/src/openvic-simulation/research/Invention.cpp
@@ -8,13 +8,25 @@ using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
 Invention::Invention(
-	std::string_view new_identifier, ModifierValue&& new_values, bool new_news, unit_set_t&& new_activated_units,
-	building_set_t&& new_activated_buildings, crime_set_t&& new_enabled_crimes, bool new_unlock_gas_attack,
-	bool new_unlock_gas_defence, ConditionScript&& new_limit, ConditionalWeight&& new_chance
-) : Modifier { new_identifier, std::move(new_values), 0 }, news { new_news },
-	activated_units { std::move(new_activated_units) }, activated_buildings { std::move(new_activated_buildings) },
-	enabled_crimes { std::move(new_enabled_crimes) }, unlock_gas_attack { new_unlock_gas_attack },
-	unlock_gas_defence { new_unlock_gas_defence }, limit { std::move(new_limit) }, chance { std::move(new_chance) } {}
+	std::string_view new_identifier,
+	ModifierValue&& new_values,
+	bool new_news,
+	unit_set_t&& new_activated_units,
+	building_set_t&& new_activated_buildings,
+	crime_set_t&& new_enabled_crimes,
+	bool new_unlock_gas_attack,
+	bool new_unlock_gas_defence,
+	ConditionScript&& new_limit,
+	ConditionalWeight&& new_chance
+) : Modifier { new_identifier, std::move(new_values) },
+	news { new_news },
+	activated_units { std::move(new_activated_units) },
+	activated_buildings { std::move(new_activated_buildings) },
+	enabled_crimes { std::move(new_enabled_crimes) },
+	unlock_gas_attack { new_unlock_gas_attack },
+	unlock_gas_defence { new_unlock_gas_defence },
+	limit { std::move(new_limit) },
+	chance { std::move(new_chance) } {}
 
 bool Invention::parse_scripts(DefinitionManager const& definition_manager) {
 	bool ret = true;

--- a/src/openvic-simulation/research/Invention.hpp
+++ b/src/openvic-simulation/research/Invention.hpp
@@ -32,9 +32,16 @@ namespace OpenVic {
 		ConditionalWeight PROPERTY(chance);
 
 		Invention(
-			std::string_view new_identifier, ModifierValue&& new_values, bool new_news, unit_set_t&& new_activated_units,
-			building_set_t&& new_activated_buildings, crime_set_t&& new_enabled_crimes, bool new_unlock_gas_attack,
-			bool new_unlock_gas_defence, ConditionScript&& new_limit, ConditionalWeight&& new_chance
+			std::string_view new_identifier,
+			ModifierValue&& new_values,
+			bool new_news,
+			unit_set_t&& new_activated_units,
+			building_set_t&& new_activated_buildings,
+			crime_set_t&& new_enabled_crimes,
+			bool new_unlock_gas_attack,
+			bool new_unlock_gas_defence,
+			ConditionScript&& new_limit,
+			ConditionalWeight&& new_chance
 		);
 
 		bool parse_scripts(DefinitionManager const& definition_manager);

--- a/src/openvic-simulation/research/Technology.cpp
+++ b/src/openvic-simulation/research/Technology.cpp
@@ -9,19 +9,32 @@ TechnologyArea::TechnologyArea(std::string_view new_identifier, TechnologyFolder
 	: HasIdentifier { new_identifier }, folder { new_folder } {}
 
 Technology::Technology(
-	std::string_view new_identifier, TechnologyArea const& new_area, Date::year_t new_year, fixed_point_t new_cost,
-	bool new_unciv_military, uint8_t new_unit, unit_set_t&& new_activated_units, building_set_t&& new_activated_buildings,
-	ModifierValue&& new_values, ConditionalWeight&& new_ai_chance
-) : Modifier { new_identifier, std::move(new_values), 0 }, area { new_area }, year { new_year }, cost { new_cost },
-	unciv_military { new_unciv_military }, unit { new_unit }, activated_buildings { std::move(new_activated_units) },
-	activated_units { std::move(new_activated_buildings) }, ai_chance { std::move(new_ai_chance) } {}
+	std::string_view new_identifier,
+	TechnologyArea const& new_area,
+	Date::year_t new_year,
+	fixed_point_t new_cost,
+	bool new_unciv_military,
+	uint8_t new_unit,
+	unit_set_t&& new_activated_units,
+	building_set_t&& new_activated_buildings,
+	ModifierValue&& new_values,
+	ConditionalWeight&& new_ai_chance
+) : Modifier { new_identifier, std::move(new_values) },
+	area { new_area },
+	year { new_year },
+	cost { new_cost },
+	unciv_military { new_unciv_military },
+	unit { new_unit },
+	activated_buildings { std::move(new_activated_units) },
+	activated_units { std::move(new_activated_buildings) },
+	ai_chance { std::move(new_ai_chance) } {}
 
 bool Technology::parse_scripts(DefinitionManager const& definition_manager) {
 	return ai_chance.parse_scripts(definition_manager);
 }
 
 TechnologySchool::TechnologySchool(std::string_view new_identifier, ModifierValue&& new_values)
-	: Modifier { new_identifier, std::move(new_values), 0 } {}
+	: Modifier { new_identifier, std::move(new_values) } {}
 
 bool TechnologyManager::add_technology_folder(std::string_view identifier) {
 	if (identifier.empty()) {

--- a/src/openvic-simulation/types/Colour.hpp
+++ b/src/openvic-simulation/types/Colour.hpp
@@ -321,7 +321,7 @@ namespace OpenVic {
 			return _array_access_helper<value_type>(*this, index);
 		}
 
-		constexpr const value_type& operator[](std::size_t index) const {
+		constexpr value_type const& operator[](std::size_t index) const {
 			return _array_access_helper<const value_type>(*this, index);
 		}
 

--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -27,7 +27,8 @@ namespace OpenVic {
 	 * can be entered into an IdentifierRegistry instance.
 	 */
 	class HasIdentifier {
-		const std::string PROPERTY(identifier);
+		/* Not const so it can be moved rather than needing to be copied. */
+		std::string PROPERTY(identifier);
 
 	protected:
 		HasIdentifier(std::string_view new_identifier): identifier { new_identifier } {
@@ -66,6 +67,9 @@ namespace OpenVic {
 		_HasColour& operator=(_HasColour const&) = delete;
 		_HasColour& operator=(_HasColour&&) = delete;
 	};
+
+	using HasColour = _HasColour<colour_t>;
+	using HasAlphaColour = _HasColour<colour_argb_t>;
 
 	/*
 	 * Base class for objects with a unique string identifier and associated colour information.

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -173,7 +173,7 @@ namespace OpenVic {
 		static constexpr bool storage_type_reservable = Reservable<storage_type>;
 
 	private:
-		const std::string PROPERTY(name);
+		std::string PROPERTY(name);
 		const bool log_lock;
 		storage_type PROPERTY_REF(items);
 		bool PROPERTY_CUSTOM_PREFIX(locked, is);

--- a/src/openvic-simulation/utility/Getters.hpp
+++ b/src/openvic-simulation/utility/Getters.hpp
@@ -99,14 +99,16 @@ namespace OpenVic::utility {
 	} \
 	template<typename T> \
 	constexpr T* cast_to() { \
-		if (is_derived_from<T>() || is_type<CLASS>()) \
+		if (is_derived_from<T>() || is_type<CLASS>()) { \
 			return (static_cast<T*>(this)); \
+		} \
 		return nullptr; \
 	} \
 	template<typename T> \
-	constexpr const T* const cast_to() const { \
-		if (is_derived_from<T>() || is_type<CLASS>()) \
-			return (static_cast<const T*>(this)); \
+	constexpr T const* const cast_to() const { \
+		if (is_derived_from<T>() || is_type<CLASS>()) { \
+			return (static_cast<T const*>(this)); \
+		} \
 		return nullptr; \
 	}
 
@@ -160,7 +162,7 @@ namespace OpenVic {
 	 * for variable getters created using the PROPERTY macro.
 	 */
 	template<typename decl, typename T>
-	inline constexpr decltype(auto) _get_property(const T& property) {
+	inline constexpr decltype(auto) _get_property(T const& property) {
 		if constexpr (std::is_reference_v<decl>) {
 			/* Return const reference */
 			return property;

--- a/src/openvic-simulation/utility/StringUtils.hpp
+++ b/src/openvic-simulation/utility/StringUtils.hpp
@@ -18,7 +18,7 @@ namespace OpenVic::StringUtils {
 	 * still starts with "0", otherwise 10. The success bool pointer parameter is used to report whether
 	 * or not conversion was successful. It can be nullptr if this information is not needed.
 	 */
-	constexpr uint64_t string_to_uint64(char const* str, const char* const end, bool* successful = nullptr, int base = 10) {
+	constexpr uint64_t string_to_uint64(char const* str, char const* const end, bool* successful = nullptr, int base = 10) {
 		if (successful != nullptr) {
 			*successful = false;
 		}
@@ -105,7 +105,7 @@ namespace OpenVic::StringUtils {
 		return string_to_uint64(str.data(), str.length(), successful, base);
 	}
 
-	constexpr int64_t string_to_int64(char const* str, const char* const end, bool* successful = nullptr, int base = 10) {
+	constexpr int64_t string_to_int64(char const* str, char const* const end, bool* successful = nullptr, int base = 10) {
 		if (successful != nullptr) {
 			*successful = false;
 		}

--- a/src/openvic-simulation/utility/TslHelper.hpp
+++ b/src/openvic-simulation/utility/TslHelper.hpp
@@ -70,39 +70,39 @@ namespace OpenVic {
 				return tmp;
 			}
 
-			bool operator==(const ordered_iterator& rhs) const {
+			bool operator==(ordered_iterator const& rhs) const {
 				return m_iterator == rhs.m_iterator;
 			}
 
-			bool operator!=(const ordered_iterator& rhs) const {
+			bool operator!=(ordered_iterator const& rhs) const {
 				return m_iterator != rhs.m_iterator;
 			}
 
-			bool operator<(const ordered_iterator& rhs) const {
+			bool operator<(ordered_iterator const& rhs) const {
 				return m_iterator < rhs.m_iterator;
 			}
 
-			bool operator>(const ordered_iterator& rhs) const {
+			bool operator>(ordered_iterator const& rhs) const {
 				return m_iterator > rhs.m_iterator;
 			}
 
-			bool operator<=(const ordered_iterator& rhs) const {
+			bool operator<=(ordered_iterator const& rhs) const {
 				return m_iterator <= rhs.m_iterator;
 			}
 
-			bool operator>=(const ordered_iterator& rhs) const {
+			bool operator>=(ordered_iterator const& rhs) const {
 				return m_iterator >= rhs.m_iterator;
 			}
 
-			friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) {
+			friend ordered_iterator operator+(difference_type n, ordered_iterator const& it) {
 				return n + it.m_iterator;
 			}
 
-			ordered_iterator operator+(const ordered_iterator& rhs) const {
+			ordered_iterator operator+(ordered_iterator const& rhs) const {
 				return m_iterator + rhs.m_iterator;
 			}
 
-			difference_type operator-(const ordered_iterator& rhs) const {
+			difference_type operator-(ordered_iterator const& rhs) const {
 				return m_iterator - rhs.m_iterator;
 			}
 

--- a/src/openvic-simulation/utility/Utility.hpp
+++ b/src/openvic-simulation/utility/Utility.hpp
@@ -32,13 +32,13 @@ namespace OpenVic::utility {
 	}
 
 	template<class T>
-	inline constexpr void hash_combine(std::size_t& s, const T& v) {
+	inline constexpr void hash_combine(std::size_t& s, T const& v) {
 		std::hash<T> h;
 		s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
 	}
 
 	template<size_t Shift, class T>
-	inline constexpr void hash_combine_index(std::size_t& s, const T& v) {
+	inline constexpr void hash_combine_index(std::size_t& s, T const& v) {
 		std::hash<T> h;
 		if constexpr (Shift == 0) {
 			s = h(v);
@@ -61,8 +61,8 @@ namespace OpenVic::utility {
 			(
 				[&] {
 					// If args is not last pointer of args
-					if (static_cast<const void*>(&(std::get<sizeof...(args) - 1>(arg_tuple))) !=
-						static_cast<const void*>(&args)) {
+					if (static_cast<void const*>(&(std::get<sizeof...(args) - 1>(arg_tuple))) !=
+						static_cast<void const*>(&args)) {
 						s <<= sizeof(Args) * CHAR_BIT;
 					}
 					s |= std::hash<Args> {}(args);
@@ -82,10 +82,10 @@ namespace OpenVic::utility {
 	inline constexpr bool is_specialization_of_v = is_specialization_of<T, Z>::value;
 
 	template <template<typename...> class Template, typename... Args>
-	void _derived_from_specialization_impl(const Template<Args...>&);
+	void _derived_from_specialization_impl(Template<Args...> const&);
 
 	template <typename T, template<typename...> class Template>
-	concept is_derived_from_specialization_of = requires(const T& t) {
+	concept is_derived_from_specialization_of = requires(T const& t) {
 		_derived_from_specialization_impl<Template>(t);
 	};
 


### PR DESCRIPTION
- Make greater use of `HasIndex` and `Modifier` (for `TerrainType` I've given up `HasIdentifierAndColour` for `Modifier` and `HasColour`, as being able to treat it as a `Modifier` is more useful and extending `HasIdentifierAndColour` as well isn't worth the virtual inheritance it would require).
- Make various moveable variables (`std::string`, `std::vector`, etc.) non-const so they can actually be moved.