### PR TITLE
Added stores for pop Income solves #225

### DIFF
--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -1,5 +1,6 @@
+#define KEEP_DO_FOR_ALL_TYPES_OF_INCOME
 #include "Pop.hpp"
-
+#undef KEEP_DO_FOR_ALL_TYPES_OF_INCOME
 #include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/defines/Define.hpp"
@@ -44,6 +45,11 @@ Pop::Pop(PopBase const& pop_base, decltype(ideologies)::keys_t const& ideology_k
 	life_needs_fulfilled { 0 },
 	everyday_needs_fulfilled { 0 },
 	luxury_needs_fulfilled { 0 },
+	#define INITALIZE_POP_INCOME_STORES(name)\
+		name { 0 },
+
+	DO_FOR_ALL_TYPES_OF_POP_INCOME(INITALIZE_POP_INCOME_STORES)
+	#undef INITALIZE_POP_INCOME_STORES
 	max_supported_regiments { 0 } {}
 
 void Pop::setup_pop_test_values(IssueManager const& issue_manager) {
@@ -159,9 +165,23 @@ void Pop::update_gamestate(
 	}
 }
 
-//TODO store income
-void Pop::add_rgo_owner_income(const fixed_point_t income) {}
-void Pop::add_rgo_worker_income(const fixed_point_t income) {}
+#define DEFINE_ADD_INCOME_FUNCTIONS(name)\
+	void Pop::add_##name(const fixed_point_t pop_income){\
+		name += pop_income;\
+		income += pop_income;\
+	}
+
+DO_FOR_ALL_TYPES_OF_POP_INCOME(DEFINE_ADD_INCOME_FUNCTIONS)
+#undef DEFINE_ADD_INCOME_FUNCTIONS
+
+#define SET_ALL_INCOME_TO_ZERO(name)\
+	name = fixed_point_t::_0();
+
+void Pop::clear_all_income(){
+	DO_FOR_ALL_TYPES_OF_POP_INCOME(SET_ALL_INCOME_TO_ZERO)
+	#undef DO_FOR_ALL_TYPES_OF_POP_INCOME
+	#undef SET_ALL_INCOME_TO_ZERO
+}
 
 Strata::Strata(std::string_view new_identifier) : HasIdentifier { new_identifier } {}
 

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -49,6 +49,26 @@ namespace OpenVic {
 		);
 	};
 
+	#define DO_FOR_ALL_TYPES_OF_POP_INCOME(F)\
+		F(rgo_owner_income)\
+		F(rgo_worker_income)\
+		F(artisanal_income)\
+		F(factory_worker_income)\
+		F(factory_owner_income)\
+		F(unemployment_subsidies)\
+		F(pensions)\
+		F(government_salary_administration)\
+		F(government_salary_education)\
+		F(government_salary_military)\
+		F(event_and_decision_income)\
+		F(loan_interest_payments)
+	
+	#define DECLARE_POP_INCOME_STORES(income_type)\
+		fixed_point_t PROPERTY(income_type); 
+	
+	#define DECLARE_POP_INCOME_STORE_FUNCTIONS(name)\
+		void add_##name(const fixed_point_t pop_income);
+
 	/* REQUIREMENTS:
 	 * POP-18, POP-19, POP-20, POP-21, POP-34, POP-35, POP-36, POP-37
 	 */
@@ -84,6 +104,9 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(everyday_needs_fulfilled);
 		fixed_point_t PROPERTY(luxury_needs_fulfilled);
 
+		DO_FOR_ALL_TYPES_OF_POP_INCOME(DECLARE_POP_INCOME_STORES);
+		#undef DECLARE_POP_INCOME_STORES
+		
 		size_t PROPERTY(max_supported_regiments);
 
 		Pop(PopBase const& pop_base, decltype(ideologies)::keys_t const& ideology_keys);
@@ -104,8 +127,10 @@ namespace OpenVic {
 			const fixed_point_t pop_size_per_regiment_multiplier
 		);
 
-		void add_rgo_owner_income(const fixed_point_t income);
-		void add_rgo_worker_income(const fixed_point_t income);
+		DO_FOR_ALL_TYPES_OF_POP_INCOME(DECLARE_POP_INCOME_STORE_FUNCTIONS)
+		#undef DECLARE_POP_INCOME_STORE_FUNCTIONS
+		void clear_all_income();
+
 	};
 
 	struct Strata : HasIdentifier {
@@ -346,3 +371,6 @@ namespace OpenVic {
 		bool parse_scripts(DefinitionManager const& definition_manager);
 	};
 }
+#ifndef KEEP_DO_FOR_ALL_TYPES_OF_INCOME 
+	#undef DO_FOR_ALL_TYPES_OF_POP_INCOME
+#endif


### PR DESCRIPTION
I added the stores directly to the pop type. I thought of creating an object for them but worried it would hurt performance. I also considered making them a single array but worried that might hurt readability. For the clear_income_per_source() function, I wasn't sure how to get it to trigger every tick, and I'm not sure creating new fixed_point objects would be the most efficient approach. One idea I had was to zero out the sources by subtracting them from themselves, but I was worried that would cause problems since the economy is parallelized.