### PR TITLE
Fix strata order to: poor, middle, rich

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.cpp
+++ b/src/openvic-simulation/dataloader/Dataloader.cpp
@@ -308,6 +308,9 @@ bool Dataloader::_load_interface_files(UIManager& ui_manager) const {
 
 bool Dataloader::_load_pop_types(DefinitionManager& definition_manager) {
 	PopManager& pop_manager = definition_manager.get_pop_manager();
+
+	bool ret = pop_manager.setup_stratas();
+
 	GoodDefinitionManager const& good_definition_manager =
 		definition_manager.get_economy_manager().get_good_definition_manager();
 	IdeologyManager const& ideology_manager = definition_manager.get_politics_manager().get_ideology_manager();
@@ -316,9 +319,9 @@ bool Dataloader::_load_pop_types(DefinitionManager& definition_manager) {
 
 	const path_vector_t pop_type_files = lookup_files_in_dir(pop_type_directory, ".txt");
 
-	pop_manager.reserve_all_pop_types(pop_type_files.size());
+	pop_manager.reserve_pop_types_and_delayed_nodes(pop_type_files.size());
 
-	bool ret = apply_to_files(
+	ret &= apply_to_files(
 		pop_type_files,
 		[this, &pop_manager, &good_definition_manager, &ideology_manager](fs::path const& file) -> bool {
 			return pop_manager.load_pop_type_file(
@@ -327,7 +330,7 @@ bool Dataloader::_load_pop_types(DefinitionManager& definition_manager) {
 		}
 	);
 
-	pop_manager.lock_all_pop_types();
+	pop_manager.lock_pop_types();
 
 	if (pop_manager.get_slave_sprite() <= 0) {
 		Logger::error("No slave pop type sprite found!");

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -48,6 +48,8 @@ namespace OpenVic {
 		Issue(Issue&&) = default;
 	};
 
+	struct ReformGroup;
+
 	// Reform type (i.e. political_issues)
 	struct ReformType : HasIdentifier {
 		friend struct IssueManager;
@@ -55,6 +57,7 @@ namespace OpenVic {
 	private:
 		bool PROPERTY_CUSTOM_PREFIX(uncivilised, is); // whether this group is available to non-westernised countries
 		// in vanilla education, military and economic reforms are hardcoded to true and the rest to false
+		std::vector<ReformGroup const*> PROPERTY(reform_groups);
 
 		ReformType(std::string_view new_identifier, bool new_uncivilised);
 
@@ -139,7 +142,7 @@ namespace OpenVic {
 			IssueGroup& issue_group, ast::NodeCPtr node
 		);
 		bool _load_reform_group(
-			size_t& expected_reforms, std::string_view identifier, ReformType const* reform_type, ast::NodeCPtr node
+			size_t& expected_reforms, std::string_view identifier, ReformType& reform_type, ast::NodeCPtr node
 		);
 		bool _load_reform(
 			ModifierManager const& modifier_manager, RuleManager const& rule_manager, size_t ordinal,
@@ -153,7 +156,7 @@ namespace OpenVic {
 			bool jingoism
 		);
 		bool add_reform_type(std::string_view identifier, bool uncivilised);
-		bool add_reform_group(std::string_view identifier, ReformType const* reform_type, bool ordered, bool administrative);
+		bool add_reform_group(std::string_view identifier, ReformType& reform_type, bool ordered, bool administrative);
 		bool add_reform(
 			std::string_view identifier, colour_t new_colour, ModifierValue&& values, ReformGroup& reform_group,
 			size_t ordinal, fixed_point_t administrative_multiplier, RuleSet&& rules, Reform::tech_cost_t technology_cost,

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -325,7 +325,7 @@ void Pop::pop_tick() {
 	money_to_spend_per_good.clear();
 	fill_needs_fulfilled_goods_with_false();
 	if (artisanal_producer_nullable != nullptr) {
-		//execute artisan_tick before needs 
+		//execute artisan_tick before needs
 		artisanal_producer_nullable->artisan_tick(*this);
 	}
 
@@ -337,7 +337,7 @@ void Pop::pop_tick() {
 	const fixed_point_t base_needs_scalar = (
 		fixed_point_t::_1() + 2 * consciousness / defines.get_pdef_base_con()
 	) * size;
-	constexpr int32_t size_denominator = 200000;	
+	constexpr int32_t size_denominator = 200000;
 
 	CountryInstance* country_to_report_economy_nullable = location_never_null.get_country_to_report_economy();
 	#define FILL_NEEDS(need_category) \
@@ -374,7 +374,7 @@ void Pop::pop_tick() {
 				max_quantity_to_buy_per_good[good_definition] += max_quantity_to_buy; \
 			} \
 		}
-	
+
 	DO_FOR_ALL_NEED_CATEGORIES(FILL_NEEDS)
 	#undef FILL_NEEDS
 
@@ -449,7 +449,7 @@ void Pop::pop_tick() {
 						); \
 						add_##need_category##_needs_expense(expense); \
 					}
-				
+
 				DO_FOR_ALL_NEED_CATEGORIES(CONSUME_NEED)
 				#undef CONSUME_NEED
 			}


### PR DESCRIPTION
- Needed for budget menu where strata UI elements are identified by index (0 = poor, 1 = middle, 2 = rich). Previous system indexed stratas based on their order of appearance in loaded pop type files, for vanilla: rich, middle, poor.
- This also adds a `default_strata`, following the base game's behaviour of defaulting to middle strata for invalid defines file strata values.
- This adds a vector of pop types to each strata so we can easily iterate over their pop types.
- This adds index variables to Strata and PopType, so they can be reliably identified by ints rather than strings.