### PR TITLE
Store vectors of personality and background leader traits to choose from when generating leaders

### DIFF
--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -49,13 +49,15 @@ namespace OpenVic {
 	using name_list_t = std::vector<std::string>;
 	std::ostream& operator<<(std::ostream& stream, name_list_t const& name_list);
 
+	// This adds to capacity rather than size so that it can be used multiple times in a row.
+	// If it added to size, it would only reserve enough for max(arguments...)
 	template<typename T>
 	concept Reservable = requires(T& t, size_t size) {
-		{ t.size() } -> std::same_as<size_t>;
+		{ t.capacity() } -> std::same_as<size_t>;
 		t.reserve(size);
 	};
 	constexpr void reserve_more(Reservable auto& t, size_t size) {
-		t.reserve(t.size() + size);
+		t.reserve(t.capacity() + size);
 	}
 
 	namespace NodeTools {

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -76,6 +76,10 @@ size_t ProvinceSet::size() const {
 	return provinces.size();
 }
 
+size_t ProvinceSet::capacity() const {
+	return provinces.capacity();
+}
+
 void ProvinceSet::reserve(size_t size) {
 	if (locked) {
 		Logger::error("Failed to reserve space for ", size, " items in province set - already locked!");

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -40,6 +40,7 @@ namespace OpenVic {
 		void reset();
 		bool empty() const;
 		size_t size() const;
+		size_t capacity() const;
 		void reserve(size_t size);
 		void reserve_more(size_t size);
 		bool contains_province(ProvinceDefinition const* province) const;

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -45,6 +45,8 @@ namespace OpenVic {
 	struct LeaderTraitManager {
 	private:
 		IdentifierRegistry<LeaderTrait> IDENTIFIER_REGISTRY(leader_trait);
+		std::vector<LeaderTrait const*> PROPERTY(personality_traits);
+		std::vector<LeaderTrait const*> PROPERTY(background_traits);
 
 		// As well as their background and personality traits, leaders get this modifier scaled by their prestige
 		Modifier PROPERTY(leader_prestige_modifier);

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -231,6 +231,15 @@ namespace OpenVic {
 			return items.size();
 		}
 
+		constexpr size_t capacity() const {
+			if constexpr (storage_type_reservable) {
+				return items.capacity();
+			} else {
+				Logger::error("Cannot check capacity of ", name, " registry - storage_type not reservable!");
+				return size();
+			}
+		}
+
 		constexpr bool empty() const {
 			return items.empty();
 		}
@@ -553,6 +562,10 @@ public: \
 	} \
 	constexpr std::size_t get_##singular##_count() const { \
 		return registry.size(); \
+	} \
+	template<typename = void> \
+	constexpr std::size_t get_##plural##_capacity() const requires(decltype(registry)::storage_type_reservable) { \
+		return registry.capacity(); \
 	} \
 	constexpr bool plural##_empty() const { \
 		return registry.empty(); \


### PR DESCRIPTION
Also changes `reserve_more` to add to capacity rather than size so it can be used multiple times in a row