### PR TITLE
Music and Sound Effect define loading

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -26,8 +26,8 @@ static bool run_headless(Dataloader::path_vector_t const& roots, bool run_tests)
 	}, nullptr };
 
 	Logger::info("===== Loading definitions... =====");
+	ret &= game_manager.set_roots(roots);
 	ret &= game_manager.load_definitions(
-		roots,
 		[](std::string_view key, Dataloader::locale_t locale, std::string_view localisation) -> bool {
 			return true;
 		}

--- a/src/openvic-simulation/DefinitionManager.hpp
+++ b/src/openvic-simulation/DefinitionManager.hpp
@@ -13,6 +13,8 @@
 #include "openvic-simulation/misc/Define.hpp"
 #include "openvic-simulation/misc/Event.hpp"
 #include "openvic-simulation/misc/Modifier.hpp"
+#include "openvic-simulation/misc/SongChance.hpp"
+#include "openvic-simulation/misc/SoundEffect.hpp"
 #include "openvic-simulation/politics/PoliticsManager.hpp"
 #include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/research/ResearchManager.hpp"
@@ -38,5 +40,7 @@ namespace OpenVic {
 		MapDefinition PROPERTY_REF(map_definition);
 		MapmodeManager PROPERTY_REF(mapmode_manager);
 		ScriptManager PROPERTY_REF(script_manager);
+		SongChanceManager PROPERTY_REF(song_chance_manager);
+		SoundEffectManager PROPERTY_REF(sound_effect_manager);
 	};
 }

--- a/src/openvic-simulation/GameManager.cpp
+++ b/src/openvic-simulation/GameManager.cpp
@@ -11,20 +11,21 @@ GameManager::GameManager(
 		new_clock_state_changed_callback ? std::move(new_clock_state_changed_callback) : []() {}
 	}, definitions_loaded { false } {}
 
-bool GameManager::load_definitions(
-	Dataloader::path_vector_t const& roots, Dataloader::localisation_callback_t localisation_callback
-) {
+bool GameManager::set_roots(Dataloader::path_vector_t const& roots) {
+	if (!dataloader.set_roots(roots)) {
+		Logger::error("Failed to set dataloader roots!");
+		return false;
+	}
+	return true;
+}
+
+bool GameManager::load_definitions(Dataloader::localisation_callback_t localisation_callback) {
 	if (definitions_loaded) {
 		Logger::error("Cannot load definitions - already loaded!");
 		return false;
 	}
 
 	bool ret = true;
-
-	if (!dataloader.set_roots(roots)) {
-		Logger::error("Failed to set dataloader roots!");
-		ret = false;
-	}
 
 	if (!dataloader.load_defines(definition_manager)) {
 		Logger::error("Failed to load defines!");

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -31,9 +31,9 @@ namespace OpenVic {
 			return instance_manager ? &*instance_manager : nullptr;
 		}
 
-		bool load_definitions(
-			Dataloader::path_vector_t const& roots, Dataloader::localisation_callback_t localisation_callback
-		);
+		bool set_roots(Dataloader::path_vector_t const& roots);
+
+		bool load_definitions(Dataloader::localisation_callback_t localisation_callback);
 
 		bool setup_instance(Bookmark const* bookmark);
 

--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -21,7 +21,7 @@ namespace OpenVic {
 		using path_vector_t = std::vector<fs::path>;
 
 	private:
-		path_vector_t roots;
+		path_vector_t PROPERTY(roots);
 		std::vector<ovdl::v2script::Parser> cached_parsers;
 
 		bool _load_interface_files(UIManager& ui_manager) const;
@@ -33,6 +33,8 @@ namespace OpenVic {
 		bool _load_inventions(DefinitionManager& definition_manager);
 		bool _load_events(DefinitionManager& definition_manager);
 		bool _load_map_dir(DefinitionManager& definition_manager) const;
+		bool _load_song_chances(DefinitionManager& definition_manager);
+		bool _load_sound_effect_defines(DefinitionManager& definition_manager) const;
 		bool _load_decisions(DefinitionManager& definition_manager);
 		bool _load_history(DefinitionManager& definition_manager, bool unused_history_file_warnings) const;
 

--- a/src/openvic-simulation/misc/SongChance.cpp
+++ b/src/openvic-simulation/misc/SongChance.cpp
@@ -1,0 +1,53 @@
+#include "SongChance.hpp"
+
+using namespace OpenVic;
+using namespace OpenVic::NodeTools;
+
+SongChance::SongChance(size_t new_index, std::string_view new_filename, ConditionalWeight&& new_chance):
+HasIdentifier { std::to_string(new_index) },
+file_name { new_filename },
+chance { std::move(new_chance) }
+{}
+
+bool SongChance::parse_scripts(DefinitionManager const& definition_manager) {
+	return chance.parse_scripts(definition_manager);
+}
+
+bool SongChanceManager::load_songs_file(ast::NodeCPtr root) {
+    bool ret = true;
+
+	ret &= expect_dictionary_reserve_length(
+		song_chances,
+		[this](std::string_view key, ast::NodeCPtr value) -> bool {
+			if (key != "song") {
+				Logger::error("Invalid song declaration ", key);
+				return false;
+			}
+			std::string_view name {};
+			ConditionalWeight chance { scope_t::COUNTRY, scope_t::COUNTRY, scope_t::NO_SCOPE };
+
+			bool ret = expect_dictionary_keys(
+				"name", ONE_EXACTLY, expect_string(assign_variable_callback(name)),
+				"chance", ONE_EXACTLY, chance.expect_conditional_weight(ConditionalWeight::BASE)
+			)(value);
+
+			ret &= song_chances.add_item({song_chances.size(), name, std::move(chance) });
+			return ret;
+		}
+	)(root);
+
+	if(song_chances.size() == 0) {
+		Logger::error("No songs found in Songs.txt");
+		return false;
+	}
+
+	return ret;
+}
+
+bool SongChanceManager::parse_scripts(DefinitionManager const& definition_manager) {
+	bool ret = true;
+	for (SongChance& songChance : song_chances.get_items()) {
+		ret &= songChance.parse_scripts(definition_manager);
+	}
+	return ret;
+}

--- a/src/openvic-simulation/misc/SongChance.hpp
+++ b/src/openvic-simulation/misc/SongChance.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <openvic-simulation/types/IdentifierRegistry.hpp>
+#include <openvic-simulation/scripts/ConditionalWeight.hpp>
+
+namespace OpenVic {
+	/*For music/Songs.txt if it exists*/
+	struct SongChanceManager;
+	struct SongChance : HasIdentifier {
+	private:
+		friend struct SongChanceManager;
+		std::string PROPERTY(file_name);
+		ConditionalWeight PROPERTY(chance);
+		SongChance(size_t new_index, std::string_view new_filename, ConditionalWeight&& new_chance);
+		bool parse_scripts(DefinitionManager const& definition_manager);
+	
+	public:
+		SongChance(SongChance&&) = default;
+	};
+
+	struct SongChanceManager {
+	private:
+		IdentifierRegistry<SongChance> IDENTIFIER_REGISTRY(song_chance);
+		//Songs.txt
+	public:
+		bool load_songs_file(ast::NodeCPtr root);
+		bool parse_scripts(DefinitionManager const& definition_manager);
+	};
+}
+

--- a/src/openvic-simulation/misc/SoundEffect.cpp
+++ b/src/openvic-simulation/misc/SoundEffect.cpp
@@ -1,0 +1,38 @@
+#include "SoundEffect.hpp"
+
+using namespace OpenVic;
+using namespace OpenVic::NodeTools;
+
+SoundEffect::SoundEffect (
+	std::string_view new_identifier, std::string_view new_file, fixed_point_t new_volume
+) : HasIdentifier { new_identifier }, file { new_file }, volume { new_volume } {}
+
+bool SoundEffectManager::_load_sound_define(std::string_view sfx_identifier, ast::NodeCPtr root) {
+	std::string_view file {};
+	fixed_point_t volume = 1;
+	bool ret = expect_dictionary_keys(
+		"file", ONE_EXACTLY, expect_string(assign_variable_callback(file)),
+		"volume", ZERO_OR_ONE,
+			expect_fixed_point(assign_variable_callback(volume))
+	)(root);
+
+	if (sfx_identifier.empty()) {
+		Logger::error("Invalid sound identifier - empty!");
+		return false;
+	}
+	if(file.empty()) {
+		Logger::error("Invalid sound file name - empty!");
+		return false;
+	}
+
+	ret &= sound_effects.add_item({sfx_identifier,file,volume});
+	return ret;
+}
+
+bool SoundEffectManager::load_sound_defines_file(ast::NodeCPtr root) {
+	return expect_dictionary_reserve_length(sound_effects,
+		[this](std::string_view key, ast::NodeCPtr value) -> bool {
+			return _load_sound_define(key,value);
+		}
+	)(root);
+}

--- a/src/openvic-simulation/misc/SoundEffect.hpp
+++ b/src/openvic-simulation/misc/SoundEffect.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <openvic-simulation/types/fixed_point/FixedPoint.hpp>
+#include <openvic-simulation/types/IdentifierRegistry.hpp>
+
+namespace OpenVic {
+	/*For interface/Sound.sfx */
+	struct SoundEffectManager;
+	struct SoundEffect : HasIdentifier {
+	private:
+		friend struct SoundEffectManager;
+		std::string PROPERTY(file);
+		fixed_point_t PROPERTY(volume);
+		SoundEffect(std::string_view new_identifier, std::string_view new_file, fixed_point_t new_volume);
+	
+	public:
+		SoundEffect(SoundEffect&&) = default;
+	};
+	
+	struct SoundEffectManager {
+	
+	private:
+		IdentifierRegistry<SoundEffect> IDENTIFIER_REGISTRY(sound_effect);	
+		bool _load_sound_define(std::string_view sfx_identifier, ast::NodeCPtr root);
+
+	public:
+		bool load_sound_defines_file(ast::NodeCPtr root);
+	};
+}


### PR DESCRIPTION
This is the sim portion of the music and Sound defines pr, needs review (code style?).
Main changes are:
- Addition of SongChance and SoundEffect loaders
- Dataloader now has separated root setting, and define loading functions so that the title_theme soundtrack can be loaded before the defines. Other files like GameSingleton and main.cpp changed to match.