### PR TITLE
Add game rule for economic country

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -145,6 +145,7 @@ bool InstanceManager::setup() {
 	ret &= map_instance.setup(
 		definition_manager.get_economy_manager().get_building_type_manager(),
 		market_instance,
+		game_rules_manager,
 		definition_manager.get_modifier_manager().get_modifier_effect_cache(),
 		definition_manager.get_pop_manager().get_stratas(),
 		definition_manager.get_pop_manager().get_pop_types(),

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -19,6 +19,7 @@ ProvinceInstance const& MapInstance::get_province_instance_from_definition(Provi
 bool MapInstance::setup(
 	BuildingTypeManager const& building_type_manager,
 	MarketInstance& market_instance,
+	GameRulesManager const& game_rules_manager,
 	ModifierEffectCache const& modifier_effect_cache,
 	decltype(ProvinceInstance::population_by_strata)::keys_type const& strata_keys,
 	decltype(ProvinceInstance::pop_type_distribution)::keys_type const& pop_type_keys,
@@ -40,6 +41,7 @@ bool MapInstance::setup(
 		for (ProvinceDefinition const& province : map_definition.get_province_definitions()) {
 			if (province_instances.add_item({
 				market_instance,
+				game_rules_manager,
 				modifier_effect_cache,
 				province,
 				strata_keys,

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -49,6 +49,7 @@ namespace OpenVic {
 		bool setup(
 			BuildingTypeManager const& building_type_manager,
 			MarketInstance& market_instance,
+			GameRulesManager const& game_rules_manager,
 			ModifierEffectCache const& modifier_effect_cache,
 			decltype(ProvinceInstance::population_by_strata)::keys_type const& strata_keys,
 			decltype(ProvinceInstance::pop_type_distribution)::keys_type const& pop_type_keys,

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -32,6 +32,7 @@ namespace OpenVic {
 	struct CountryInstanceManager;
 	struct ModifierEffectCache;
 	struct MarketInstance;
+	struct GameRulesManager;
 
 	struct UnitInstanceGroup;
 
@@ -64,6 +65,7 @@ namespace OpenVic {
 
 	private:
 		ProvinceDefinition const& PROPERTY(province_definition);
+		GameRulesManager const& PROPERTY(game_rules_manager);
 		ModifierEffectCache const& PROPERTY(modifier_effect_cache);
 
 		TerrainType const* PROPERTY(terrain_type);
@@ -73,6 +75,7 @@ namespace OpenVic {
 
 		CountryInstance* PROPERTY_PTR(owner, nullptr);
 		CountryInstance* PROPERTY_PTR(controller, nullptr);
+		CountryInstance* PROPERTY_PTR(country_to_report_economy, nullptr);
 		ordered_set<CountryInstance*> PROPERTY(cores);
 
 		// The total/resultant modifier of local effects on this province (global effects come from the province's owner)
@@ -117,6 +120,7 @@ namespace OpenVic {
 
 		ProvinceInstance(
 			MarketInstance& new_market_instance,
+			GameRulesManager const& new_game_rules_manager,
 			ModifierEffectCache const& new_modifier_effect_cache,
 			ProvinceDefinition const& new_province_definition,
 			decltype(population_by_strata)::keys_type const& strata_keys,
@@ -136,14 +140,6 @@ namespace OpenVic {
 			return province_definition;
 		}
 
-		constexpr CountryInstance const* get_country_to_report_economy() const {
-			return controller;
-		}
-
-		constexpr CountryInstance* get_country_to_report_economy() {
-			return controller;
-		}
-
 		void set_state(State* new_state);
 
 		constexpr GoodDefinition const* get_rgo_good() const {
@@ -157,6 +153,7 @@ namespace OpenVic {
 
 		bool set_owner(CountryInstance* new_owner);
 		bool set_controller(CountryInstance* new_controller);
+
 		// The warn argument controls whether a log message is emitted when a core already does/doesn't exist, e.g. we may
 		// want to know if there are redundant province history instructions setting a core multiple times, but we may not
 		// want to be swamped with log messages by effect scripts which use add_core/remove_core very liberally. Regardless
@@ -169,6 +166,9 @@ namespace OpenVic {
 		// This combines COLONY and PROTECTORATE statuses, as opposed to non-colonial STATE provinces
 		constexpr bool is_colonial_province() const {
 			return colony_status != colony_status_t::STATE;
+		}
+		constexpr bool is_occupied() const {
+			return owner != controller;
 		}
 
 		// The values returned by these functions are scaled by population size, so they must be divided by population size

--- a/src/openvic-simulation/misc/GameRulesManager.hpp
+++ b/src/openvic-simulation/misc/GameRulesManager.hpp
@@ -2,6 +2,12 @@
 
 #include "openvic-simulation/utility/Getters.hpp"
 namespace OpenVic {
+	enum struct country_to_report_economy_t : uint8_t {
+		Owner,
+		Controller,
+		NeitherWhenOccupied
+	};
+
 	enum struct demand_category : uint8_t {
 		None,
 		PopNeeds,
@@ -14,6 +20,7 @@ namespace OpenVic {
 		// if changed during a session, call on_use_exponential_price_changes_changed for each GoodInstance.
 		bool PROPERTY_RW(use_exponential_price_changes, false);
 		demand_category PROPERTY_RW(artisanal_input_demand_category, demand_category::None);
+		country_to_report_economy_t PROPERTY_RW(country_to_report_economy, country_to_report_economy_t::Owner);
 
 	public:
 		constexpr bool get_use_optimal_pricing() const {


### PR DESCRIPTION
In Victoria 2, the owner collects taxes and gold income even when provinces are occupied.
It makes more sense that the controller gets that. Alternatively occupied territories could be considered in disarray and neither the owner nor the controller are able to collect taxes.

All of this is now supported via game rules.