### PR TITLE
Round up income and expenses to handle inaccuracies

### DIFF
--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -370,7 +370,10 @@ void ResourceGatheringOperation::pay_employees(
 
 		for (Pop* owner_pop_ptr : *owner_pops_cache_nullable) {
 			Pop& owner_pop = *owner_pop_ptr;
-			const fixed_point_t income_for_this_pop = revenue_left * (owner_share * owner_pop.get_size()) / total_owner_count_in_state_cache;
+			const fixed_point_t income_for_this_pop = std::max(
+				revenue_left * (owner_share * owner_pop.get_size()) / total_owner_count_in_state_cache,
+				fixed_point_t::epsilon() //revenue_left > 0 is already checked, so rounding up
+			);
 			owner_pop.add_rgo_owner_income(income_for_this_pop);
 			total_owner_income_cache += income_for_this_pop;
 		}

--- a/src/openvic-simulation/economy/trading/MarketInstance.cpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.cpp
@@ -21,6 +21,16 @@ fixed_point_t MarketInstance::get_max_next_price(GoodDefinition const& good_defi
 	return good_instance_manager.get_good_instance_from_definition(good_definition).get_max_next_price();
 }
 
+fixed_point_t MarketInstance::get_min_next_price(GoodDefinition const& good_definition) const {
+	return good_instance_manager.get_good_instance_from_definition(good_definition).get_min_next_price();
+}
+
+fixed_point_t MarketInstance::get_max_money_to_allocate_to_buy_quantity(GoodDefinition const& good_definition, const fixed_point_t quantity) const {
+	//round up so money_to_spend >= max_next_price * max_quantity_to_buy;
+	//always add epsilon as money_to_spend == max_next_price * max_quantity_to_buy is rare and this is cheaper for performance.
+	return quantity * get_max_next_price(good_definition) + fixed_point_t::epsilon();
+}
+
 fixed_point_t MarketInstance::get_price_inverse(GoodDefinition const& good_definition) const {
 	return good_instance_manager.get_good_instance_from_definition(good_definition).get_price_inverse();
 }

--- a/src/openvic-simulation/economy/trading/MarketInstance.hpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.hpp
@@ -17,6 +17,8 @@ namespace OpenVic {
 		MarketInstance(CountryDefines const& new_country_defines, GoodInstanceManager& new_good_instance_manager);
 		bool get_is_available(GoodDefinition const& good_definition) const;
 		fixed_point_t get_max_next_price(GoodDefinition const& good_definition) const;
+		fixed_point_t get_min_next_price(GoodDefinition const& good_definition) const;
+		fixed_point_t get_max_money_to_allocate_to_buy_quantity(GoodDefinition const& good_definition, const fixed_point_t quantity) const;
 		fixed_point_t get_price_inverse(GoodDefinition const& good_definition) const;
 		void place_buy_up_to_order(BuyUpToOrder&& buy_up_to_order);
 		void place_market_sell_order(MarketSellOrder&& market_sell_order);


### PR DESCRIPTION
Round up income to epsilon when you have sold a good.
Round up expenses to epsilon when you have bought a good.
Round up money_to_spend when allocating to buy a good (so `money_to_spend >= max_next_price * max_quantity_to_buy`).

Round down quanity bought