### PR TITLE
Initialise `ModifierEffectCache::supply_limit_global_base` to `nullptr`

### DIFF
--- a/src/openvic-simulation/modifier/ModifierEffectCache.cpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.cpp
@@ -213,6 +213,7 @@ ModifierEffectCache::ModifierEffectCache()
 	pop_militancy_modifier { nullptr },
 	population_growth { nullptr },
 	supply_limit_global_percentage_change { nullptr },
+	supply_limit_global_base { nullptr },
 	supply_limit_local_base { nullptr },
 
 	/* Military Modifier Effects */


### PR DESCRIPTION
This was caught when @BrickPi noticed errors running the program on ARM64 Mac