### PR TITLE
Cache pops by type per state and province

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -61,7 +61,7 @@ void InstanceManager::tick() {
 	Logger::info("Tick: ", today);
 
 	// Tick...
-	map_instance.tick(today);
+	map_instance.map_tick(today, definition_manager.get_modifier_manager().get_modifier_effect_cache());
 
 	set_gamestate_needs_update();
 }
@@ -140,7 +140,11 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 
 	if (ret) {
 		update_modifier_sums();
-		map_instance.initialise_for_new_game(definition_manager.get_modifier_manager().get_modifier_effect_cache());
+		map_instance.initialise_for_new_game(
+			today,
+			definition_manager.get_define_manager(),
+			definition_manager.get_modifier_manager().get_modifier_effect_cache()
+		);
 	}
 
 	return ret;

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.hpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.hpp
@@ -23,25 +23,19 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(total_employee_income_cache);
 		IndexedMap<PopType, Pop::pop_size_t> PROPERTY(employee_count_per_type_cache);
 
-		Pop::pop_size_t update_size_and_return_total_worker_count(
-			ProvinceInstance& location,
-			ModifierEffectCache const& modifier_effect_cache,
-			const fixed_point_t size_modifier
-		);
 		fixed_point_t calculate_size_modifier(ProvinceInstance const& location, ModifierEffectCache const& modifier_effect_cache) const;
 		void hire(ProvinceInstance& location, const Pop::pop_size_t available_worker_count);
 		fixed_point_t produce(
 			ProvinceInstance& location,
-			std::vector<Pop*>& owner_pops_cache,
-			Pop::pop_size_t& total_owner_count_in_state_cache,
-			ModifierEffectCache const& modifier_effect_cache,
-			const fixed_point_t size_modifier
+			std::vector<Pop*> const* const owner_pops_cache,
+			const Pop::pop_size_t total_owner_count_in_state_cache,
+			ModifierEffectCache const& modifier_effect_cache
 		);
 		void pay_employees(
 			ProvinceInstance& location,
 			const fixed_point_t revenue,
 			const Pop::pop_size_t total_worker_count_in_province,
-			std::vector<Pop*>& owner_pops_cache,
+			std::vector<Pop*> const* const owner_pops_cache,
 			const Pop::pop_size_t total_owner_count_in_state_cache
 		);
 
@@ -59,6 +53,7 @@ namespace OpenVic {
 		constexpr bool is_valid() const {
 			return production_type_nullable != nullptr;
 		}
-		void initialise_for_new_game(ProvinceInstance& location, ModifierEffectCache const& modifier_effect_cache);
+		void initialise_rgo_size_multiplier(ProvinceInstance& location, ModifierEffectCache const& modifier_effect_cache);
+		void rgo_tick(ProvinceInstance& location, ModifierEffectCache const& modifier_effect_cache);
 	};
 }

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -48,13 +48,13 @@ namespace OpenVic {
 			decltype(ProvinceInstance::ideology_distribution)::keys_t const& ideology_keys
 		);
 		bool apply_history_to_provinces(
-			ProvinceHistoryManager const& history_manager, Date date, CountryInstanceManager& country_manager,
+			ProvinceHistoryManager const& history_manager, const Date date, CountryInstanceManager& country_manager,
 			IssueManager const& issue_manager
 		);
 
-		void update_modifier_sums(Date today, StaticModifierCache const& static_modifier_cache);
-		void update_gamestate(Date today, DefineManager const& define_manager);
-		void tick(Date today);
-		void initialise_for_new_game(ModifierEffectCache const& modifier_effect_cache);
+		void update_modifier_sums(const Date today, StaticModifierCache const& static_modifier_cache);
+		void update_gamestate(const Date today, DefineManager const& define_manager);
+		void map_tick(const Date today, ModifierEffectCache const& modifier_effect_cache);
+		void initialise_for_new_game(const Date today, DefineManager const& define_manager, ModifierEffectCache const& modifier_effect_cache);
 	};
 }

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -96,6 +96,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(average_consciousness);
 		fixed_point_t PROPERTY(average_militancy);
 		IndexedMap<PopType, Pop::pop_size_t> PROPERTY(pop_type_distribution);
+		IndexedMap<PopType, std::vector<Pop*>> PROPERTY(pops_cache_by_type);
 		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
 		fixed_point_map_t<Religion const*> PROPERTY(religion_distribution);
@@ -148,8 +149,8 @@ namespace OpenVic {
 		) const;
 		std::vector<ModifierSum::modifier_entry_t> get_contributing_modifiers(ModifierEffect const& effect) const;
 
-		void update_gamestate(Date today, DefineManager const& define_manager);
-		void tick(Date today);
+		void update_gamestate(const Date today, DefineManager const& define_manager);
+		void province_tick(const Date today, ModifierEffectCache const& modifier_effect_cache);
 
 		template<UnitType::branch_t Branch>
 		bool add_unit_instance_group(UnitInstanceGroup<Branch>& group);
@@ -159,7 +160,7 @@ namespace OpenVic {
 		bool setup(BuildingTypeManager const& building_type_manager);
 		bool apply_history_to_province(ProvinceHistoryEntry const& entry, CountryInstanceManager& country_manager);
 
-		void initialise_for_new_game(ModifierEffectCache const& modifier_effect_cache);
+		void initialise_rgo(ModifierEffectCache const& modifier_effect_cache);
 
 		void setup_pop_test_values(IssueManager const& issue_manager);
 		plf::colony<Pop>& get_mutable_pops();

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -30,6 +30,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(average_consciousness);
 		fixed_point_t PROPERTY(average_militancy);
 		IndexedMap<PopType, Pop::pop_size_t> PROPERTY(pop_type_distribution);
+		IndexedMap<PopType, std::vector<Pop*>> PROPERTY(pops_cache_by_type);
 
 		fixed_point_t PROPERTY(industrial_power);
 


### PR DESCRIPTION
Cache pops by type so RGOs and factories can quickly iterate over owner pops when paying.