### PR TITLE
Fix pop need modifiers

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -69,13 +69,15 @@ void InstanceManager::update_gamestate() {
  * SS-98, SS-101
  */
 void InstanceManager::tick() {
+	country_instance_manager.country_manager_reset_before_tick();
+
 	today++;
 
 	Logger::info("Tick: ", today);
 
 	// Tick...
 	map_instance.map_tick(today);
-	country_instance_manager.tick(*this);
+	country_instance_manager.country_manager_tick(*this);
 	unit_instance_manager.tick();
 	market_instance.execute_orders();
 

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1403,11 +1403,13 @@ void CountryInstance::update_gamestate(InstanceManager& instance_manager) {
 	}
 }
 
-void CountryInstance::tick(InstanceManager& instance_manager) {
+void CountryInstance::country_reset_before_tick() {
 	for (auto pair : goods_data) {
 		pair.second.clear_daily_recorded_data();
 	}
+}
 
+void CountryInstance::country_tick(InstanceManager& instance_manager) {
 	DefinitionManager const& definition_manager = instance_manager.get_definition_manager();
 	DefineManager const& define_manager = definition_manager.get_define_manager();
 
@@ -1812,8 +1814,14 @@ void CountryInstanceManager::update_gamestate(InstanceManager& instance_manager)
 	update_rankings(instance_manager.get_today(), instance_manager.get_definition_manager().get_define_manager());
 }
 
-void CountryInstanceManager::tick(InstanceManager& instance_manager) {
+void CountryInstanceManager::country_manager_reset_before_tick() {
 	for (CountryInstance& country : country_instances.get_items()) {
-		country.tick(instance_manager);
+		country.country_reset_before_tick();
+	}
+}
+
+void CountryInstanceManager::country_manager_tick(InstanceManager& instance_manager) {
+	for (CountryInstance& country : country_instances.get_items()) {
+		country.country_tick(instance_manager);
 	}
 }

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -520,7 +520,6 @@ namespace OpenVic {
 		bool update_rule_set();
 
 	public:
-
 		void update_modifier_sum(Date today, StaticModifierCache const& static_modifier_cache);
 		void contribute_province_modifier_sum(ModifierSum const& province_modifier_sum);
 		fixed_point_t get_modifier_effect_value(ModifierEffect const& effect) const;
@@ -530,8 +529,9 @@ namespace OpenVic {
 			return modifier_sum.for_each_contributing_modifier(effect, std::move(callback));
 		}
 
+		void country_reset_before_tick();
 		void update_gamestate(InstanceManager& instance_manager);
-		void tick(InstanceManager& instance_manager);
+		void country_tick(InstanceManager& instance_manager);
 
 		good_data_t& get_good_data(GoodInstance const& good_instance);
 		good_data_t const& get_good_data(GoodInstance const& good_instance) const;
@@ -596,6 +596,7 @@ namespace OpenVic {
 
 		void update_modifier_sums(Date today, StaticModifierCache const& static_modifier_cache);
 		void update_gamestate(InstanceManager& instance_manager);
-		void tick(InstanceManager& instance_manager);
+		void country_manager_reset_before_tick();
+		void country_manager_tick(InstanceManager& instance_manager);
 	};
 }

--- a/src/openvic-simulation/economy/GoodInstance.cpp
+++ b/src/openvic-simulation/economy/GoodInstance.cpp
@@ -4,8 +4,7 @@ using namespace OpenVic;
 
 GoodInstance::GoodInstance(GoodDefinition const& new_good_definition, GameRulesManager const& new_game_rules_manager)
   : HasIdentifierAndColour { new_good_definition },
-	GoodMarket { new_game_rules_manager, new_good_definition.get_base_price(), new_good_definition.get_is_available_from_start() },
-	good_definition { new_good_definition }
+	GoodMarket { new_game_rules_manager, new_good_definition }
 	{}
 
 GoodInstanceManager::GoodInstanceManager(GoodDefinitionManager const& new_good_definition_manager)

--- a/src/openvic-simulation/economy/GoodInstance.hpp
+++ b/src/openvic-simulation/economy/GoodInstance.hpp
@@ -12,8 +12,6 @@ namespace OpenVic {
 		friend struct GoodInstanceManager;
 
 	private:
-		GoodDefinition const& PROPERTY(good_definition);
-
 		GoodInstance(GoodDefinition const& new_good_definition, GameRulesManager const& new_game_rules_manager);
 
 	public:

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
@@ -28,7 +28,10 @@ namespace OpenVic {
 			ProductionType const& new_production_type,
 			fixed_point_t new_current_production
 		);
+
 		void artisan_tick(Pop& pop);
+
+		//thread safe
 		//adds to stockpile up to max_quantity_to_buy and returns quantity added to stockpile
 		fixed_point_t add_to_stockpile(GoodDefinition const& good, const fixed_point_t quantity);
 	};

--- a/src/openvic-simulation/economy/trading/GoodMarket.hpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.hpp
@@ -17,7 +17,6 @@ namespace OpenVic {
 		std::unique_ptr<std::mutex> buy_lock;
 		std::unique_ptr<std::mutex> sell_lock;
 		GameRulesManager const& game_rules_manager;
-		const fixed_point_t base_price;
 		fixed_point_t absolute_maximum_price;
 		fixed_point_t absolute_minimum_price;
 
@@ -31,6 +30,7 @@ namespace OpenVic {
 		std::vector<GoodMarketSellOrder> market_sell_orders;
 
 	protected:
+		GoodDefinition const& PROPERTY_ACCESS(good_definition, protected);
 		bool PROPERTY_ACCESS(is_available, protected);
 
 	private:
@@ -46,7 +46,7 @@ namespace OpenVic {
 
 		void update_next_price_limits();
 	public:
-		GoodMarket(GameRulesManager const& new_game_rules_manager, fixed_point_t new_base_price, bool new_is_available);
+		GoodMarket(GameRulesManager const& new_game_rules_manager, GoodDefinition const& new_good_definition);
 		GoodMarket(GoodMarket&&) = default;
 
 		//thread safe

--- a/src/openvic-simulation/economy/trading/MarketInstance.cpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.cpp
@@ -13,6 +13,10 @@ MarketInstance::MarketInstance(CountryDefines const& new_country_defines, GoodIn
 :	country_defines { new_country_defines },
 	good_instance_manager { new_good_instance_manager} {}
 
+bool MarketInstance::get_is_available(GoodDefinition const& good_definition) const {
+	return good_instance_manager.get_good_instance_from_definition(good_definition).get_is_available();
+}
+
 fixed_point_t MarketInstance::get_max_next_price(GoodDefinition const& good_definition) const {
 	return good_instance_manager.get_good_instance_from_definition(good_definition).get_max_next_price();
 }

--- a/src/openvic-simulation/economy/trading/MarketInstance.hpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.hpp
@@ -15,6 +15,7 @@ namespace OpenVic {
 		GoodInstanceManager& good_instance_manager;
 	public:
 		MarketInstance(CountryDefines const& new_country_defines, GoodInstanceManager& new_good_instance_manager);
+		bool get_is_available(GoodDefinition const& good_definition) const;
 		fixed_point_t get_max_next_price(GoodDefinition const& good_definition) const;
 		fixed_point_t get_price_inverse(GoodDefinition const& good_definition) const;
 		void place_buy_up_to_order(BuyUpToOrder&& buy_up_to_order);

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -410,7 +410,7 @@ void ProvinceInstance::update_gamestate(const Date today, DefineManager const& d
 }
 
 void ProvinceInstance::province_tick(const Date today) {
-	shared_pop_values.update();
+	shared_pop_values.update_pop_values_from_province();
 	try_parallel_for_each(
 		pops.begin(),
 		pops.end(),

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/economy/production/ArtisanalProducerFactoryPattern.hpp"
 #include "openvic-simulation/pop/PopType.hpp"
+#include "types/fixed_point/FixedPoint.hpp"
 
 namespace OpenVic {
 	struct CountryInstance;
@@ -30,35 +31,35 @@ namespace OpenVic {
 		);
 	};
 
-	#define DO_FOR_ALL_TYPES_OF_POP_INCOME(F)\
-		F(rgo_owner_income)\
-		F(rgo_worker_income)\
-		F(artisanal_income)\
-		F(factory_worker_income)\
-		F(factory_owner_income)\
-		F(unemployment_subsidies)\
-		F(pensions)\
-		F(government_salary_administration)\
-		F(government_salary_education)\
-		F(government_salary_military)\
-		F(event_and_decision_income)\
+	#define DO_FOR_ALL_TYPES_OF_POP_INCOME(F) \
+		F(rgo_owner_income) \
+		F(rgo_worker_income) \
+		F(artisanal_income) \
+		F(factory_worker_income) \
+		F(factory_owner_income) \
+		F(unemployment_subsidies) \
+		F(pensions) \
+		F(government_salary_administration) \
+		F(government_salary_education) \
+		F(government_salary_military) \
+		F(event_and_decision_income) \
 		F(loan_interest_payments)
 
-	#define DO_FOR_ALL_TYPES_OF_POP_EXPENSES(F)\
-		F(life_needs_expense)\
-		F(everyday_needs_expense)\
-		F(luxury_needs_expense)\
+	#define DO_FOR_ALL_TYPES_OF_POP_EXPENSES(F) \
+		F(life_needs_expense) \
+		F(everyday_needs_expense) \
+		F(luxury_needs_expense) \
 		F(artisan_inputs_expense)
 
-	#define DO_FOR_ALL_NEED_CATEGORIES(F)\
-		F(life)\
-		F(everyday)\
+	#define DO_FOR_ALL_NEED_CATEGORIES(F) \
+		F(life) \
+		F(everyday) \
 		F(luxury)
 
-	#define DECLARE_POP_MONEY_STORES(money_type)\
+	#define DECLARE_POP_MONEY_STORES(money_type) \
 		fixed_point_t PROPERTY(money_type);
 
-	#define DECLARE_POP_MONEY_STORE_FUNCTIONS(name)\
+	#define DECLARE_POP_MONEY_STORE_FUNCTIONS(name) \
 		void add_##name(const fixed_point_t amount);
 
 	/* REQUIREMENTS:
@@ -103,7 +104,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(expenses); //positive value means POP paid for goods. This is displayed * -1 in UI.
 		fixed_point_t PROPERTY(savings);
 
-		#define NEED_MEMBERS(need_category)\
+		#define NEED_MEMBERS(need_category) \
 			fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
 			public: \
 			constexpr fixed_point_t get_##need_category##_needs_fulfilled() const { \
@@ -135,6 +136,11 @@ namespace OpenVic {
 		std::stringstream get_pop_context_text() const;
 		void reserve_needs_fulfilled_goods();
 		void fill_needs_fulfilled_goods_with_false();
+		void allocate_for_needs(
+			GoodDefinition::good_definition_map_t const& scaled_needs,
+			fixed_point_t& price_inverse_sum,
+			fixed_point_t& cash_left_to_spend
+		);
 
 	public:
 		Pop(Pop const&) = delete;

--- a/src/openvic-simulation/pop/PopValuesFromProvince.hpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.hpp
@@ -16,7 +16,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(shared_everyday_needs_scalar);
 		fixed_point_t PROPERTY(shared_luxury_needs_scalar);
 	public:
-		void update(PopValuesFromProvince const& parent, Strata const& strata);
+		void update_pop_strata_values_from_province(PopValuesFromProvince const& parent, Strata const& strata);
 	};
 
 	struct PopValuesFromProvince {
@@ -30,6 +30,6 @@ namespace OpenVic {
 			decltype(effects_per_strata)::keys_type const& strata_keys
 		);
 
-		void update();
+		void update_pop_values_from_province();
 	};
 }

--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -38,7 +38,7 @@ namespace OpenVic {
 	static_assert( \
 		sizeof(prefix##vec##size##_t) == size * sizeof(type), \
 		#prefix "vec" #size "_t size does not equal the sum of its parts' sizes" \
-	);\
+	); \
 	extern template struct vec##size##_t<type>;
 
 #define MAKE_VEC_ALIASES(prefix, type) \


### PR DESCRIPTION
- Assign properties instead of unused local variables.
- Multiply by `1 + modifier` instead of only the modifier.
- Correct local variable name
- Skip logic when max_quantity == 0
- Add space before \ (in macros)
- Reset country data, then do province ticks and then country ticks (otherwise country tick resets the data generated in province tick)
- Skip pop needs that aren't available yet.
- Renamed tick to country_tick so it's easier to find its uses.
- Added GoodDefinition to GoodMarket for easier debugging
- Extracted allocate_needs to a method instead of a macro for easier debugging.
- Update cash_left_to_spend even when a pop couldn't afford max price.
- In ArtisanalProducer::add_to_stockpile use .find() & .at() instead of indexing to allow parallel execution.