### PR TITLE
Reduce pop size to int32

### DIFF
--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -642,8 +642,8 @@ bool PopManager::load_pop_bases_into_vector(
 		*non_integer_size = true;
 	}
 
-	if (culture != nullptr && religion != nullptr && size >= 1) {
-		vec.emplace_back(PopBase { type, *culture, *religion, size.to_int64_t(), militancy, consciousness, rebel_type });
+	if (culture != nullptr && religion != nullptr && size >= 1 && size <= std::numeric_limits<Pop::pop_size_t>::max()) {
+		vec.emplace_back(PopBase { type, *culture, *religion, size.to_int32_t(), militancy, consciousness, rebel_type });
 	} else {
 		Logger::warning(
 			"Some pop arguments are invalid: culture = ", culture, ", religion = ", religion, ", size = ", size

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -32,7 +32,7 @@ namespace OpenVic {
 	struct PopBase {
 		friend struct PopManager;
 
-		using pop_size_t = int64_t;
+		using pop_size_t = int32_t;
 
 	protected:
 		PopType const& PROPERTY_ACCESS(type, protected);


### PR DESCRIPTION
I had to change this as fixed_point_t can't handle int64. Also pop size shouldn't exceed int32.
We need fixed_point_t for calculations.