### PR TITLE
Improve calculation accuracy by avoiding shifting via mul_div

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -920,8 +920,11 @@ void CountryInstance::_update_production(DefineManager const& define_manager) {
 
 	for (auto const& [country, money_invested] : foreign_investments) {
 		if (country->exists()) {
-			const fixed_point_t investment_industrial_power =
-				money_invested * define_manager.get_country_defines().get_country_investment_industrial_score_factor() / 100;
+			const fixed_point_t investment_industrial_power = fixed_point_t::mul_div(
+				money_invested,
+				define_manager.get_country_defines().get_country_investment_industrial_score_factor(),
+				fixed_point_t::_100()
+			);
 
 			if (investment_industrial_power != 0) {
 				industrial_power += investment_industrial_power;

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -73,7 +73,11 @@ void ArtisanalProducer::artisan_tick(Pop& pop) {
 			fixed_point_t& good_stockpile = stockpile[input_good_ptr];
 
 			//Consume input good
-			fixed_point_t consumed_quantity = desired_quantity * inputs_bought_numerator / inputs_bought_denominator;
+			fixed_point_t consumed_quantity = fixed_point_t::mul_div(
+				desired_quantity,
+				inputs_bought_numerator,
+				inputs_bought_denominator
+			);
 			if (country_to_report_economy_nullable != nullptr) {
 				country_to_report_economy_nullable->report_input_consumption(
 					production_type,
@@ -138,7 +142,11 @@ void ArtisanalProducer::artisan_tick(Pop& pop) {
 				max_possible_satisfaction_denominator
 			](auto const& pair)->bool {
 				GoodDefinition const* const input_good_ptr = pair.first;
-				const fixed_point_t optimal_quantity = demand[input_good_ptr] * max_possible_satisfaction_numerator / max_possible_satisfaction_denominator;
+				const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
+					demand[input_good_ptr],
+					max_possible_satisfaction_numerator,
+					max_possible_satisfaction_denominator
+				);
 				if (stockpile[input_good_ptr] < optimal_quantity) {
 					return false;
 				}
@@ -151,7 +159,11 @@ void ArtisanalProducer::artisan_tick(Pop& pop) {
 		for (auto const& [input_good_ptr, max_price] : goods_to_buy_and_max_price) {
 			const fixed_point_t good_demand = demand[input_good_ptr];
 			fixed_point_t& good_stockpile = stockpile[input_good_ptr];
-			const fixed_point_t optimal_quantity = good_demand * max_possible_satisfaction_numerator / max_possible_satisfaction_denominator;
+			const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
+				good_demand,
+				max_possible_satisfaction_numerator,
+				max_possible_satisfaction_denominator
+			);
 			const fixed_point_t max_quantity_to_buy = good_demand - good_stockpile;
 			if (max_quantity_to_buy > fixed_point_t::_0()) {
 				const fixed_point_t money_to_spend = optimal_quantity * max_price;

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -362,7 +362,7 @@ void ResourceGatheringOperation::pay_employees(
 
 	fixed_point_t revenue_left = revenue;
 	if (total_owner_count_in_state_cache > 0) {
-		fixed_point_t owner_share = (fixed_point_t::_2() * total_owner_count_in_state_cache / total_worker_count_in_province);
+		fixed_point_t owner_share = fixed_point_t::_2() * total_owner_count_in_state_cache / total_worker_count_in_province;
 		constexpr fixed_point_t upper_limit = fixed_point_t::_0_50();
 		if (owner_share > upper_limit) {
 			owner_share = upper_limit;
@@ -370,7 +370,7 @@ void ResourceGatheringOperation::pay_employees(
 
 		for (Pop* owner_pop_ptr : *owner_pops_cache_nullable) {
 			Pop& owner_pop = *owner_pop_ptr;
-			const fixed_point_t income_for_this_pop = revenue_left * owner_share * owner_pop.get_size() / total_owner_count_in_state_cache;
+			const fixed_point_t income_for_this_pop = revenue_left * (owner_share * owner_pop.get_size()) / total_owner_count_in_state_cache;
 			owner_pop.add_rgo_owner_income(income_for_this_pop);
 			total_owner_income_cache += income_for_this_pop;
 		}

--- a/src/openvic-simulation/economy/trading/GoodMarket.cpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.cpp
@@ -173,7 +173,11 @@ void GoodMarket::execute_orders() {
 
 					const fixed_point_t distributed_supply
 						= quantity_bought_per_order[i]
-						= remaining_supply * purchasing_power_per_order[i] / purchasing_power_sum;
+						= fixed_point_t::mul_div(
+							remaining_supply,
+							purchasing_power_per_order[i],
+							purchasing_power_sum
+						);
 					if (distributed_supply >= buy_up_to_order.get_max_quantity()) {
 						someone_bought_max_quantity = true;
 						quantity_bought_per_order[i] = buy_up_to_order.get_max_quantity();
@@ -254,7 +258,11 @@ void GoodMarket::execute_orders() {
 		}
 
 		for (GoodMarketSellOrder const& market_sell_order : market_sell_orders) {
-			const fixed_point_t quantity_sold = market_sell_order.get_quantity() * quantity_traded_yesterday / supply_sum;
+			const fixed_point_t quantity_sold = fixed_point_t::mul_div(
+				market_sell_order.get_quantity(),
+				quantity_traded_yesterday,
+				supply_sum
+			);
 			market_sell_order.get_after_trade()({
 				quantity_sold,
 				quantity_sold * new_price

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -345,7 +345,11 @@ void Pop::pop_tick() {
 					continue; \
 				} \
 				fixed_point_t price_inverse = market_instance.get_price_inverse(*good_definition); \
-				fixed_point_t cash_available_for_good = cash_left_to_spend * price_inverse / need_category##_needs_price_inverse_sum; \
+				fixed_point_t cash_available_for_good = fixed_point_t::mul_div( \
+					cash_left_to_spend, \
+					price_inverse, \
+					need_category##_needs_price_inverse_sum \
+				); \
 				if (cash_available_for_good >= max_money_to_spend) {\
 					cash_left_to_spend -= max_money_to_spend; \
 					money_to_spend_per_good_draft[good_definition] = max_money_to_spend; \
@@ -386,7 +390,11 @@ void Pop::pop_tick() {
 
 					if (quantity_added_to_stockpile > fixed_point_t::_0()) {
 						quantity_left_to_consume -= quantity_added_to_stockpile;
-						const fixed_point_t expense = buy_result.get_money_spent() * quantity_added_to_stockpile / buy_result.get_quantity_bought();
+						const fixed_point_t expense = fixed_point_t::mul_div(
+							buy_result.get_money_spent(),
+							quantity_added_to_stockpile,
+							buy_result.get_quantity_bought()
+						);
 						add_artisan_inputs_expense(expense);
 					}
 				}
@@ -411,7 +419,11 @@ void Pop::pop_tick() {
 						if (get_country_to_report_economy_nullable != nullptr) { \
 							get_country_to_report_economy_nullable->report_pop_need_consumption(*type, *good_definition, consumed_quantity); \
 						} \
-						const fixed_point_t expense = buy_result.get_money_spent() * consumed_quantity / buy_result.get_quantity_bought(); \
+						const fixed_point_t expense = fixed_point_t::mul_div( \
+							buy_result.get_money_spent(), \
+							consumed_quantity, \
+							buy_result.get_quantity_bought() \
+						); \
 						add_##need_category##_needs_expense(expense); \
 					}
 				

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -533,6 +533,11 @@ namespace OpenVic {
 			return *this;
 		}
 
+		//Preserves accuracy. Performing a normal multiplication of small values results in 0.
+		constexpr static fixed_point_t mul_div(fixed_point_t const& a, fixed_point_t const& b, fixed_point_t const& denominator) {
+			return parse_raw(a.value * b.value / denominator.value);
+		}
+
 		constexpr friend fixed_point_t operator%(fixed_point_t const& lhs, fixed_point_t const& rhs) {
 			return parse_raw(lhs.value % rhs.value);
 		}

--- a/tests/src/types/FixedPoint.cpp
+++ b/tests/src/types/FixedPoint.cpp
@@ -204,4 +204,10 @@ TEST_CASE("fixed_point_t Operators", "[fixed_point_t][fixed_point_t-operators]")
 	CHECK(((int32_t)decimal2) == 1);
 	CHECK(((int32_t)decimal3) == 4);
 	CHECK(((int32_t)decimal4) == 3);
+
+	CHECK(fixed_point_t::mul_div(
+		fixed_point_t::parse_raw(2),
+		fixed_point_t::parse_raw(3),
+		fixed_point_t::parse_raw(6)
+	) == fixed_point_t::parse_raw(1));
 }


### PR DESCRIPTION
`fixed_point_t * fixed_point_t / fixed_point_t`
First does `parse_raw(lhs.value * rhs.value >> PRECISION)` which becomes 0 for small values.
Any division (by even by a small value) is then useless.
`mul_div` avoids the shifts and preserves accuracy.

See also https://discord.com/channels/1063392556160909312/1105422859641290803/1340640042523168811