### PR TITLE
Fix bugs in threadpool

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -168,7 +168,7 @@ bool InstanceManager::setup() {
 		definition_manager.get_define_manager().get_economy_defines()
 	);
 
-	thread_pool.initialise(
+	thread_pool.initialise_threadpool(
 		definition_manager.get_define_manager().get_pops_defines(),
 		definition_manager.get_pop_manager().get_stratas(),
 		good_instance_manager.get_good_instances(),

--- a/src/openvic-simulation/utility/ThreadPool.hpp
+++ b/src/openvic-simulation/utility/ThreadPool.hpp
@@ -33,9 +33,8 @@ namespace OpenVic {
 
 		std::vector<std::thread> threads;
 		std::vector<work_t> work_per_thread;
-		std::mutex mutex;
-		std::condition_variable thread_condition;
-		std::condition_variable completed_condition;
+		std::mutex thread_mutex, completed_mutex;
+		std::condition_variable thread_condition, completed_condition;
 		std::atomic<size_t> active_work_count = 0;
 		bool is_cancellation_requested = false;
 		Date const& current_date;
@@ -49,7 +48,7 @@ namespace OpenVic {
 		ThreadPool(Date const& new_current_date);
 		~ThreadPool();
 
-		void initialise(
+		void initialise_threadpool(
 			PopsDefines const& pop_defines,
 			std::vector<Strata> const& strata_keys,
 			std::span<GoodInstance> goods,


### PR DESCRIPTION
- Use max_worker_threads instead of threads.size() to fill threads as size start 0 (even after resizing).
- Renamed `initialise` to `initialise_threadpool` so you can search for it easily.
- Use different locks for the thread condition and the completed condition to avoid deadlocking.
- Pass `work_type` reference as reference instead of passing it by value as that will never change.