### PR TITLE
Return money spent, instead of money left

### DIFF
--- a/src/openvic-simulation/economy/GoodInstance.cpp
+++ b/src/openvic-simulation/economy/GoodInstance.cpp
@@ -68,25 +68,20 @@ void GoodInstance::execute_orders() {
 			= total_demand_yesterday
 			= total_supply_yesterday
 			= fixed_point_t::_0();
+
 		try_parallel_for_each(
 			buy_up_to_orders.begin(),
 			buy_up_to_orders.end(),
 			[](GoodBuyUpToOrder const& buy_up_to_order) -> void {
-				buy_up_to_order.get_after_trade()({
-					fixed_point_t::_0(),
-					buy_up_to_order.get_money_to_spend()
-				});
+				buy_up_to_order.get_after_trade()(BuyResult::no_purchase_result());
 			}
 		);
-		const SellResult no_sales_result {
-			fixed_point_t::_0(),
-			fixed_point_t::_0()
-		};
+
 		try_parallel_for_each(
 			market_sell_orders.begin(),
 			market_sell_orders.end(),
-			[&no_sales_result](GoodMarketSellOrder const& market_sell_order) -> void {
-				market_sell_order.get_after_trade()(no_sales_result);
+			[](GoodMarketSellOrder const& market_sell_order) -> void {
+				market_sell_order.get_after_trade()(SellResult::no_sales_result());
 			}
 		);
 		return;
@@ -107,12 +102,7 @@ void GoodInstance::execute_orders() {
 			}
 
 			demand_sum += buy_up_to_order.get_max_quantity();
-
-			constexpr fixed_point_t quantity_bought = fixed_point_t::_0();
-			buy_up_to_order.get_after_trade()({
-				quantity_bought,
-				buy_up_to_order.get_money_to_spend()
-			});
+			buy_up_to_order.get_after_trade()(BuyResult::no_purchase_result());
 		}
 
 		if (game_rules_manager.get_use_optimal_pricing()) {
@@ -198,7 +188,7 @@ void GoodInstance::execute_orders() {
 				quantity_traded_yesterday += quantity_bought;
 				buy_up_to_order.get_after_trade()({
 					quantity_bought,
-					buy_up_to_order.get_money_to_spend() - quantity_bought * new_price
+					quantity_bought * new_price
 				});
 			}
 		} else {
@@ -256,7 +246,7 @@ void GoodInstance::execute_orders() {
 				quantity_traded_yesterday += quantity_bought;
 				buy_up_to_order.get_after_trade()({
 					quantity_bought,
-					buy_up_to_order.get_money_to_spend() - quantity_bought * new_price
+					quantity_bought * new_price
 				});
 			}
 		}

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -109,14 +109,15 @@ void ArtisanalProducer::artisan_tick(Pop& pop) {
 				const fixed_point_t max_quantity_to_buy = good_demand - good_stockpile;
 				if (max_quantity_to_buy > 0) {
 					const fixed_point_t money_to_spend = optimal_quantity * max_price;
-					pop.add_artisan_inputs_expense(money_to_spend);
 					market_instance.place_buy_up_to_order({
 						*input_good_ptr,
 						max_quantity_to_buy,
 						money_to_spend,
 						[this, &pop, &good_stockpile](const BuyResult buy_result) -> void {
-							pop.add_artisan_inputs_expense(-buy_result.get_money_left());
-							good_stockpile += buy_result.get_quantity_bought();
+							if (buy_result.get_quantity_bought() > fixed_point_t::_0()) {
+								pop.add_artisan_inputs_expense(buy_result.get_money_spent());
+								good_stockpile += buy_result.get_quantity_bought();
+							}
 						}
 					});
 				}

--- a/src/openvic-simulation/economy/trading/BuyResult.hpp
+++ b/src/openvic-simulation/economy/trading/BuyResult.hpp
@@ -6,12 +6,16 @@ namespace OpenVic {
 	struct BuyResult {
 	private:
 		const fixed_point_t PROPERTY(quantity_bought);
-		const fixed_point_t PROPERTY(money_left);
+		const fixed_point_t PROPERTY(money_spent);
 	public:
 		constexpr BuyResult(
 			const fixed_point_t new_quantity_bought,
-			const fixed_point_t new_money_left
+			const fixed_point_t new_money_spent
 		) : quantity_bought { new_quantity_bought },
-			money_left { new_money_left } {}
+			money_spent { new_money_spent } {}
+
+		static constexpr BuyResult no_purchase_result() {
+			return { fixed_point_t::_0(), fixed_point_t::_0() };
+		}
 	};
 }

--- a/src/openvic-simulation/economy/trading/MarketInstance.cpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.cpp
@@ -12,9 +12,7 @@ void MarketInstance::place_buy_up_to_order(BuyUpToOrder&& buy_up_to_order) {
 	GoodDefinition const& good = buy_up_to_order.get_good();
 	if (OV_unlikely(buy_up_to_order.get_max_quantity() <= 0)) {
 		Logger::error("Received BuyUpToOrder for ",good," with max quantity ",buy_up_to_order.get_max_quantity());
-		buy_up_to_order.get_after_trade()({
-			fixed_point_t::_0(), buy_up_to_order.get_money_to_spend()
-		});
+		buy_up_to_order.get_after_trade()(BuyResult::no_purchase_result());
 		return;
 	}
 
@@ -25,9 +23,7 @@ void MarketInstance::place_market_sell_order(MarketSellOrder&& market_sell_order
 	GoodDefinition const& good = market_sell_order.get_good();
 	if (OV_unlikely(market_sell_order.get_quantity() <= 0)) {
 		Logger::error("Received MarketSellOrder for ",good," with quantity ",market_sell_order.get_quantity());
-		market_sell_order.get_after_trade()({
-			fixed_point_t::_0(), fixed_point_t::_0()
-		});
+		market_sell_order.get_after_trade()(SellResult::no_sales_result());
 		return;
 	}
 

--- a/src/openvic-simulation/economy/trading/SellResult.hpp
+++ b/src/openvic-simulation/economy/trading/SellResult.hpp
@@ -13,5 +13,9 @@ namespace OpenVic {
 			const fixed_point_t new_money_gained
 		) : quantity_sold { new_quantity_sold },
 			money_gained { new_money_gained } {}
+
+		static constexpr SellResult no_sales_result() {
+			return { fixed_point_t::_0(), fixed_point_t::_0() };
+		}
 	};
 }


### PR DESCRIPTION
This simplifies the code and fixes the `artisan expense 0` warnings.