### PR TITLE
Performance: reuse maps & PopValuesFromProvince

### DIFF
--- a/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
@@ -29,7 +29,13 @@ namespace OpenVic {
 			fixed_point_t new_current_production
 		);
 
-		void artisan_tick(Pop& pop);
+		void artisan_tick(
+			Pop& pop,
+			GoodDefinition::good_definition_map_t& pop_max_quantity_to_buy_per_good,
+			GoodDefinition::good_definition_map_t& pop_money_to_spend_per_good,
+			GoodDefinition::good_definition_map_t& reusable_map_0,
+			GoodDefinition::good_definition_map_t& reusable_map_1
+		);
 
 		//thread safe if called once per good and stockpile already has an entry.
 		//adds to stockpile up to max_quantity_to_buy and returns quantity added to stockpile

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -2,12 +2,14 @@
 
 #include "openvic-simulation/history/ProvinceHistory.hpp"
 #include "openvic-simulation/map/MapDefinition.hpp"
-#include "openvic-simulation/utility/CompilerFeatureTesting.hpp"
+#include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
 
 using namespace OpenVic;
 
-MapInstance::MapInstance(MapDefinition const& new_map_definition) : map_definition { new_map_definition } {}
+MapInstance::MapInstance(MapDefinition const& new_map_definition)
+	: map_definition { new_map_definition }
+	{}
 
 ProvinceInstance& MapInstance::get_province_instance_from_definition(ProvinceDefinition const& province) {
 	return province_instances.get_items()[province.get_index() - 1];
@@ -43,7 +45,6 @@ bool MapInstance::setup(
 			if (province_instances.add_item({
 				market_instance,
 				modifier_effect_cache,
-				pop_defines,
 				province,
 				strata_keys,
 				pop_type_keys,
@@ -71,6 +72,24 @@ bool MapInstance::setup(
 			map_definition.get_province_definition_count(), ")!"
 		);
 		return false;
+	}
+
+	if (ret) {
+		const size_t max_worker_threads = std::thread::hardware_concurrency();
+		const size_t max_threads_including_parent = max_worker_threads + 1;
+		reusable_pop_values_collection.reserve(max_threads_including_parent);
+		threads.reserve(max_worker_threads);
+
+		for (size_t i = 0; i < max_worker_threads; i++) {
+			reusable_pop_values_collection.emplace_back(PopValuesFromProvince {
+				pop_defines, strata_keys
+			});
+			threads.emplace_back();
+		}
+
+		reusable_pop_values_collection.emplace_back(PopValuesFromProvince {
+			pop_defines, strata_keys
+		});
 	}
 
 	return ret;
@@ -156,12 +175,47 @@ void MapInstance::update_gamestate(const Date today, DefineManager const& define
 	state_manager.update_gamestate();
 }
 
+void MapInstance::process_provinces_in_parallel(std::invocable<ProvinceInstance&, PopValuesFromProvince&> auto callback) {
+	std::vector<ProvinceInstance>& provinces = province_instances.get_items();
+	const auto [quotient, remainder] = std::ldiv(provinces.size(), reusable_pop_values_collection.size());
+	std::vector<ProvinceInstance>::iterator begin = provinces.begin();
+	for (size_t i = 0; i < threads.size(); i++) {
+		const size_t chunk_size = i < remainder
+			? quotient + 1
+			: quotient;
+			std::vector<ProvinceInstance>::iterator end = begin + chunk_size;
+		threads[i] = std::thread{
+			[
+				&callback,
+				&reusable_pop_values = reusable_pop_values_collection[i],
+				begin,
+				end
+			]()->void{
+				for (std::vector<ProvinceInstance>::iterator it = begin; it < end; it++) {
+					callback(*it, reusable_pop_values);
+				}
+			}
+		};
+		begin = end;
+	}
+	{
+		auto parent_thread_end = begin + quotient;
+		auto& reusable_pop_values = reusable_pop_values_collection.back();
+		for (auto it = begin; it < parent_thread_end; it++) {
+			callback(*it, reusable_pop_values);
+		}
+	}
+	for (std::thread& thread : threads) {
+		if (thread.joinable()) {
+			thread.join();
+		}
+	}
+}
+
 void MapInstance::map_tick(const Date today) {
-	auto& provinces = province_instances.get_items();
-	parallel_for_each(
-		provinces,
-		[today](ProvinceInstance& province) -> void {
-			province.province_tick(today);
+	process_provinces_in_parallel(
+		[today](ProvinceInstance& province, PopValuesFromProvince& reusable_pop_values) -> void {
+			province.province_tick(today, reusable_pop_values);
 		}
 	);
 }
@@ -171,12 +225,9 @@ void MapInstance::initialise_for_new_game(
 	DefineManager const& define_manager
 ) {
 	update_gamestate(today, define_manager);
-	auto& provinces = province_instances.get_items();
-	parallel_for_each(
-		provinces,
-		[today](ProvinceInstance& province) -> void {
-			province.initialise_rgo();
-			province.province_tick(today);
+	process_provinces_in_parallel(
+		[today](ProvinceInstance& province, PopValuesFromProvince& reusable_pop_values) -> void {
+			province.initialise_for_new_game(today, reusable_pop_values);
 		}
 	);
 }

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include <thread>
+
 #include "openvic-simulation/economy/trading/MarketInstance.hpp"
 #include "openvic-simulation/map/ProvinceDefinition.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/map/State.hpp"
+#include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
@@ -26,6 +29,11 @@ namespace OpenVic {
 		pop_size_t PROPERTY(total_map_population, 0);
 
 		StateManager PROPERTY_REF(state_manager);
+
+		std::vector<PopValuesFromProvince> reusable_pop_values_collection;
+		std::vector<std::thread> threads;
+
+		void process_provinces_in_parallel(std::invocable<ProvinceInstance&, PopValuesFromProvince&> auto callback);
 
 	public:
 		MapInstance(MapDefinition const& new_map_definition);

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -10,7 +10,6 @@
 #include "openvic-simulation/military/UnitType.hpp"
 #include "openvic-simulation/modifier/ModifierSum.hpp"
 #include "openvic-simulation/pop/Pop.hpp"
-#include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/FlagStrings.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
@@ -95,7 +94,6 @@ namespace OpenVic {
 
 	private:
 		plf::colony<Pop> PROPERTY(pops); // TODO - replace with a more easily vectorisable container?
-		PopValuesFromProvince PROPERTY(shared_pop_values);
 		pop_size_t PROPERTY(total_population, 0);
 		// TODO - population change (growth + migration), monthly totals + breakdown by source/destination
 		fixed_point_t PROPERTY(average_literacy);
@@ -120,7 +118,6 @@ namespace OpenVic {
 		ProvinceInstance(
 			MarketInstance& new_market_instance,
 			ModifierEffectCache const& new_modifier_effect_cache,
-			PopsDefines const& new_pop_defines,
 			ProvinceDefinition const& new_province_definition,
 			decltype(population_by_strata)::keys_type const& strata_keys,
 			decltype(pop_type_distribution)::keys_type const& pop_type_keys,
@@ -130,6 +127,7 @@ namespace OpenVic {
 		void _add_pop(Pop&& pop);
 		void _update_pops(DefineManager const& define_manager);
 		bool convert_rgo_worker_pops_to_equivalent(ProductionType const& production_type);
+		void initialise_rgo();
 
 	public:
 		ProvinceInstance(ProvinceInstance&&) = default;
@@ -228,15 +226,14 @@ namespace OpenVic {
 		}
 
 		void update_gamestate(const Date today, DefineManager const& define_manager);
-		void province_tick(const Date today);
+		void province_tick(const Date today, PopValuesFromProvince& reusable_pop_values);
+		void initialise_for_new_game(const Date today, PopValuesFromProvince& reusable_pop_values);
 
 		bool add_unit_instance_group(UnitInstanceGroup& group);
 		bool remove_unit_instance_group(UnitInstanceGroup const& group);
 
 		bool setup(BuildingTypeManager const& building_type_manager);
 		bool apply_history_to_province(ProvinceHistoryEntry const& entry, CountryInstanceManager& country_manager);
-
-		void initialise_rgo();
 
 		void setup_pop_test_values(IssueManager const& issue_manager);
 		plf::colony<Pop>& get_mutable_pops();

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -12,6 +12,7 @@ namespace OpenVic {
 	struct DefineManager;
 	struct MarketInstance;
 	struct ProvinceInstance;
+	struct PopValuesFromProvince;
 
 	struct PopBase {
 		friend PopManager;
@@ -74,8 +75,6 @@ namespace OpenVic {
 		std::unique_ptr<ArtisanalProducer> artisanal_producer_nullable;
 		fixed_point_t cash_allocated_for_artisanal_spending;
 		fixed_point_t artisanal_produce_left_to_sell;
-		GoodDefinition::good_definition_map_t max_quantity_to_buy_per_good; //TODO pool?
-		GoodDefinition::good_definition_map_t money_to_spend_per_good; //TODO pool?
 		ProvinceInstance* PROPERTY_PTR(location, nullptr);
 		MarketInstance& PROPERTY(market_instance);
 
@@ -105,12 +104,12 @@ namespace OpenVic {
 		moveable_atomic_fixed_point_t PROPERTY(expenses); //positive value means POP paid for goods. This is displayed * -1 in UI.
 
 		#define NEED_MEMBERS(need_category) \
-			moveable_atomic_fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
+				moveable_atomic_fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
 			public: \
-			fixed_point_t get_##need_category##_needs_fulfilled() const; \
+				fixed_point_t get_##need_category##_needs_fulfilled() const; \
 			private: \
-			GoodDefinition::good_definition_map_t need_category##_needs; \
-			ordered_map<GoodDefinition const*, bool> PROPERTY(need_category##_needs_fulfilled_goods);
+				GoodDefinition::good_definition_map_t PROPERTY(need_category##_needs); /* TODO pool? (if recalculating in UI is acceptable) */ \
+				ordered_map<GoodDefinition const*, bool> PROPERTY(need_category##_needs_fulfilled_goods);
 
 		DO_FOR_ALL_NEED_CATEGORIES(NEED_MEMBERS)
 		#undef NEED_MEMBERS
@@ -133,9 +132,12 @@ namespace OpenVic {
 		void fill_needs_fulfilled_goods_with_false();
 		void allocate_for_needs(
 			GoodDefinition::good_definition_map_t const& scaled_needs,
+			GoodDefinition::good_definition_map_t& money_to_spend_per_good,
+			GoodDefinition::good_definition_map_t& reusable_map_0,
 			fixed_point_t& price_inverse_sum,
 			fixed_point_t& cash_left_to_spend
 		);
+		void pop_tick_without_cleanup(PopValuesFromProvince& shared_values);
 
 	public:
 		Pop(Pop const&) = delete;
@@ -163,9 +165,9 @@ namespace OpenVic {
 		DO_FOR_ALL_TYPES_OF_POP_INCOME(DECLARE_POP_MONEY_STORE_FUNCTIONS)
 		DO_FOR_ALL_TYPES_OF_POP_EXPENSES(DECLARE_POP_MONEY_STORE_FUNCTIONS)
 		#undef DECLARE_POP_MONEY_STORE_FUNCTIONS
-		void pop_tick();
-		void artisanal_buy(GoodDefinition const& good, const fixed_point_t max_quantity_to_buy, const fixed_point_t money_to_spend);
-		void artisanal_sell(const fixed_point_t quantity);
+		void pop_tick(PopValuesFromProvince& shared_values);
+		void allocate_cash_for_artisanal_spending(const fixed_point_t money_to_spend);
+		void report_artisanal_produce(const fixed_point_t quantity);
 	};
 }
 #ifndef KEEP_DO_FOR_ALL_TYPES_OF_INCOME

--- a/src/openvic-simulation/pop/PopValuesFromProvince.cpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.cpp
@@ -4,15 +4,16 @@
 #include "openvic-simulation/defines/PopsDefines.hpp"
 #include "openvic-simulation/modifier/ModifierEffectCache.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
-#include "openvic-simulation/utility/Utility.hpp"
 
 using namespace OpenVic;
 
-void PopStrataValuesFromProvince::update_pop_strata_values_from_province(PopValuesFromProvince const& parent, Strata const& strata) {
-	ProvinceInstance const& province = *parent.get_province();
+void PopStrataValuesFromProvince::update_pop_strata_values_from_province(
+	PopsDefines const& defines,
+	Strata const& strata,
+	ProvinceInstance const& province
+) {
 	ModifierEffectCache const& modifier_effect_cache = province.get_modifier_effect_cache();
 	ModifierEffectCache::strata_effects_t const& strata_effects = modifier_effect_cache.get_strata_effects()[strata];
-	PopsDefines const& defines = parent.get_defines();
 	fixed_point_t shared_base_needs_scalar = defines.get_base_goods_demand()
 		* (fixed_point_t::_1() + province.get_modifier_effect_value(*modifier_effect_cache.get_goods_demand()));
 
@@ -41,13 +42,8 @@ PopValuesFromProvince::PopValuesFromProvince(
 	effects_per_strata { &strata_keys }
 	{}
 
-void PopValuesFromProvince::update_pop_values_from_province() {
-	if (OV_unlikely(province == nullptr)) {
-		OpenVic::Logger::error("PopValuesFromProvince has no province. Check ProvinceInstance::setup correctly sets it.");
-		return;
-	}
-
+void PopValuesFromProvince::update_pop_values_from_province(ProvinceInstance const& province) {
 	for (auto [strata, values] : effects_per_strata) {
-		values.update_pop_strata_values_from_province(*this, strata);
+		values.update_pop_strata_values_from_province(defines, strata, province);
 	}
 }

--- a/src/openvic-simulation/pop/PopValuesFromProvince.hpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "openvic-simulation/pop/PopType.hpp"
 #include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
@@ -16,20 +18,24 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(shared_everyday_needs_scalar);
 		fixed_point_t PROPERTY(shared_luxury_needs_scalar);
 	public:
-		void update_pop_strata_values_from_province(PopValuesFromProvince const& parent, Strata const& strata);
+		void update_pop_strata_values_from_province(PopsDefines const& defines, Strata const& strata, ProvinceInstance const& province);
 	};
 
 	struct PopValuesFromProvince {
 	private:
+		static constexpr size_t MAPS_FOR_POP = 4;
 		PopsDefines const& PROPERTY(defines);
-		ProvinceInstance const* PROPERTY_RW(province, nullptr);
 		IndexedMap<Strata, PopStrataValuesFromProvince> PROPERTY(effects_per_strata);
 	public:
+	 	//public field as mutable references are required.
+		std::array<GoodDefinition::good_definition_map_t, MAPS_FOR_POP> reusable_maps {};
+
 		PopValuesFromProvince(
 			PopsDefines const& new_defines,
 			decltype(effects_per_strata)::keys_type const& strata_keys
 		);
+		PopValuesFromProvince(PopValuesFromProvince&&) = default;
 
-		void update_pop_values_from_province();
+		void update_pop_values_from_province(ProvinceInstance const& province);
 	};
 }


### PR DESCRIPTION
Pops use several `GoodDefinition::good_definition_map_t` in their tick method. These maps can be cleared and reused by the next pop. `PopValuesFromProvince` similarly can be reused for multiple provinces as all data is overwritten in the `update_pop_values_from_province` method.

So to reuse resources when possible, `PopValuesFromProvince` is expanded to include several reusable maps.
The MapInstance now stores the instances of `PopValuesFromProvince` and creates threads explicitly to process provinces in parallel. This is done to limit the number of threads to the number of `PopValuesFromProvince`s.

`std::thread::hardware_concurrency()` is used to determine the amount of worker threads. Those threads are created in the map tick to process the provinces. The parent thread also processes provinces, so there is 1 more `PopValuesFromProvince`.

GoodMarket also has maps that can be reused. If this PR is approved, we can apply the same idea to MarketInstance.