### PR TITLE
Fix artisan overspending

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -129,6 +129,16 @@ static bool run_headless(Dataloader::path_vector_t const& roots, bool run_tests)
 		ret = false;
 	}
 
+	if (ret) {
+		size_t ticks_passed = 0;
+		auto start_time = std::chrono::high_resolution_clock::now();
+		while (ticks_passed++ < 10) {
+			game_manager.get_instance_manager()->force_tick_and_update();
+		}
+		auto end_time = std::chrono::high_resolution_clock::now();
+		Logger::info("Ran ", --ticks_passed, " ticks in ", end_time - start_time);
+	}
+
 	return ret;
 }
 

--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -253,6 +253,10 @@ bool InstanceManager::update_clock() {
 	return true;
 }
 
+void InstanceManager::force_tick_and_update() {
+	simulation_clock.force_advance_game();
+}
+
 bool InstanceManager::set_today_and_update(Date new_today) {
 	if (!is_game_session_started()) {
 		Logger::error("Cannot update clock - game session not started!");

--- a/src/openvic-simulation/InstanceManager.hpp
+++ b/src/openvic-simulation/InstanceManager.hpp
@@ -79,6 +79,7 @@ namespace OpenVic {
 		bool load_bookmark(Bookmark const* new_bookmark);
 		bool start_game_session();
 		bool update_clock();
+		void force_tick_and_update();
 
 		bool set_today_and_update(Date new_today);
 

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -372,7 +372,7 @@ void ResourceGatheringOperation::pay_employees(
 			Pop& owner_pop = *owner_pop_ptr;
 			const fixed_point_t income_for_this_pop = std::max(
 				revenue_left * (owner_share * owner_pop.get_size()) / total_owner_count_in_state_cache,
-				fixed_point_t::epsilon() //revenue_left > 0 is already checked, so rounding up
+				fixed_point_t::epsilon() //revenue > 0 is already checked, so rounding up
 			);
 			owner_pop.add_rgo_owner_income(income_for_this_pop);
 			total_owner_income_cache += income_for_this_pop;
@@ -395,7 +395,10 @@ void ResourceGatheringOperation::pay_employees(
 			}
 
 			const pop_size_t employee_size = employee.get_size();
-			const fixed_point_t income_for_this_pop = revenue_left * employee_size / total_paid_employees_count_cache;
+			const fixed_point_t income_for_this_pop = std::max(
+				revenue_left * employee_size / total_paid_employees_count_cache,
+				fixed_point_t::epsilon() //revenue > 0 is already checked, so rounding up
+			);
 			employee_pop.add_rgo_worker_income(income_for_this_pop);
 			total_employee_income_cache += income_for_this_pop;
 		}

--- a/src/openvic-simulation/misc/SimulationClock.cpp
+++ b/src/openvic-simulation/misc/SimulationClock.cpp
@@ -57,6 +57,12 @@ void SimulationClock::conditionally_advance_game() {
 	update_function();
 }
 
+void SimulationClock::force_advance_game() {
+	last_tick_time = std::chrono::high_resolution_clock::now();
+	tick_function();
+	update_function();
+}
+
 void SimulationClock::reset() {
 	paused = true;
 	current_speed = 0;

--- a/src/openvic-simulation/misc/SimulationClock.hpp
+++ b/src/openvic-simulation/misc/SimulationClock.hpp
@@ -50,6 +50,7 @@ namespace OpenVic {
 		bool can_decrease_simulation_speed() const;
 
 		void conditionally_advance_game();
+		void force_advance_game(); //for debug only
 		void reset();
 	};
 }

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -445,7 +445,7 @@ void Pop::pop_tick_without_cleanup(PopValuesFromProvince& shared_values) {
 		const fixed_point_t max_quantity_to_buy = max_quantity_to_buy_per_good[good_definition];
 
 		if (OV_unlikely(max_quantity_to_buy <= fixed_point_t::_0())) {
-			Logger::error("Aborted placing buy order for ",*good_definition," of max_quantity_to_buy 0.");
+			Logger::error("Aborted placing buy order for ", *good_definition, " of max_quantity_to_buy 0.");
 			continue;
 		}
 

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -104,7 +104,7 @@ namespace OpenVic {
 		moveable_atomic_fixed_point_t PROPERTY(expenses); //positive value means POP paid for goods. This is displayed * -1 in UI.
 
 		#define NEED_MEMBERS(need_category) \
-				moveable_atomic_fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
+			moveable_atomic_fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
 			public: \
 				fixed_point_t get_##need_category##_needs_fulfilled() const; \
 			private: \


### PR DESCRIPTION
#337 rounded up expenses.
The artisanal optimal quantity was calculated as if we have endless precision and no rounding.
(Also optimal quantity wasn't used. Demand was used instead.)
The optimal quantity needs to take the minimum cost of epsilon into account. This is a flat cost and not proportional to the quantity bought.

Other changes:
- added force_tick_and_update to simulate several days in headless
- rounded up income for RGO workers (#337 should've included this...)
- minor spacing corrections in pop files