### PR TITLE
Fix Backup Path Search Ignoring User-Selected Directory

### DIFF
--- a/src/openvic-simulation/dataloader/Vic2PathSearch.cpp
+++ b/src/openvic-simulation/dataloader/Vic2PathSearch.cpp
@@ -75,10 +75,8 @@ static fs::path _search_for_game_path(fs::path hint_path = {}) {
 	std::error_code error_code;
 
 	// Don't waste time trying to search for Victoria 2 when supplied a valid looking Victoria 2 game directory
-	if (filename_equals(Victoria_2_folder, hint_path)) {
-		if (fs::is_regular_file(hint_path / v2_game_exe, error_code)) {
-			return hint_path;
-		}
+	if (fs::is_regular_file(hint_path / v2_game_exe, error_code)) {
+		return hint_path;
 	}
 
 	const bool hint_path_was_empty = hint_path.empty();


### PR DESCRIPTION
Another mac fix-up, for whatever reason, after failing to find a steam install and asking me to point to my Vic2 install (in this case a network drive shared with windows), the current function ignores the entry and fails, whereas this branch succeeds and works as expected. Not sure why, as the folder is called "Victoria 2", but removing that statement additionally makes it less confusing for people to load OpenVic if they've renamed their Victoria 2 folder - instead relying on the presence of v2game.exe alone, which is still a pretty safe bet.