### PR TITLE
Added support for remove_culture custom instruction

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -671,9 +671,13 @@ bool CountryInstance::apply_history_to_country(
 
 	bool ret = true;
 
-	set_optional(primary_culture, entry.get_primary_culture());
-	for (Culture const* culture : entry.get_accepted_cultures()) {
-		ret &= add_accepted_culture(*culture);
+	set_optional(primary_culture, entry.get_primary_culture());	
+	for (auto const& [culture, add] : entry.get_accepted_cultures()) {
+		if (add) {
+			ret &= add_accepted_culture(*culture);
+		} else {
+			ret &= remove_accepted_culture(*culture);
+		}
 	}
 	set_optional(religion, entry.get_religion());
 	if (entry.get_ruling_party()) {

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -33,7 +33,7 @@ namespace OpenVic {
 		CountryDefinition const& PROPERTY(country);
 
 		std::optional<Culture const*> PROPERTY(primary_culture);
-		ordered_set<Culture const*> PROPERTY(accepted_cultures);
+		ordered_map<Culture const*, bool> PROPERTY(accepted_cultures);
 		std::optional<Religion const*> PROPERTY(religion);
 		std::optional<CountryParty const*> PROPERTY(ruling_party);
 		std::optional<Date> PROPERTY(last_election);

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -50,7 +50,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 				Logger::warning(
 					"Attempted to ", add ? "add" : "remove", " core of country ", country.get_identifier(),
 					" ", add ? "to" : "from", " province history of ", entry.get_province(),
-					" after previously ", add ? "adding" : "removing", " it"
+					" after previously ", add ? "removing" : "adding", " it"
 				);
 				return true;
 			}


### PR DESCRIPTION
As requested by #191.

This was pretty much a glorified copy-paste operation. If you think it would be better, I'm open to try and remake the add/remove core/culture lambda as a single function with templates, but I'm not sure of where I could put it. Also, it may be overkill. Depends how many more times will we have to do this.

 By the way, fixed a small mistake in add/remove_core's logging. 

Tested it and it appears to work.