### PR TITLE
Add TerrainType movement_cost, IdentifierRegistry back(), allow no trigger Crimes

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -79,7 +79,7 @@ namespace OpenVic {
 		// by swapping with another CountryInstance's country_definition.
 		CountryDefinition const* PROPERTY(country_definition);
 		colour_t PROPERTY(colour); // Cached to avoid searching government overrides for every province
-		ProvinceInstance const* PROPERTY(capital);
+		ProvinceInstance* PROPERTY(capital);
 		bool PROPERTY_CUSTOM_PREFIX(releasable_vassal, is);
 		bool PROPERTY(owns_colonial_province);
 
@@ -288,6 +288,10 @@ namespace OpenVic {
 		}
 
 		std::string_view get_identifier() const;
+
+		constexpr ProvinceInstance* get_capital() {
+			return capital;
+		}
 
 		void update_country_definition_based_attributes();
 

--- a/src/openvic-simulation/economy/production/ProductionType.cpp
+++ b/src/openvic-simulation/economy/production/ProductionType.cpp
@@ -178,14 +178,13 @@ bool ProductionTypeManager::add_production_type(
 	});
 
 	if (ret && (template_type == RGO)) {
-		ProductionType const& production_type = production_types.get_items().back();
 		ProductionType const*& current_rgo_pt = good_to_rgo_production_type[*output_good];
 		if (current_rgo_pt == nullptr || (
 			(is_farm && !is_mine)
 			&& (!current_rgo_pt->_is_farm || current_rgo_pt->_is_mine)
 		)) {
 			// pure farms are preferred over alternatives. Use first pt otherwise.
-			current_rgo_pt = &production_type;
+			current_rgo_pt = &get_back_production_type();
 		}
 		//else ignore, we already have an rgo pt
 	}
@@ -247,7 +246,6 @@ bool ProductionTypeManager::load_production_types_file(
 			return true;
 		}
 	)(parser.get_file_node());
-
 
 	/* Pass #3: actually load production types */
 	good_to_rgo_production_type.set_keys(&good_definition_manager.get_good_definitions());

--- a/src/openvic-simulation/economy/production/ProductionType.hpp
+++ b/src/openvic-simulation/economy/production/ProductionType.hpp
@@ -82,7 +82,7 @@ namespace OpenVic {
 				return _is_farm;
 			}
 
-			return !_is_mine && _is_farm;	
+			return !_is_mine && _is_farm;
 		}
 		constexpr bool get_is_farm_for_non_tech() const {
 			return _is_farm;

--- a/src/openvic-simulation/interface/UI.cpp
+++ b/src/openvic-simulation/interface/UI.cpp
@@ -29,7 +29,7 @@ bool UIManager::add_font(
 	);
 
 	if (universal_colour_codes.empty() && ret) {
-		GFX::Font::colour_codes_t const& loaded_colour_codes = get_fonts().back().get_colour_codes();
+		GFX::Font::colour_codes_t const& loaded_colour_codes = get_back_font().get_colour_codes();
 		if (!loaded_colour_codes.empty()) {
 			universal_colour_codes = loaded_colour_codes;
 			Logger::info("Loaded universal colour codes from font: \"", identifier, "\"");

--- a/src/openvic-simulation/map/Crime.cpp
+++ b/src/openvic-simulation/map/Crime.cpp
@@ -40,7 +40,7 @@ bool CrimeManager::load_crime_modifiers(ModifierManager const& modifier_manager,
 			bool ret = NodeTools::expect_dictionary_keys_and_default(
 				modifier_manager.expect_base_province_modifier(modifier_value),
 				"icon", ZERO_OR_ONE, expect_uint(assign_variable_callback(icon)),
-				"trigger", ONE_EXACTLY, trigger.expect_script(),
+				"trigger", ZERO_OR_ONE, trigger.expect_script(),
 				"active", ZERO_OR_ONE, expect_bool(assign_variable_callback(default_active))
 			)(value);
 
@@ -59,7 +59,10 @@ bool CrimeManager::parse_scripts(DefinitionManager const& definition_manager) {
 	bool ret = true;
 
 	for (Crime& crime : crime_modifiers.get_items()) {
-		ret &= crime.parse_scripts(definition_manager);
+		ret &= crime.parse_scripts(
+			definition_manager,
+			true // Script can be null, meaning this won't emit an error message if the crime has no trigger in its definition
+		);
 	}
 
 	return ret;

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -329,7 +329,7 @@ bool MapDefinition::add_region(std::string_view identifier, std::vector<Province
 	region.lock();
 	if (regions.add_item(std::move(region))) {
 		if (!meta) {
-			Region const& last_region = regions.get_items().back();
+			Region const& last_region = get_back_region();
 			for (ProvinceDefinition const* province : last_region.get_provinces()) {
 				remove_province_definition_const(province)->region = &last_region;
 			}
@@ -1039,7 +1039,7 @@ bool MapDefinition::load_continent_file(ModifierManager const& modifier_manager,
 			continent.lock();
 
 			if (continents.add_item(std::move(continent))) {
-				Continent const& moved_continent = continents.get_items().back();
+				Continent const& moved_continent = get_back_continent();
 				for (ProvinceDefinition const* prov : moved_continent.get_provinces()) {
 					remove_province_definition_const(prov)->continent = &moved_continent;
 				}

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -13,9 +13,16 @@ namespace OpenVic {
 
 	private:
 		ModifierValue PROPERTY(modifier);
+		fixed_point_t PROPERTY(movement_cost);
 		const bool PROPERTY(is_water);
 
-		TerrainType(std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_modifier, bool new_is_water);
+		TerrainType(
+			std::string_view new_identifier,
+			colour_t new_colour,
+			ModifierValue&& new_modifier,
+			fixed_point_t new_movement_cost,
+			bool new_is_water
+		);
 
 	public:
 		TerrainType(TerrainType&&) = default;
@@ -33,8 +40,11 @@ namespace OpenVic {
 		const bool PROPERTY(has_texture);
 
 		TerrainTypeMapping(
-			std::string_view new_identifier, TerrainType const& new_type, std::vector<index_t>&& new_terrain_indicies,
-			index_t new_priority, bool new_has_texture
+			std::string_view new_identifier,
+			TerrainType const& new_type,
+			std::vector<index_t>&& new_terrain_indicies,
+			index_t new_priority,
+			bool new_has_texture
 		);
 
 	public:
@@ -55,11 +65,20 @@ namespace OpenVic {
 		bool _load_terrain_type_mapping(std::string_view key, ast::NodeCPtr value);
 
 	public:
-		bool add_terrain_type(std::string_view identifier, colour_t colour, ModifierValue&& values, bool is_water);
+		bool add_terrain_type(
+			std::string_view identifier,
+			colour_t colour,
+			ModifierValue&& values,
+			fixed_point_t movement_cost,
+			bool is_water
+		);
 
 		bool add_terrain_type_mapping(
-			std::string_view identifier, TerrainType const* type, std::vector<TerrainTypeMapping::index_t>&& terrain_indicies,
-			TerrainTypeMapping::index_t priority, bool has_texture
+			std::string_view identifier,
+			TerrainType const* type,
+			std::vector<TerrainTypeMapping::index_t>&& terrain_indicies,
+			TerrainTypeMapping::index_t priority,
+			bool has_texture
 		);
 
 		TerrainTypeMapping const* get_terrain_type_mapping_for(TerrainTypeMapping::index_t idx) const;

--- a/src/openvic-simulation/military/Deployment.cpp
+++ b/src/openvic-simulation/military/Deployment.cpp
@@ -237,7 +237,7 @@ bool DeploymentManager::load_oob_file(
 	}
 
 	if (add_deployment(history_path, std::move(armies), std::move(navies), std::move(leaders))) {
-		deployment = &get_deployments().back();
+		deployment = &get_back_deployment();
 	} else {
 		ret = false;
 	}

--- a/src/openvic-simulation/military/UnitType.cpp
+++ b/src/openvic-simulation/military/UnitType.cpp
@@ -147,7 +147,8 @@ bool UnitTypeManager::add_regiment_type(
 
 	bool ret = regiment_types.add_item({ identifier, unit_args, std::move(regiment_type_args) });
 	if (ret) {
-		ret &= unit_types.add_item(&regiment_types.get_items().back());
+		// Cannot use get_back_regiment_type() as we need non-const but don't want to generate all non-const functions.
+		ret &= unit_types.add_item(&regiment_types.back());
 	}
 	return ret;
 }
@@ -175,7 +176,8 @@ bool UnitTypeManager::add_ship_type(
 
 	bool ret = ship_types.add_item({ identifier, unit_args, ship_type_args });
 	if (ret) {
-		ret &= unit_types.add_item(&ship_types.get_items().back());
+		// Cannot use get_back_ship_type() as we need non-const but don't want to generate all non-const functions.
+		ret &= unit_types.add_item(&ship_types.back());
 	}
 	return ret;
 }

--- a/src/openvic-simulation/modifier/Modifier.cpp
+++ b/src/openvic-simulation/modifier/Modifier.cpp
@@ -41,8 +41,8 @@ TriggeredModifier::TriggeredModifier(
 	ConditionScript&& new_trigger
 ) : IconModifier { new_identifier, std::move(new_values), new_type, new_icon }, trigger { std::move(new_trigger) } {}
 
-bool TriggeredModifier::parse_scripts(DefinitionManager const& definition_manager) {
-	return trigger.parse_script(false, definition_manager);
+bool TriggeredModifier::parse_scripts(DefinitionManager const& definition_manager, bool can_be_null) {
+	return trigger.parse_script(can_be_null, definition_manager);
 }
 
 ModifierInstance::ModifierInstance(Modifier const& new_modifier, Date new_expiry_date)

--- a/src/openvic-simulation/modifier/Modifier.hpp
+++ b/src/openvic-simulation/modifier/Modifier.hpp
@@ -62,7 +62,7 @@ namespace OpenVic {
 			ConditionScript&& new_trigger
 		);
 
-		bool parse_scripts(DefinitionManager const& definition_manager);
+		bool parse_scripts(DefinitionManager const& definition_manager, bool can_be_null = false);
 
 	public:
 		TriggeredModifier(TriggeredModifier&&) = default;

--- a/src/openvic-simulation/modifier/ModifierEffectCache.cpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.cpp
@@ -206,7 +206,6 @@ ModifierEffectCache::ModifierEffectCache()
 	mine_rgo_size_fake { nullptr },
 	mine_rgo_size_global { nullptr },
 	mine_rgo_size_local { nullptr },
-	movement_cost_base { nullptr },
 	movement_cost_percentage_change { nullptr },
 	number_of_voters { nullptr },
 	pop_consciousness_modifier { nullptr },

--- a/src/openvic-simulation/modifier/ModifierEffectCache.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.hpp
@@ -176,7 +176,6 @@ namespace OpenVic {
 		ModifierEffect const* PROPERTY(mine_rgo_size_fake);
 		ModifierEffect const* PROPERTY(mine_rgo_size_global);
 		ModifierEffect const* PROPERTY(mine_rgo_size_local);
-		ModifierEffect const* PROPERTY(movement_cost_base);
 		ModifierEffect const* PROPERTY(movement_cost_percentage_change);
 		ModifierEffect const* PROPERTY(number_of_voters);
 		ModifierEffect const* PROPERTY(pop_consciousness_modifier);

--- a/src/openvic-simulation/modifier/ModifierManager.cpp
+++ b/src/openvic-simulation/modifier/ModifierManager.cpp
@@ -64,7 +64,7 @@ bool ModifierManager::_register_modifier_effect(
 	});
 
 	if (ret) {
-		effect_cache = &registry.get_items().back();
+		effect_cache = &registry.back();
 	}
 
 	return ret;
@@ -308,7 +308,7 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= register_base_country_modifier_effect(modifier_effect_cache.max_tariff, "max_tariff", true, PROPORTION_DECIMAL);
 	ret &= register_base_country_modifier_effect(modifier_effect_cache.max_tax, "max_tax", true, PROPORTION_DECIMAL);
 	ret &= register_base_country_modifier_effect(
-		modifier_effect_cache.max_war_exhaustion, "max_war_exhaustion", true, RAW_DECIMAL, "MAX_WAR_EXHAUSTION"
+		modifier_effect_cache.max_war_exhaustion, "max_war_exhaustion", false, RAW_DECIMAL, "MAX_WAR_EXHAUSTION"
 	);
 	ret &= register_technology_modifier_effect(
 		modifier_effect_cache.military_tactics, "military_tactics", true, PROPORTION_DECIMAL, "MIL_TACTICS_TECH"
@@ -444,7 +444,7 @@ bool ModifierManager::setup_modifier_effects() {
 		modifier_effect_cache.unit_recruitment_time, "unit_recruitment_time", false, PROPORTION_DECIMAL
 	);
 	ret &= register_shared_tech_country_modifier_effect(
-		modifier_effect_cache.war_exhaustion, "war_exhaustion", false, PROPORTION_DECIMAL, "WAR_EXHAUST_BATTLES"
+		modifier_effect_cache.war_exhaustion, "war_exhaustion", false, RAW_DECIMAL, "WAR_EXHAUST_BATTLES"
 	);
 
 	/* Province Modifier Effects */
@@ -560,9 +560,6 @@ bool ModifierManager::setup_modifier_effects() {
 	ret &= register_base_province_modifier_effect(
 		modifier_effect_cache.mine_rgo_size_local, "mine_rgo_size", true, PROPORTION_DECIMAL,
 		ModifierEffect::make_default_modifier_effect_localisation_key("mine_size")
-	);
-	ret &= register_terrain_modifier_effect(
-		modifier_effect_cache.movement_cost_base, "movement_cost", true, PROPORTION_DECIMAL
 	);
 	ret &= register_base_province_modifier_effect(
 		modifier_effect_cache.movement_cost_percentage_change, "movement_cost", false, PROPORTION_DECIMAL

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -97,7 +97,7 @@ bool CultureManager::load_graphical_culture_type_file(ast::NodeCPtr root) {
 	}
 
 	/* Last defined graphical culture type is used as default. */
-	default_graphical_culture_type = &get_graphical_culture_types().back();
+	default_graphical_culture_type = &get_back_graphical_culture_type();
 
 	return ret;
 }

--- a/src/openvic-simulation/pop/PopType.cpp
+++ b/src/openvic-simulation/pop/PopType.cpp
@@ -329,7 +329,7 @@ bool PopManager::load_pop_type_file(
 					return true;
 				}
 				if (add_strata(identifier)) {
-					strata = &get_stratas().back();
+					strata = &get_back_strata();
 					return true;
 				}
 				return false;

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -85,7 +85,7 @@ namespace OpenVic {
 	public:
 		bool add_technology_folder(std::string_view identifier);
 
-		bool add_technology_area(std::string_view identifier, TechnologyFolder const* folder);
+		bool add_technology_area(std::string_view identifier, TechnologyFolder const& folder);
 
 		bool add_technology(
 			std::string_view identifier, TechnologyArea const* area, Date::year_t year, fixed_point_t cost,

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -259,6 +259,12 @@ namespace OpenVic {
 		}
 
 #define GETTERS(CONST) \
+	constexpr external_value_type CONST& front() CONST { \
+		return ValueInfo::get_external_value(ItemInfo::get_value(items.front())); \
+	} \
+	constexpr external_value_type CONST& back() CONST { \
+		return ValueInfo::get_external_value(ItemInfo::get_value(items.back())); \
+	} \
 	constexpr external_value_type CONST* get_item_by_identifier(std::string_view identifier) CONST { \
 		const typename decltype(identifier_index_map)::const_iterator it = identifier_index_map.find(identifier); \
 		if (it != identifier_index_map.end()) { \
@@ -578,6 +584,12 @@ private:
 	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset,)
 
 #define IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset, const_kw) \
+	constexpr decltype(registry)::external_value_type const_kw& get_front_##singular() const_kw { \
+		return registry.front(); \
+	} \
+	constexpr decltype(registry)::external_value_type const_kw& get_back_##singular() const_kw { \
+		return registry.back(); \
+	} \
 	constexpr decltype(registry)::external_value_type const_kw* get_##singular##_by_identifier(std::string_view identifier) const_kw { \
 		return registry.get_item_by_identifier(identifier); \
 	} \

--- a/src/openvic-simulation/utility/Getters.hpp
+++ b/src/openvic-simulation/utility/Getters.hpp
@@ -138,10 +138,10 @@ namespace OpenVic::utility {
 	NAME; \
 \
 public: \
-	constexpr decltype(NAME)& get_##NAME() { \
+	[[nodiscard]] constexpr decltype(NAME)& get_##NAME() { \
 		return NAME; \
 	} \
-	constexpr decltype(NAME) const& get_##NAME() const { \
+	[[nodiscard]] constexpr decltype(NAME) const& get_##NAME() const { \
 		return NAME; \
 	} \
 	ACCESS:
@@ -204,7 +204,7 @@ namespace OpenVic {
 	NAME __VA_OPT__(=) __VA_ARGS__; \
 \
 public: \
-	constexpr auto GETTER_NAME() const -> decltype(OpenVic::_get_property<decltype(NAME)>(NAME)) { \
+	[[nodiscard]] constexpr auto GETTER_NAME() const -> decltype(OpenVic::_get_property<decltype(NAME)>(NAME)) { \
 		return OpenVic::_get_property<decltype(NAME)>(NAME); \
 	} \
 	ACCESS:


### PR DESCRIPTION
Also:
- improve `fixed_point_t` print function (now `decimal_places = -1` let's it use however many it needs, matching the behaviour of Godot's float-to-string functions)
- make `PROPERTY` getters `[[nodiscard]]`
- make `CountryInstance`'s `capital` a non-const pointer with a non-const getter function
- add a `PROPERTY` getter for `ResourceGatheringOperation`'s `location_ptr`
- fix format and colour rules for `war_exhaustion` and `max_war_exhaustion` `ModifierEffect`s