### PR TITLE
Remove selected province, add player country+selected province mapmode args

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -225,9 +225,8 @@ bool InstanceManager::set_today_and_update(Date new_today) {
 	return true;
 }
 
-bool InstanceManager::expand_selected_province_building(size_t building_index) {
+bool InstanceManager::expand_province_building(ProvinceInstance* province, size_t building_index) {
 	set_gamestate_needs_update();
-	ProvinceInstance* province = map_instance.get_selected_province();
 	if (province == nullptr) {
 		Logger::error("Cannot expand building index ", building_index, " - no province selected!");
 		return false;

--- a/src/openvic-simulation/InstanceManager.hpp
+++ b/src/openvic-simulation/InstanceManager.hpp
@@ -75,6 +75,6 @@ namespace OpenVic {
 
 		bool set_today_and_update(Date new_today);
 
-		bool expand_selected_province_building(size_t building_index);
+		bool expand_province_building(ProvinceInstance* province, size_t building_index);
 	};
 }

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -17,24 +17,6 @@ ProvinceInstance const& MapInstance::get_province_instance_from_definition(Provi
 	return province_instances.get_items()[province.get_index() - 1];
 }
 
-void MapInstance::set_selected_province(ProvinceDefinition::index_t index) {
-	if (index == ProvinceDefinition::NULL_INDEX) {
-		selected_province = nullptr;
-	} else {
-		selected_province = get_province_instance_by_index(index);
-		if (selected_province == nullptr) {
-			Logger::error(
-				"Trying to set selected province to an invalid index ", index, " (max index is ",
-				get_province_instance_count(), ")"
-			);
-		}
-	}
-}
-
-ProvinceDefinition::index_t MapInstance::get_selected_province_index() const {
-	return selected_province != nullptr ? selected_province->get_index() : ProvinceDefinition::NULL_INDEX;
-}
-
 bool MapInstance::setup(
 	BuildingTypeManager const& building_type_manager,
 	MarketInstance& market_instance,

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -22,7 +22,6 @@ namespace OpenVic {
 
 		IdentifierRegistry<ProvinceInstance> IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(province_instance, 1);
 
-		ProvinceInstance* PROPERTY_PTR(selected_province, nullptr);
 		pop_size_t PROPERTY(highest_province_population, 0);
 		pop_size_t PROPERTY(total_map_population, 0);
 
@@ -39,9 +38,6 @@ namespace OpenVic {
 
 		ProvinceInstance& get_province_instance_from_definition(ProvinceDefinition const& province);
 		ProvinceInstance const& get_province_instance_from_definition(ProvinceDefinition const& province) const;
-
-		void set_selected_province(ProvinceDefinition::index_t index);
-		ProvinceDefinition::index_t get_selected_province_index() const;
 
 		bool setup(
 			BuildingTypeManager const& building_type_manager,

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -22,15 +22,19 @@ Mapmode::Mapmode(
 	parchment_mapmode_allowed { new_parchment_mapmode_allowed } {}
 
 const Mapmode Mapmode::ERROR_MAPMODE {
-	"mapmode_error", -1, [](MapInstance const&, ProvinceInstance const& province) -> base_stripe_t {
+	"mapmode_error", -1, [](
+		MapInstance const& map_instance, ProvinceInstance const& province,
+		CountryInstance const* player_country, ProvinceInstance const* selected_province
+	) -> base_stripe_t {
 		return { 0xFFFF0000_argb, colour_argb_t::null() };
 	}
 };
 
 Mapmode::base_stripe_t Mapmode::get_base_stripe_colours(
-	MapInstance const& map_instance, ProvinceInstance const& province
+	MapInstance const& map_instance, ProvinceInstance const& province,
+	CountryInstance const* player_country, ProvinceInstance const* selected_province
 ) const {
-	return colour_func ? colour_func(map_instance, province) : colour_argb_t::null();
+	return colour_func ? colour_func(map_instance, province, player_country, selected_province) : colour_argb_t::null();
 }
 
 bool MapmodeManager::add_mapmode(
@@ -56,7 +60,11 @@ bool MapmodeManager::add_mapmode(
 	});
 }
 
-bool MapmodeManager::generate_mapmode_colours(MapInstance const& map_instance, Mapmode const* mapmode, uint8_t* target) const {
+bool MapmodeManager::generate_mapmode_colours(
+	MapInstance const& map_instance, Mapmode const* mapmode,
+	CountryInstance const* player_country, ProvinceInstance const* selected_province,
+	uint8_t* target
+) const {
 	if (target == nullptr) {
 		Logger::error("Mapmode colour target pointer is null!");
 		return false;
@@ -77,7 +85,9 @@ bool MapmodeManager::generate_mapmode_colours(MapInstance const& map_instance, M
 
 	if (map_instance.province_instances_are_locked()) {
 		for (ProvinceInstance const& province : map_instance.get_province_instances()) {
-			target_stripes[province.get_index()] = mapmode->get_base_stripe_colours(map_instance, province);
+			target_stripes[province.get_index()] = mapmode->get_base_stripe_colours(
+				map_instance, province, player_country, selected_province
+			);
 		}
 	} else {
 		for (
@@ -102,7 +112,10 @@ static constexpr colour_argb_t DEFAULT_COLOUR_GREY = (0x7F7F7F_argb).with_alpha(
 template<HasGetColour T, typename P>
 requires(std::same_as<P, ProvinceDefinition> || std::same_as<P, ProvinceInstance>)
 static constexpr auto get_colour_mapmode(T const*(P::*get_item)() const) {
-	return [get_item](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+	return [get_item](
+		MapInstance const& map_instance, ProvinceInstance const& province,
+		CountryInstance const* player_country, ProvinceInstance const* selected_province
+	) -> Mapmode::base_stripe_t {
 		ProvinceDefinition const& province_definition = province.get_province_definition();
 
 		T const* item = ([&province, &province_definition]() -> P const& {
@@ -143,7 +156,10 @@ static constexpr Mapmode::base_stripe_t shaded_mapmode(fixed_point_map_t<T const
 
 template<HasGetColour T>
 static constexpr auto shaded_mapmode(fixed_point_map_t<T const*> const&(ProvinceInstance::*get_map)() const) {
-	return [get_map](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+	return [get_map](
+		MapInstance const& map_instance, ProvinceInstance const& province,
+		CountryInstance const* player_country, ProvinceInstance const* selected_province
+	) -> Mapmode::base_stripe_t {
 		return shaded_mapmode((province.*get_map)());
 	};
 }
@@ -162,7 +178,10 @@ bool MapmodeManager::setup_mapmodes() {
 	// The order of mapmodes matches their numbering, but is different from the order in which their buttons appear
 	ret &= add_mapmode(
 		"mapmode_terrain",
-		[](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+		[](
+			MapInstance const& map_instance, ProvinceInstance const& province,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province
+		) -> Mapmode::base_stripe_t {
 			return colour_argb_t::null();
 		},
 		"MAPMODE_1",
@@ -174,7 +193,10 @@ bool MapmodeManager::setup_mapmodes() {
 	ret &= add_mapmode("mapmode_region", get_colour_mapmode(&ProvinceDefinition::get_region), "MAPMODE_5");
 	ret &= add_mapmode(
 		"mapmode_infrastructure",
-		[](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+		[](
+			MapInstance const& map_instance, ProvinceInstance const& province,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province
+		) -> Mapmode::base_stripe_t {
 			BuildingInstance const* railroad = province.get_building_by_identifier("railroad");
 			if (railroad != nullptr) {
 				const colour_argb_t::value_type val = colour_argb_t::colour_traits::component_from_fraction(
@@ -200,7 +222,10 @@ bool MapmodeManager::setup_mapmodes() {
 	ret &= add_mapmode("mapmode_rgo", get_colour_mapmode(&ProvinceInstance::get_rgo_good), "MAPMODE_11");
 	ret &= add_mapmode(
 		"mapmode_population",
-		[](MapInstance const& map_instance, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+		[](
+			MapInstance const& map_instance, ProvinceInstance const& province,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province
+		) -> Mapmode::base_stripe_t {
 			// TODO - explore non-linear scaling to have more variation among non-massive provinces
 			// TODO - when selecting a province, only show the population of provinces controlled (or owned?)
 			// by the same country, relative to the most populous province in that set of provinces
@@ -226,7 +251,10 @@ bool MapmodeManager::setup_mapmodes() {
 	ret &= add_mapmode("mapmode_crisis", Mapmode::ERROR_MAPMODE.get_colour_func(), "MAPMODE_21");
 	ret &= add_mapmode(
 		"mapmode_naval",
-		[](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
+		[](
+			MapInstance const& map_instance, ProvinceInstance const& province,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province
+		) -> Mapmode::base_stripe_t {
 			ProvinceDefinition const& province_definition = province.get_province_definition();
 
 			if (province_definition.has_port()) {
@@ -241,72 +269,80 @@ bool MapmodeManager::setup_mapmodes() {
 	);
 
 	/*
-	*** CUSTOM MAPMODES FOR TESTING ***
-	- For these mapmodes to have a button in-game you either need to remove the same number of default mapmodes
-	  or add more mapmode buttons (GUIIconButton nodes with path ^".../Menubar/menubar/mapmode_<index>")
-
-	ret &= add_mapmode(
-		"mapmode_province",
-		[](MapInstance const&, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
-			return colour_argb_t { province.get_province_definition().get_colour(), ALPHA_VALUE };
-		}
-	);
-	ret &= add_mapmode(
-		"mapmode_index",
-		[](MapInstance const& map_instance, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
-			const colour_argb_t::value_type f = colour_argb_t::colour_traits::component_from_fraction(
-				province.get_index(), map_instance.get_map_definition().get_province_definition_count() + 1
-			);
-			return colour_argb_t::fill_as(f).with_alpha(ALPHA_VALUE);
-		}
-	);
-	ret &= add_mapmode("mapmode_religion", shaded_mapmode(&ProvinceInstance::get_religion_distribution));
-	ret &= add_mapmode("mapmode_terrain_type", get_colour_mapmode(&ProvinceInstance::get_terrain_type));
-	ret &= add_mapmode(
-		"mapmode_adjacencies",
-		[](MapInstance const& map_instance, ProvinceInstance const& province) -> Mapmode::base_stripe_t {
-			ProvinceInstance const* selected_province = map_instance.get_selected_province();
-
-			if (selected_province != nullptr) {
-				ProvinceDefinition const& selected_province_definition = selected_province->get_province_definition();
-
-				if (selected_province == &province) {
-					return (0xFFFFFF_argb).with_alpha(ALPHA_VALUE);
-				}
-
-				ProvinceDefinition const* province_definition = &province.get_province_definition();
-
-				colour_argb_t base = colour_argb_t::null(), stripe = colour_argb_t::null();
-				ProvinceDefinition::adjacency_t const* adj =
-					selected_province_definition.get_adjacency_to(province_definition);
-
-				if (adj != nullptr) {
-					colour_argb_t::integer_type base_int;
-					switch (adj->get_type()) {
-						using enum ProvinceDefinition::adjacency_t::type_t;
-					case LAND:       base_int = 0x00FF00; break;
-					case WATER:      base_int = 0x0000FF; break;
-					case COASTAL:    base_int = 0xF9D199; break;
-					case IMPASSABLE: base_int = 0x8B4513; break;
-					case STRAIT:     base_int = 0x00FFFF; break;
-					case CANAL:      base_int = 0x888888; break;
-					default:         base_int = 0xFF0000; break;
-					}
-					base = colour_argb_t::from_integer(base_int).with_alpha(ALPHA_VALUE);
-					stripe = base;
-				}
-
-				if (selected_province_definition.has_adjacency_going_through(province_definition)) {
-					stripe = (0xFFFF00_argb).with_alpha(ALPHA_VALUE);
-				}
-
-				return { base, stripe };
-			}
-
-			return colour_argb_t::null();
-		}
-	);
+		*** CUSTOM MAPMODES FOR TESTING ***
+		- For these mapmodes to have a button in-game you either need to remove the same number of default mapmodes
+		  or add more mapmode buttons (GUIIconButton nodes with path ^".../Menubar/menubar/mapmode_<index>")
 	*/
+	if constexpr (false) {
+		ret &= add_mapmode(
+			"mapmode_province",
+			[](
+				MapInstance const& map_instance, ProvinceInstance const& province,
+				CountryInstance const* player_country, ProvinceInstance const* selected_province
+			) -> Mapmode::base_stripe_t {
+				return colour_argb_t { province.get_province_definition().get_colour(), ALPHA_VALUE };
+			}
+		);
+		ret &= add_mapmode(
+			"mapmode_index",
+			[](
+				MapInstance const& map_instance, ProvinceInstance const& province,
+				CountryInstance const* player_country, ProvinceInstance const* selected_province
+			) -> Mapmode::base_stripe_t {
+				const colour_argb_t::value_type f = colour_argb_t::colour_traits::component_from_fraction(
+					province.get_index(), map_instance.get_map_definition().get_province_definition_count() + 1
+				);
+				return colour_argb_t::fill_as(f).with_alpha(ALPHA_VALUE);
+			}
+		);
+		ret &= add_mapmode("mapmode_religion", shaded_mapmode(&ProvinceInstance::get_religion_distribution));
+		ret &= add_mapmode("mapmode_terrain_type", get_colour_mapmode(&ProvinceInstance::get_terrain_type));
+		ret &= add_mapmode(
+			"mapmode_adjacencies",
+			[](
+				MapInstance const& map_instance, ProvinceInstance const& province,
+				CountryInstance const* player_country, ProvinceInstance const* selected_province
+			) -> Mapmode::base_stripe_t {
+				if (selected_province != nullptr) {
+					ProvinceDefinition const& selected_province_definition = selected_province->get_province_definition();
+
+					if (selected_province == &province) {
+						return (0xFFFFFF_argb).with_alpha(ALPHA_VALUE);
+					}
+
+					ProvinceDefinition const* province_definition = &province.get_province_definition();
+
+					colour_argb_t base = colour_argb_t::null(), stripe = colour_argb_t::null();
+					ProvinceDefinition::adjacency_t const* adj =
+						selected_province_definition.get_adjacency_to(province_definition);
+
+					if (adj != nullptr) {
+						colour_argb_t::integer_type base_int;
+						switch (adj->get_type()) {
+							using enum ProvinceDefinition::adjacency_t::type_t;
+						case LAND:       base_int = 0x00FF00; break;
+						case WATER:      base_int = 0x0000FF; break;
+						case COASTAL:    base_int = 0xF9D199; break;
+						case IMPASSABLE: base_int = 0x8B4513; break;
+						case STRAIT:     base_int = 0x00FFFF; break;
+						case CANAL:      base_int = 0x888888; break;
+						default:         base_int = 0xFF0000; break;
+						}
+						base = colour_argb_t::from_integer(base_int).with_alpha(ALPHA_VALUE);
+						stripe = base;
+					}
+
+					if (selected_province_definition.has_adjacency_going_through(province_definition)) {
+						stripe = (0xFFFF00_argb).with_alpha(ALPHA_VALUE);
+					}
+
+					return { base, stripe };
+				}
+
+				return colour_argb_t::null();
+			}
+		);
+	}
 
 	lock_mapmodes();
 

--- a/src/openvic-simulation/map/Mapmode.hpp
+++ b/src/openvic-simulation/map/Mapmode.hpp
@@ -10,6 +10,7 @@ namespace OpenVic {
 	struct MapmodeManager;
 	struct MapInstance;
 	struct ProvinceInstance;
+	struct CountryInstance;
 
 	struct Mapmode : HasIdentifier, HasIndex<int32_t> {
 		friend struct MapmodeManager;
@@ -23,7 +24,9 @@ namespace OpenVic {
 				: base_colour { base }, stripe_colour { stripe } {}
 			constexpr base_stripe_t(colour_argb_t both) : base_stripe_t { both, both } {}
 		};
-		using colour_func_t = std::function<base_stripe_t(MapInstance const&, ProvinceInstance const&)>;
+		using colour_func_t = std::function<
+			base_stripe_t(MapInstance const&, ProvinceInstance const&, CountryInstance const*, ProvinceInstance const*)
+		>;
 
 	private:
 		// Not const so they don't have to be copied when the Mapmode is moved
@@ -44,7 +47,10 @@ namespace OpenVic {
 
 		Mapmode(Mapmode&&) = default;
 
-		base_stripe_t get_base_stripe_colours(MapInstance const& map_instance, ProvinceInstance const& province) const;
+		base_stripe_t get_base_stripe_colours(
+			MapInstance const& map_instance, ProvinceInstance const& province,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province
+		) const;
 	};
 
 	struct MapmodeManager {
@@ -66,7 +72,11 @@ namespace OpenVic {
 		 * and A = 255 is fully the RGB colour packaged with A. The base and stripe colours for each province are packed
 		 * together adjacently, so each province's entry is 8 bytes long. The list contains ProvinceDefinition::MAX_INDEX + 1
 		 * entries, that is the maximum allowed number of provinces plus one for the index-zero "null province". */
-		bool generate_mapmode_colours(MapInstance const& map_instance, Mapmode const* mapmode, uint8_t* target) const;
+		bool generate_mapmode_colours(
+			MapInstance const& map_instance, Mapmode const* mapmode,
+			CountryInstance const* player_country, ProvinceInstance const* selected_province,
+			uint8_t* target
+		) const;
 
 		bool setup_mapmodes();
 	};


### PR DESCRIPTION
Selected province should be handled at the GDExtension level, e.g. in multiplayer the host and each client will have a different selected province so it shouldn't be part of `MapInstance`