### PR TITLE
Provinces contribute modifiers to controller, not owner

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1011,7 +1011,7 @@ void CountryInstance::update_modifier_sum(Date today, StaticModifierCache const&
 
 	if constexpr (ProvinceInstance::ADD_OWNER_CONTRIBUTION) {
 		// Add province base modifiers (with local province modifier effects removed)
-		for (ProvinceInstance const* province : owned_provinces) {
+		for (ProvinceInstance const* province : controlled_provinces) {
 			contribute_province_modifier_sum(province->get_modifier_sum());
 		}
 

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -238,8 +238,8 @@ void ProvinceInstance::update_modifier_sum(Date today, StaticModifierCache const
 	modifier_sum.add_modifier_nullcheck(terrain_type, province_source);
 
 	if constexpr (!ADD_OWNER_CONTRIBUTION) {
-		if (owner != nullptr) {
-			owner->contribute_province_modifier_sum(modifier_sum);
+		if (controller != nullptr) {
+			controller->contribute_province_modifier_sum(modifier_sum);
 		}
 	}
 }


### PR DESCRIPTION
A province contributes its modifiers to its controller, not the owner.
A province is affected by the modifiers of the owner, not the controller.