### PR TITLE
Store vectors of Issues/Reforms under each IssueGroup/ReformGroup

### DIFF
--- a/src/openvic-simulation/country/CountryDefinition.cpp
+++ b/src/openvic-simulation/country/CountryDefinition.cpp
@@ -150,25 +150,29 @@ node_callback_t CountryDefinitionManager::load_country_party(
 		bool ret = expect_dictionary_keys_and_default(
 			[&politics_manager, &policies, &party_name](std::string_view key, ast::NodeCPtr value) -> bool {
 				return politics_manager.get_issue_manager().expect_issue_group_str(
-					[&politics_manager, &policies, value, &party_name](IssueGroup const& group) -> bool {
-						CountryParty::policy_map_t::value_ref_type policy = policies[group];
+					[&politics_manager, &policies, value, &party_name](IssueGroup const& issue_group) -> bool {
+						CountryParty::policy_map_t::value_ref_type policy = policies[issue_group];
 
 						if (policy != nullptr) {
-							Logger::error("Country party ", party_name, " has duplicate entry for ", group.get_identifier());
+							Logger::error(
+								"Country party \"", party_name, "\" has duplicate entry for issue gorup \"",
+								issue_group.get_identifier(), "\""
+							);
 							return false;
 						}
 
 						return politics_manager.get_issue_manager().expect_issue_identifier(
-							[&group, &policy](Issue const& issue) -> bool {
-								if (&issue.get_group() == &group) {
+							[&issue_group, &policy](Issue const& issue) -> bool {
+								if (&issue.get_issue_group() == &issue_group) {
 									policy = &issue;
 									return true;
 								}
 
 								// TODO - change this back to error/false once TGC no longer has this issue
 								Logger::warning(
-									"Invalid policy ", issue.get_identifier(), ", group is ",
-									issue.get_group().get_identifier(), " when ", group.get_identifier(), " was expected."
+									"Invalid policy \"", issue.get_identifier(), "\", group is \"",
+									issue.get_issue_group().get_identifier(), "\" when \"", issue_group.get_identifier(),
+									"\" was expected."
 								);
 								return true;
 							}

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -273,7 +273,7 @@ bool CountryInstance::add_reform(Reform const& new_reform) {
 
 		reform = &new_reform;
 
-		// TODO - if new_reform.get_reform_group().get_type().is_uncivilised() ?
+		// TODO - if new_reform.get_reform_group().is_uncivilised() ?
 		// TODO - new_reform.get_on_execute_trigger() / new_reform.get_on_execute_effect() ?
 
 		return update_rule_set();

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -84,7 +84,7 @@ void Pop::setup_pop_test_values(IssueManager const& issue_manager) {
 		test_weight(issue_distribution, issue, 3, 6);
 	}
 	for (Reform const& reform : issue_manager.get_reforms()) {
-		if (!reform.get_reform_group().get_type().is_uncivilised()) {
+		if (!reform.get_reform_group().is_uncivilised()) {
 			test_weight(issue_distribution, reform, 3, 6);
 		}
 	}


### PR DESCRIPTION
Also adds definition index variables to `IssueGroup` and `ReformGroup`.
These features are intended to help with Politics Menu setup