### PR TITLE
Allow CountryParty ideology to be nullptr

### DIFF
--- a/src/openvic-simulation/country/CountryDefinition.hpp
+++ b/src/openvic-simulation/country/CountryDefinition.hpp
@@ -29,11 +29,11 @@ namespace OpenVic {
 	private:
 		const Date PROPERTY(start_date);
 		const Date PROPERTY(end_date);
-		Ideology const& PROPERTY(ideology);
+		Ideology const* PROPERTY(ideology); // Can be nullptr, shows up as "No Ideology" in game
 		policy_map_t PROPERTY(policies);
 
 		CountryParty(
-			std::string_view new_identifier, Date new_start_date, Date new_end_date, Ideology const& new_ideology,
+			std::string_view new_identifier, Date new_start_date, Date new_end_date, Ideology const* new_ideology,
 			policy_map_t&& new_policies
 		);
 

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -19,6 +19,8 @@ namespace OpenVic {
 	struct Ideology : HasIdentifierAndColour {
 		friend struct IdeologyManager;
 
+		static constexpr colour_t NO_IDEOLOGY_COLOUR = colour_t::fill_as(colour_t::max_value);
+
 	private:
 		IdeologyGroup const& PROPERTY(group);
 		const bool PROPERTY_CUSTOM_PREFIX(uncivilised, is);


### PR DESCRIPTION
This fixes a crash when country parties have a missing or invalid ideology entry, allowing their ideology variable to be null in that case (following Vic2's approach of showing such parties as having "No Ideology" rather than crashing).