### PR TITLE
Allow unit icon to be 0

### DIFF
--- a/src/openvic-simulation/military/UnitType.cpp
+++ b/src/openvic-simulation/military/UnitType.cpp
@@ -116,8 +116,8 @@ static bool _check_shared_parameters(std::string_view identifier, UnitType::unit
 		return false;
 	}
 
-	if (unit_args.icon <= 0) {
-		Logger::error("Invalid icon for unit ", identifier, " - ", unit_args.icon, " (must be positive)");
+	if (unit_args.icon < 0) {
+		Logger::error("Invalid icon for unit ", identifier, " - ", unit_args.icon, " (must be >= 0)");
 		return false;
 	}
 


### PR DESCRIPTION
Setting a unit icon to 0 in Victoria 2 is valid and hides the unit from the country-wide recruitment UI.
The unit is still visible in the province recruitment UI.