### PR TITLE
Unlock invention if limit is met when applying history (placeholder)

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -156,7 +156,12 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 	);
 
 	ret &= country_instance_manager.apply_history_to_countries(
-		definition_manager.get_history_manager().get_country_manager(), today, unit_instance_manager, map_instance
+		definition_manager.get_history_manager().get_country_manager(),
+		today,
+		unit_instance_manager,
+		map_instance,
+		definition_manager.get_research_manager().get_technology_manager(),
+		definition_manager.get_research_manager().get_invention_manager()
 	);
 
 	ret &= map_instance.get_state_manager().generate_states(

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -20,7 +20,9 @@ namespace OpenVic {
 	struct ProvinceInstance;
 	struct State;
 	struct Technology;
+	struct TechnologyManager;
 	struct Invention;
+	struct InventionManager;
 	struct TechnologySchool;
 	struct NationalValue;
 	struct GovernmentType;
@@ -286,7 +288,8 @@ namespace OpenVic {
 		);
 
 		bool apply_history_to_country(
-			CountryHistoryEntry const& entry, MapInstance& map_instance, CountryInstanceManager const& country_instance_manager
+			CountryHistoryEntry const& entry, MapInstance& map_instance, CountryInstanceManager const& country_instance_manager,
+			TechnologyManager const& technology_manager, InventionManager const& invention_manager
 		);
 
 	private:
@@ -360,7 +363,7 @@ namespace OpenVic {
 
 		bool apply_history_to_countries(
 			CountryHistoryManager const& history_manager, Date date, UnitInstanceManager& unit_instance_manager,
-			MapInstance& map_instance
+			MapInstance& map_instance, TechnologyManager const& technology_manager, InventionManager const& invention_manager
 		);
 
 		void update_modifier_sums(Date today, StaticModifierCache const& static_modifier_cache);


### PR DESCRIPTION
When history is applied (starting new game), inventions are unlocked if their `limit` condition is met.

The condition checking is limited only to checking 1 technology is present. Most vanilla inventions have such limits.
Some vanilla inventions have more complex limits, they will (perhaps incorrectly) not be unlocked.

Once the complete condition checking functionality is ready, that should be used instead.