### PR TITLE
Add constexpr unit tests

### DIFF
--- a/src/openvic-simulation/types/Date.cpp
+++ b/src/openvic-simulation/types/Date.cpp
@@ -34,13 +34,6 @@ std::ostream& OpenVic::operator<<(std::ostream& out, Timespan const& timespan) {
 	return out << timespan.to_string();
 }
 
-inline Date::stack_string Date::to_array(bool pad_year, bool pad_month, bool pad_day) const {
-	stack_string str {};
-	std::to_chars_result result = to_chars(str.array.data(), str.array.data() + str.array.size(), pad_year, pad_month, pad_day);
-	str.string_size = result.ptr - str.data();
-	return str;
-}
-
 std::string Date::to_string(bool pad_year, bool pad_month, bool pad_day) const {
 	stack_string result = to_array(pad_year, pad_month, pad_day);
 	if (OV_unlikely(result.empty())) {

--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -3,15 +3,16 @@
 #include <cmath>
 
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/utility/Utility.hpp"
 
 namespace OpenVic::_vector_detail {
 	template<typename T>
-	inline T abs(T num) {
-		return std::abs(num);
+	inline constexpr T abs(T num) {
+		return OpenVic::utility::abs(num);
 	}
 
 	template<>
-	inline fixed_point_t abs<fixed_point_t>(fixed_point_t num) {
+	inline constexpr fixed_point_t abs<fixed_point_t>(fixed_point_t num) {
 		return num.abs();
 	}
 }

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.cpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.cpp
@@ -4,13 +4,6 @@
 
 using namespace OpenVic;
 
-fixed_point_t::stack_string fixed_point_t::to_array(size_t decimal_places) const {
-	stack_string str {};
-	std::to_chars_result result = to_chars(str.array.data(), str.array.data() + str.array.size(), decimal_places);
-	str.string_size = result.ptr - str.data();
-	return str;
-}
-
 auto fmt::formatter<fixed_point_t>::format(fixed_point_t fp, format_context& ctx) const -> format_context::iterator {
 	fixed_point_t::stack_string result = fp.to_array();
 	if (OV_unlikely(result.empty())) {

--- a/src/openvic-simulation/utility/Utility.hpp
+++ b/src/openvic-simulation/utility/Utility.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <climits>
+#include <cmath>
+#include <concepts>
 #include <functional>
 #include <type_traits>
 
@@ -137,4 +139,13 @@ namespace OpenVic::utility {
 
 	template<typename T, typename T2>
 	concept not_same_as = !std::same_as<T, T2>;
+
+	template<typename T> requires std::integral<T> || std::floating_point<T>
+	[[nodiscard]] inline constexpr T abs(T num) {
+		if (std::is_constant_evaluated()) {
+			return num < 0 ? -num : num;
+		} else {
+			return std::abs(num);
+		}
+	}
 }

--- a/tests/src/types/Approx.hpp
+++ b/tests/src/types/Approx.hpp
@@ -6,6 +6,7 @@
 #include <limits>
 
 #include "openvic-simulation/types/Vector.hpp"
+#include "openvic-simulation/utility/Utility.hpp"
 
 #include "Vector.hpp" // IWYU pragma: keep
 #include <snitch/snitch_string.hpp>
@@ -59,21 +60,21 @@ namespace OpenVic::testing {
 		}
 
 		template<std::convertible_to<double> T>
-		bool operator==(T rhs) const {
+		constexpr bool operator==(T rhs) const {
 			return operator==(static_cast<double>(rhs));
 		}
 
-		bool operator==(double rhs) const {
+		constexpr bool operator==(double rhs) const {
 			// Thanks to Richard Harris for his help refining this formula
-			return std::abs(rhs - _value) < _epsilon * (_scale + std::max<double>(std::abs(rhs), std::abs(_value)));
+			return OpenVic::utility::abs(rhs - _value) < _epsilon * (_scale + std::max<double>(OpenVic::utility::abs(rhs), OpenVic::utility::abs(_value)));
 		}
 
 		template<std::convertible_to<double> T>
-		std::partial_ordering operator<=>(T rhs) const {
+		constexpr std::partial_ordering operator<=>(T rhs) const {
 			return operator<=>(static_cast<double>(rhs));
 		}
 
-		std::partial_ordering operator<=>(double rhs) const {
+		constexpr std::partial_ordering operator<=>(double rhs) const {
 			return _value <=> rhs;
 		}
 
@@ -94,7 +95,7 @@ namespace OpenVic::testing {
 }
 
 namespace snitch {
-	inline static bool append(snitch::small_string_span ss, OpenVic::testing::approx const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::testing::approx const& s) {
 		return append(ss, s._value);
 	}
 }

--- a/tests/src/types/Colour.cpp
+++ b/tests/src/types/Colour.cpp
@@ -3,12 +3,12 @@
 #include <cmath>
 #include <cstdlib>
 #include <string_view>
-#include <type_traits>
 
 #include "Colour.hpp" // IWYU pragma: keep
 #include "Helper.hpp" // IWYU pragma: keep
 #include "Numeric.hpp" // IWYU pragma: keep
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
@@ -21,43 +21,46 @@ using ColourTypes = snitch::type_list<colour_rgb_t, colour_argb_t>;
 TEMPLATE_LIST_TEST_CASE("basic_colour_t Constructor methods", "[basic_colour_t][basic_colour_t-constructor]", ColourTypes) {
 	using value_t = TestType::value_type;
 
-	const TestType blue_rgb = TestType(
+	static constexpr TestType blue_rgb = TestType(
 		(value_t)(63.0 / 255 * TestType::max_value), //
 		(value_t)(96.0 / 255 * TestType::max_value), //
 		(value_t)(1.0 * TestType::max_value)
 	);
-	const TestType blue_float = TestType::from_floats(0.25098, 0.376471, 1);
+	static constexpr TestType blue_float = TestType::from_floats(0.25098, 0.376471, 1);
 
-	CHECK(blue_rgb == blue_float);
+	CONSTEXPR_CHECK(blue_rgb == blue_float);
 
-	const TestType invalid = TestType::null();
+	static constexpr TestType invalid = TestType::null();
 
-	CHECK(invalid == TestType());
-	CHECK(invalid.is_null());
+	CONSTEXPR_CHECK(invalid == TestType());
+	CONSTEXPR_CHECK(invalid.is_null());
 }
 
 TEMPLATE_LIST_TEST_CASE("basic_colour_t Operators", "[basic_colour_t][basic_colour_t-operators]", ColourTypes) {
-	const TestType blue = TestType::from_floats(0.2, 0.2, 1);
+	static constexpr TestType blue = TestType::from_floats(0.2, 0.2, 1);
 
-	CHECK(-blue == TestType::from_floats(0.8, 0.8, 0));
-	CHECK(blue.invert() == TestType::from_floats(0.8, 0.8, 0));
+	CONSTEXPR_CHECK(-blue == TestType::from_floats(0.8, 0.8, 0));
+	CONSTEXPR_CHECK(blue.invert() == TestType::from_floats(0.8, 0.8, 0));
 	CHECK(blue.contrast() == TestType::from_floats(0, 0, 0));
 	CHECK(blue.invert().contrast() == TestType::from_floats(1, 1, 1));
+	CONSTEXPR_CHECK(blue[0] == 51);
+	CONSTEXPR_CHECK(blue[1] == 51);
+	CONSTEXPR_CHECK(blue[2] == 255);
 }
 
 TEMPLATE_LIST_TEST_CASE("basic_colour_t Conversion methods", "[basic_colour_t][basic_colour_t-conversion]", ColourTypes) {
-	const TestType cyan = TestType::from_floats(0, 1, 1);
+	static constexpr TestType cyan = TestType::from_floats(0, 1, 1);
 
-	CHECK(cyan.as_rgb() == 0x00FFFF);
-	CHECK(cyan.as_argb() == 0xFF00FFFF);
-	CHECK(cyan.as_rgba() == 0x00FFFFFF);
-	CHECK(cyan.redf() == 0);
-	CHECK(cyan.greenf() == 1);
-	CHECK(cyan.bluef() == 1);
-	CHECK(cyan.alphaf() == 1);
-	CHECK(cyan.to_hex_string(true) == "00FFFFFF");
-	CHECK(cyan.to_hex_string(false) == "00FFFF");
-	CHECK(cyan.to_argb_hex_string() == "FF00FFFF");
+	CONSTEXPR_CHECK(cyan.as_rgb() == 0x00FFFF);
+	CONSTEXPR_CHECK(cyan.as_argb() == 0xFF00FFFF);
+	CONSTEXPR_CHECK(cyan.as_rgba() == 0x00FFFFFF);
+	CONSTEXPR_CHECK(cyan.redf() == 0);
+	CONSTEXPR_CHECK(cyan.greenf() == 1);
+	CONSTEXPR_CHECK(cyan.bluef() == 1);
+	CONSTEXPR_CHECK(cyan.alphaf() == 1);
+	CONSTEXPR_CHECK(cyan.to_hex_array(true) == "00FFFFFF"sv);
+	CONSTEXPR_CHECK(cyan.to_hex_array(false) == "00FFFF"sv);
+	CONSTEXPR_CHECK(cyan.to_argb_hex_array() == "FF00FFFF"sv);
 }
 
 TEMPLATE_LIST_TEST_CASE("basic_colour_t Parse methods", "[basic_colour_t][basic_colour_t-parse]", ColourTypes) {
@@ -67,105 +70,129 @@ TEMPLATE_LIST_TEST_CASE("basic_colour_t Parse methods", "[basic_colour_t][basic_
 	static constexpr std::string_view hex_yellow_rgb = "0xFFFF00"sv;
 	static constexpr std::string_view hex_yellow_rgba = "0xFFFF00FF"sv;
 	static constexpr std::string_view hex_yellow_argb = "0xFFFFFF00"sv;
-	const TestType yellow = TestType::from_floats(1, 1, 0);
+	static constexpr TestType yellow = TestType::from_floats(1, 1, 0);
 
-	CHECK(TestType::from_rgb_string(yellow_rgb) == yellow);
-	CHECK(TestType::from_rgba_string(yellow_rgba) == yellow);
-	CHECK(TestType::from_argb_string(yellow_argb) == yellow);
-	CHECK(TestType::from_rgb_string(hex_yellow_rgb) == yellow);
-	CHECK(TestType::from_rgba_string(hex_yellow_rgba) == yellow);
-	CHECK(TestType::from_argb_string(hex_yellow_argb) == yellow);
+	CONSTEXPR_CHECK(TestType::from_rgb_string(yellow_rgb) == yellow);
+	CONSTEXPR_CHECK(TestType::from_rgba_string(yellow_rgba) == yellow);
+	CONSTEXPR_CHECK(TestType::from_argb_string(yellow_argb) == yellow);
+	CONSTEXPR_CHECK(TestType::from_rgb_string(hex_yellow_rgb) == yellow);
+	CONSTEXPR_CHECK(TestType::from_rgba_string(hex_yellow_rgba) == yellow);
+	CONSTEXPR_CHECK(TestType::from_argb_string(hex_yellow_argb) == yellow);
 }
 
 TEMPLATE_LIST_TEST_CASE("basic_colour_t Other methods", "[basic_colour_t][basic_colour_t-other]", ColourTypes) {
-	const TestType blue = TestType::from_floats(0.2, 0.2, 1);
+	static constexpr TestType blue = TestType::from_floats(0.2, 0.2, 1);
 
-	CHECK(blue.with_red(255) == TestType::from_floats(1, 0.2, 1));
-	CHECK(blue.with_green(255) == TestType::from_floats(0.2, 1, 1));
-	CHECK(blue.with_blue(0) == TestType::from_floats(0.2, 0.2, 0));
+	CONSTEXPR_CHECK(blue.with_red(255) == TestType::from_floats(1, 0.2, 1));
+	CONSTEXPR_CHECK(blue.with_green(255) == TestType::from_floats(0.2, 1, 1));
+	CONSTEXPR_CHECK(blue.with_blue(0) == TestType::from_floats(0.2, 0.2, 0));
 }
 
 TEST_CASE("colour_rgb_t Constructor methods", "[basic_colour_t][colour_rgb_t][colour_rgb_t-constructor]") {
-	const colour_rgb_t blue_rgb = colour_rgb_t(
+	static constexpr colour_rgb_t blue_rgb = colour_rgb_t(
 		63.0 / 255 * 255, //
 		96.0 / 255 * 255, //
 		1.0 * 255
 	);
-	const colour_rgb_t blue_int = colour_rgb_t::from_integer(0x3F'60'FF);
-	const colour_rgb_t blue_rgba = colour_rgb_t::from_rgba(0x3F'60'FF'FF);
-	const colour_rgb_t blue_argb = colour_rgb_t::from_argb(0xFF'3F'60'FF);
-	const colour_rgb_t blue_udl = 0x3F'60'FF_rgb;
+	static constexpr colour_rgb_t blue_int = colour_rgb_t::from_integer(0x3F'60'FF);
+	static constexpr colour_rgb_t blue_rgba = colour_rgb_t::from_rgba(0x3F'60'FF'FF);
+	static constexpr colour_rgb_t blue_argb = colour_rgb_t::from_argb(0xFF'3F'60'FF);
+	static constexpr colour_rgb_t blue_udl = 0x3F'60'FF_rgb;
 
-	CHECK(blue_rgb == blue_int);
-	CHECK(blue_rgb == blue_rgba);
-	CHECK(blue_rgb == blue_argb);
-	CHECK(blue_rgb == blue_udl);
+	CONSTEXPR_CHECK(blue_rgb == blue_int);
+	CONSTEXPR_CHECK(blue_rgb == blue_rgba);
+	CONSTEXPR_CHECK(blue_rgb == blue_argb);
+	CONSTEXPR_CHECK(blue_rgb == blue_udl);
 
-	const colour_rgb_t fill = colour_rgb_t::fill_as(100);
+	static constexpr colour_rgb_t fill = colour_rgb_t::fill_as(100);
 
-	CHECK(fill == colour_rgb_t::from_floats(100.0 / 255, 100.0 / 255, 100.0 / 255));
+	CONSTEXPR_CHECK(fill == colour_rgb_t::from_floats(100.0 / 255, 100.0 / 255, 100.0 / 255));
 }
 
 TEST_CASE("colour_argb_t Constructor methods", "[basic_colour_t][colour_argb_t][colour_argb_t-constructor]") {
-	const colour_argb_t blue_rgb = colour_argb_t(
+	static constexpr colour_argb_t blue_rgb = colour_argb_t(
 		63.0 / 255 * 255, //
 		96.0 / 255 * 255, //
 		1.0 * 255
 	);
-	const colour_argb_t blue_int = colour_argb_t::from_integer(0x3F'60'FF'FF);
-	const colour_argb_t blue_rgba = colour_argb_t::from_rgba(0x3F'60'FF'FF);
-	const colour_argb_t blue_argb = colour_argb_t::from_argb(0xFF'3F'60'FF);
-	const colour_argb_t blue_rgb2 = colour_argb_t::from_rgb(0x3F'60'FF);
-	const colour_argb_t blue_udl = 0x3F'60'FF'FF_rgba;
-	const colour_argb_t blue_argb_udl = 0xFF'3F'60'FF_argb;
+	static constexpr colour_argb_t blue_int = colour_argb_t::from_integer(0x3F'60'FF'FF);
+	static constexpr colour_argb_t blue_rgba = colour_argb_t::from_rgba(0x3F'60'FF'FF);
+	static constexpr colour_argb_t blue_argb = colour_argb_t::from_argb(0xFF'3F'60'FF);
+	static constexpr colour_argb_t blue_rgb2 = colour_argb_t::from_rgb(0x3F'60'FF);
+	static constexpr colour_argb_t blue_udl = 0x3F'60'FF'FF_rgba;
+	static constexpr colour_argb_t blue_argb_udl = 0xFF'3F'60'FF_argb;
 
-	CHECK(blue_rgb == blue_int);
-	CHECK(blue_rgb == blue_rgba);
-	CHECK(blue_rgb == blue_argb);
-	CHECK(blue_rgb == blue_rgb2);
-	CHECK(blue_rgb == blue_udl);
-	CHECK(blue_rgb == blue_argb_udl);
+	CONSTEXPR_CHECK(blue_rgb == blue_int);
+	CONSTEXPR_CHECK(blue_rgb == blue_rgba);
+	CONSTEXPR_CHECK(blue_rgb == blue_argb);
+	CONSTEXPR_CHECK(blue_rgb == blue_rgb2);
+	CONSTEXPR_CHECK(blue_rgb == blue_udl);
+	CONSTEXPR_CHECK(blue_rgb == blue_argb_udl);
 
-	const colour_argb_t cyan_rgb = colour_argb_t::from_floats(0, 1, 1);
-	const colour_argb_t cyan_int = colour_argb_t::from_integer(0x00'FF'FF'FF);
-	const colour_argb_t cyan_rgba = colour_argb_t::from_rgba(0x00'FF'FF'FF);
-	const colour_argb_t cyan_argb = colour_argb_t::from_argb(0xFF'00'FF'FF);
-	const colour_argb_t cyan_rgb2 = colour_argb_t::from_rgb(0x00'FF'FF);
-	const colour_argb_t cyan_udl = 0x00'FF'FF'FF_rgba;
-	const colour_argb_t cyan_argb_udl = 0xFF'00'FF'FF_argb;
+	static constexpr colour_argb_t cyan_rgb = colour_argb_t::from_floats(0, 1, 1);
+	static constexpr colour_argb_t cyan_int = colour_argb_t::from_integer(0x00'FF'FF'FF);
+	static constexpr colour_argb_t cyan_rgba = colour_argb_t::from_rgba(0x00'FF'FF'FF);
+	static constexpr colour_argb_t cyan_argb = colour_argb_t::from_argb(0xFF'00'FF'FF);
+	static constexpr colour_argb_t cyan_rgb2 = colour_argb_t::from_rgb(0x00'FF'FF);
+	static constexpr colour_argb_t cyan_udl = 0x00'FF'FF'FF_rgba;
+	static constexpr colour_argb_t cyan_argb_udl = 0xFF'00'FF'FF_argb;
 
-	CHECK(cyan_rgb == cyan_int);
-	CHECK(cyan_rgb == cyan_rgba);
-	CHECK(cyan_rgb == cyan_argb);
-	CHECK(cyan_rgb == cyan_rgb2);
-	CHECK(cyan_rgb == cyan_udl);
-	CHECK(cyan_rgb == cyan_argb_udl);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_int);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_rgba);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_argb);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_rgb2);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_udl);
+	CONSTEXPR_CHECK(cyan_rgb == cyan_argb_udl);
 
-	const colour_argb_t fill = colour_argb_t::fill_as(100);
+	static constexpr colour_argb_t fill = colour_argb_t::fill_as(100);
 
-	CHECK(fill == colour_argb_t::from_floats(100.0 / 255, 100.0 / 255, 100.0 / 255, 100.0 / 255));
+	CONSTEXPR_CHECK(fill == colour_argb_t::from_floats(100.0 / 255, 100.0 / 255, 100.0 / 255, 100.0 / 255));
+}
+
+TEST_CASE("colour_rgb_t Operators", "[basic_colour_t][colour_rgb_t][colour_rgb_t-operators]") {
+	static constexpr colour_rgb_t blue = colour_rgb_t::from_floats(0.2, 0.2, 1);
+
+	CONSTEXPR_CHECK(static_cast<uint32_t>(blue) == blue.as_rgb());
+}
+
+TEST_CASE("colour_rgb_t alpha access", "[basic_colour_t][colour_rgb_t][colour_rgb_t-alpha-access]") {
+	static constexpr colour_rgb_t blue = colour_rgb_t::from_floats(0.2, 0.2, 1);
+
+	CONSTEXPR_CHECK(blue.alpha == 255);
 }
 
 TEST_CASE("colour_rgb_t Parse methods", "[basic_colour_t][colour_rgb_t][colour_rgb_t-parse]") {
 	static constexpr std::string_view yellow_rgb = "FFFF00"sv;
 	static constexpr std::string_view hex_yellow_rgb = "FFFF00"sv;
-	const colour_rgb_t yellow = colour_rgb_t::from_floats(1, 1, 0);
+	static constexpr colour_rgb_t yellow = colour_rgb_t::from_floats(1, 1, 0);
 
-	CHECK(colour_rgb_t::from_string(yellow_rgb) == yellow);
-	CHECK(colour_rgb_t::from_string(hex_yellow_rgb) == yellow);
+	CONSTEXPR_CHECK(colour_rgb_t::from_string(yellow_rgb) == yellow);
+	CONSTEXPR_CHECK(colour_rgb_t::from_string(hex_yellow_rgb) == yellow);
+}
+
+TEST_CASE("colour_argb_t Operators", "[basic_colour_t][colour_argb_t][colour_argb_t-operators]") {
+	static constexpr colour_argb_t blue = colour_argb_t::from_floats(0.2, 0.2, 1);
+	static constexpr colour_argb_t transparent = colour_argb_t::from_floats(0.2, 0.2, 1, 0);
+
+	CONSTEXPR_CHECK(static_cast<uint32_t>(blue) == blue.as_rgba());
+	CONSTEXPR_CHECK(blue[3] == 255);
+	CONSTEXPR_CHECK(transparent[0] == 51);
+	CONSTEXPR_CHECK(transparent[1] == 51);
+	CONSTEXPR_CHECK(transparent[2] == 255);
+	CONSTEXPR_CHECK(transparent[3] == 0);
 }
 
 TEST_CASE("colour_argb_t Parse methods", "[basic_colour_t][colour_argb_t][colour_argb_t-parse]") {
 	static constexpr std::string_view yellow_rgba = "FFFF00FF"sv;
 	static constexpr std::string_view hex_yellow_rgba = "0xFFFF00FF"sv;
-	const colour_argb_t yellow = colour_argb_t::from_floats(1, 1, 0);
+	static constexpr colour_argb_t yellow = colour_argb_t::from_floats(1, 1, 0);
 
-	CHECK(colour_argb_t::from_string(yellow_rgba) == yellow);
-	CHECK(colour_argb_t::from_string(hex_yellow_rgba) == yellow);
+	CONSTEXPR_CHECK(colour_argb_t::from_string(yellow_rgba) == yellow);
+	CONSTEXPR_CHECK(colour_argb_t::from_string(hex_yellow_rgba) == yellow);
 }
 
 TEST_CASE("colour_argb_t Other methods", "[basic_colour_t][colour_argb_t][colour_argb_t-other]") {
-	const colour_argb_t blue = colour_argb_t::from_floats(0.2, 0.2, 1);
+	static constexpr colour_argb_t blue = colour_argb_t::from_floats(0.2, 0.2, 1);
 
-	CHECK(blue.with_alpha(1) == colour_argb_t::from_floats(0.2, 0.2, 1, 1.0 / 255));
+	CONSTEXPR_CHECK(blue.with_alpha(1) == colour_argb_t::from_floats(0.2, 0.2, 1, 1.0 / 255));
 }

--- a/tests/src/types/Colour.hpp
+++ b/tests/src/types/Colour.hpp
@@ -9,9 +9,9 @@
 
 namespace snitch {
 	template<typename ValueT, typename ColourIntT, typename ColourTraits>
-	inline static bool append( //
+	[[nodiscard]] inline static constexpr bool append( //
 		snitch::small_string_span ss, OpenVic::basic_colour_t<ValueT, ColourIntT, ColourTraits> const& s
-	) {
+	) noexcept {
 		if constexpr (std::decay_t<decltype(s)>::colour_traits::has_alpha) {
 			return append(ss, "(", (int64_t)s.red, ",", (int64_t)s.green, ",", (int64_t)s.blue, ",", (int64_t)s.alpha, ")");
 		} else {

--- a/tests/src/types/Date.cpp
+++ b/tests/src/types/Date.cpp
@@ -6,12 +6,13 @@
 
 #include "Helper.hpp" // IWYU pragma: keep
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
 namespace snitch {
-	inline static bool append(snitch::small_string_span ss, OpenVic::Date const& s) {
-		return append(ss, s.to_string(true));
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::Date const& s) {
+		return append(ss, s.to_array(true, true, true));
 	}
 }
 
@@ -19,24 +20,24 @@ using namespace OpenVic;
 using namespace std::string_view_literals;
 
 TEST_CASE("Date Constructor method", "[Date][Date-constructor]") {
-	const Date empty = Date {};
-	const Date zero = Date { 0, 1, 1 };
-	const Date zero_timespan = Date { Timespan { 0 } };
+	static constexpr Date empty = Date {};
+	static constexpr Date zero = Date { 0, 1, 1 };
+	static constexpr Date zero_timespan = Date { Timespan { 0 } };
 
-	CHECK(empty == zero);
-	CHECK(empty == zero_timespan);
+	CONSTEXPR_CHECK(empty == zero);
+	CONSTEXPR_CHECK(empty == zero_timespan);
 
-	const Date _0_1_31 = Date { 0, 1, 31 };
-	const Date _timespan_0_1_31 = Date { Timespan { 30 } };
+	static constexpr Date _0_1_31 = Date { 0, 1, 31 };
+	static constexpr Date _timespan_0_1_31 = Date { Timespan { 30 } };
 
-	CHECK(_0_1_31 == _timespan_0_1_31);
+	CONSTEXPR_CHECK(_0_1_31 == _timespan_0_1_31);
 }
 
 TEST_CASE("Date Operators", "[Date][Date-operators]") {
-	const Date date1 = { 0, 5, 20 };
-	const Date date2 = { 40, 10, 5 };
+	static constexpr Date date1 = { 0, 5, 20 };
+	static constexpr Date date2 = { 40, 10, 5 };
 
-	CHECK((Date {} + (date2 - date1)) == Date { 40, 5, 19 });
+	CONSTEXPR_CHECK((Date {} + (date2 - date1)) == Date { 40, 5, 19 });
 
 	Date date_move = date1;
 	CHECK(date_move++ == Date { 0, 5, 20 });
@@ -46,49 +47,49 @@ TEST_CASE("Date Operators", "[Date][Date-operators]") {
 	CHECK((date_move += 5) == Date { 0, 5, 25 });
 	CHECK((date_move -= 5) == Date { 0, 5, 20 });
 
-	CHECK(date1 < date2);
-	CHECK(date2 > date1);
-	CHECK(date1 != date2);
+	CONSTEXPR_CHECK(date1 < date2);
+	CONSTEXPR_CHECK(date2 > date1);
+	CONSTEXPR_CHECK(date1 != date2);
 }
 
 TEST_CASE("Date Conversion methods", "[Date][Date-conversion]") {
-	const Date date = { 5, 4, 10 };
-	const Date date2 = { 5, 3, 2 };
+	static constexpr Date date = { 5, 4, 10 };
+	static constexpr Date date2 = { 5, 3, 2 };
 
-	CHECK(date.get_year() == 5);
-	CHECK(date.get_month() == 4);
-	CHECK(date.get_month_name() == "April"sv);
-	CHECK(date.get_day() == 10);
+	CONSTEXPR_CHECK(date.get_year() == 5);
+	CONSTEXPR_CHECK(date.get_month() == 4);
+	CONSTEXPR_CHECK(date.get_month_name() == "April"sv);
+	CONSTEXPR_CHECK(date.get_day() == 10);
 
-	CHECK(date.to_string() == "5.04.10");
-	CHECK(date.to_string(true) == "0005.04.10");
-	CHECK(date.to_string(false, false) == "5.4.10");
-	CHECK(date.to_string(true, false) == "0005.4.10");
+	CHECK(date.to_array() == "5.04.10"sv);
+	CHECK(date.to_array(true) == "0005.04.10"sv);
+	CHECK(date.to_array(false, false) == "5.4.10"sv);
+	CHECK(date.to_array(true, false) == "0005.4.10"sv);
 
-	CHECK(date2.to_string() == "5.03.02");
-	CHECK(date2.to_string(true) == "0005.03.02");
-	CHECK(date2.to_string(true, false, false) == "0005.3.2");
-	CHECK(date2.to_string(true, true, false) == "0005.03.2");
-	CHECK(date2.to_string(true, false, true) == "0005.3.02");
-	CHECK(date2.to_string(false, false, false) == "5.3.2");
-	CHECK(date2.to_string(false, false, true) == "5.3.02");
+	CHECK(date2.to_array() == "5.03.02"sv);
+	CHECK(date2.to_array(true) == "0005.03.02"sv);
+	CHECK(date2.to_array(true, false, false) == "0005.3.2"sv);
+	CHECK(date2.to_array(true, true, false) == "0005.03.2"sv);
+	CHECK(date2.to_array(true, false, true) == "0005.3.02"sv);
+	CHECK(date2.to_array(false, false, false) == "5.3.2"sv);
+	CHECK(date2.to_array(false, false, true) == "5.3.02"sv);
 }
 
 TEST_CASE("Date Parse methods", "[Date][Date-parse]") {
-	CHECK(Date::from_string("1.2.3") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("01.2.3") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("1.02.03") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("001.2.3") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("001.02.3") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("001.2.03") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("001.02.03") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("0001.02.3") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("0001.2.03") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("0001.02.03") == Date { 1, 2, 3 });
-	CHECK(Date::from_string("20.6.13") == Date { 20, 6, 13 });
-	CHECK(Date::from_string("0020.06.13") == Date { 20, 6, 13 });
-	CHECK(Date::from_string("1815.8.20") == Date { 1815, 8, 20 });
-	CHECK(Date::from_string("-1.1.1") == Date { -1, 1, 1 });
+	CONSTEXPR_CHECK(Date::from_string("1.2.3") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("01.2.3") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("1.02.03") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("001.2.3") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("001.02.3") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("001.2.03") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("001.02.03") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("0001.02.3") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("0001.2.03") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("0001.02.03") == Date { 1, 2, 3 });
+	CONSTEXPR_CHECK(Date::from_string("20.6.13") == Date { 20, 6, 13 });
+	CONSTEXPR_CHECK(Date::from_string("0020.06.13") == Date { 20, 6, 13 });
+	CONSTEXPR_CHECK(Date::from_string("1815.8.20") == Date { 1815, 8, 20 });
+	CONSTEXPR_CHECK(Date::from_string("-1.1.1") == Date { -1, 1, 1 });
 
 	Date::from_chars_result result;
 
@@ -199,13 +200,13 @@ TEST_CASE("Date Parse methods", "[Date][Date-parse]") {
 }
 
 TEST_CASE("Date Other methods", "[Date][Date-other]") {
-	const Date start = { 5, 3, 2 };
-	const Date end = { 5, 4, 10 };
-	const Date inside = { 5, 3, 5 };
-	const Date outside = { 10, 4, 2 };
+	static constexpr Date start = { 5, 3, 2 };
+	static constexpr Date end = { 5, 4, 10 };
+	static constexpr Date inside = { 5, 3, 5 };
+	static constexpr Date outside = { 10, 4, 2 };
 
-	CHECK(inside.in_range(start, end));
-	CHECK_FALSE(outside.in_range(start, end));
-	CHECK_FALSE(start.is_month_start());
-	CHECK(Date { 532, 6, 1 }.is_month_start());
+	CONSTEXPR_CHECK(inside.in_range(start, end));
+	CONSTEXPR_CHECK_FALSE(outside.in_range(start, end));
+	CONSTEXPR_CHECK_FALSE(start.is_month_start());
+	CONSTEXPR_CHECK(Date { 532, 6, 1 }.is_month_start());
 }

--- a/tests/src/types/FixedPoint.cpp
+++ b/tests/src/types/FixedPoint.cpp
@@ -10,6 +10,7 @@
 #include "Helper.hpp" // IWYU pragma: keep
 #include "Numeric.hpp" // IWYU pragma: keep
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
@@ -18,233 +19,241 @@ using namespace OpenVic::testing::approx_literal;
 using namespace std::string_view_literals;
 
 TEST_CASE("fixed_point_t Constructor methods", "[fixed_point_t][fixed_point_t-constructor]") {
-	const fixed_point_t empty = fixed_point_t();
-	const fixed_point_t zero = fixed_point_t(0);
-	const fixed_point_t constant_zero = fixed_point_t::_0();
-	const fixed_point_t one = 1;
-	const fixed_point_t constant_one = fixed_point_t::_1();
-	const fixed_point_t usable_max = 32768;
-	const fixed_point_t constant_usable_max = fixed_point_t::usable_max();
-	const fixed_point_t usable_min = -32768;
-	const fixed_point_t constant_usable_min = fixed_point_t::usable_min();
-	CHECK(empty == zero);
-	CHECK(empty == constant_zero);
-	CHECK(zero == constant_zero);
-	CHECK(one == constant_one);
-	CHECK(usable_max == constant_usable_max);
-	CHECK(usable_min == constant_usable_min);
+	static constexpr fixed_point_t empty = fixed_point_t();
+	static constexpr fixed_point_t zero = fixed_point_t(0);
+	static constexpr fixed_point_t constant_zero = fixed_point_t::_0();
+	static constexpr fixed_point_t one = 1;
+	static constexpr fixed_point_t constant_one = fixed_point_t::_1();
+	static constexpr fixed_point_t usable_max = 32768;
+	static constexpr fixed_point_t constant_usable_max = fixed_point_t::usable_max();
+	static constexpr fixed_point_t usable_min = -32768;
+	static constexpr fixed_point_t constant_usable_min = fixed_point_t::usable_min();
+	CONSTEXPR_CHECK(empty == zero);
+	CONSTEXPR_CHECK(empty == constant_zero);
+	CONSTEXPR_CHECK(zero == constant_zero);
+	CONSTEXPR_CHECK(one == constant_one);
+	CONSTEXPR_CHECK(usable_max == constant_usable_max);
+	CONSTEXPR_CHECK(usable_min == constant_usable_min);
 }
 
 TEST_CASE("fixed_point_t Linear algebra methods", "[fixed_point_t][fixed_point_t-linear-algebra]") {
-	const fixed_point_t one = 1;
-	const fixed_point_t two = 2;
-	const fixed_point_t three = 3;
-	CHECK(one.sin() == 0.8414306640625_a);
-	CHECK(two.sin() == 0.9093170166015625_a);
-	CHECK(three.sin() == 0.1412200927734375_a);
-	CHECK(one.cos() == 0.5403900146484375_a);
-	CHECK(two.cos() == -0.4160003662109375_a);
-	CHECK(three.cos() == -0.989959716796875_a);
+	static constexpr fixed_point_t one = 1;
+	static constexpr fixed_point_t two = 2;
+	static constexpr fixed_point_t three = 3;
+	CONSTEXPR_CHECK(one.sin() == 0.8414306640625_a);
+	CONSTEXPR_CHECK(two.sin() == 0.9093170166015625_a);
+	CONSTEXPR_CHECK(three.sin() == 0.1412200927734375_a);
+	CONSTEXPR_CHECK(one.cos() == 0.5403900146484375_a);
+	CONSTEXPR_CHECK(two.cos() == -0.4160003662109375_a);
+	CONSTEXPR_CHECK(three.cos() == -0.989959716796875_a);
 
-	CHECK(fixed_point_t::_0_50().sin() == 0.4793853759765625_a);
-	CHECK(fixed_point_t::_0_50().cos() == 0.87762451171875_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50().sin() == 0.4793853759765625_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50().cos() == 0.87762451171875_a);
 }
 
 TEST_CASE("fixed_point_t Constant methods", "[fixed_point_t][fixed_point_t-constants]") {
-	CHECK(fixed_point_t::max().get_raw_value() == std::numeric_limits<int64_t>::max());
-	CHECK(fixed_point_t::min().get_raw_value() == std::numeric_limits<int64_t>::min());
-	CHECK(fixed_point_t::usable_max() == 32768);
-	CHECK(fixed_point_t::usable_min() == -32768);
-	CHECK(fixed_point_t::epsilon() == 0.0000152587890625_a);
-	CHECK(fixed_point_t::_0() == 0);
-	CHECK(fixed_point_t::_1() == 1);
-	CHECK(fixed_point_t::_2() == 2);
-	CHECK(fixed_point_t::_4() == 4);
-	CHECK(fixed_point_t::_10() == 10);
-	CHECK(fixed_point_t::_100() == 100);
-	CHECK(fixed_point_t::_0_01() == 0.01_a);
-	CHECK(fixed_point_t::_0_10() == 0.1_a);
-	CHECK(fixed_point_t::_0_20() == 0.2_a);
-	CHECK(fixed_point_t::_0_25() == 0.25_a);
-	CHECK(fixed_point_t::_0_50() == 0.5_a);
-	CHECK(fixed_point_t::_1_50() == 1.5_a);
-	CHECK(fixed_point_t::minus_one() == -1);
-	CHECK(fixed_point_t::pi() == testing::approx(std::numbers::pi));
-	CHECK(fixed_point_t::pi2() == testing::approx(std::numbers::pi * 2));
-	CHECK(fixed_point_t::pi_quarter() == testing::approx(std::numbers::pi / 4));
-	CHECK(fixed_point_t::pi_half() == testing::approx(std::numbers::pi / 2));
-	CHECK(fixed_point_t::one_div_pi2() == testing::approx(1 / (std::numbers::pi * 2)));
-	CHECK(fixed_point_t::deg2rad() == 0.0174407958984375_a);
-	CHECK(fixed_point_t::rad2deg() == 57.2957763671875_a);
-	CHECK(fixed_point_t::e() == testing::approx(std::numbers::e));
+	CONSTEXPR_CHECK(fixed_point_t::max().get_raw_value() == std::numeric_limits<int64_t>::max());
+	CONSTEXPR_CHECK(fixed_point_t::min().get_raw_value() == std::numeric_limits<int64_t>::min());
+	CONSTEXPR_CHECK(fixed_point_t::usable_max() == 32768);
+	CONSTEXPR_CHECK(fixed_point_t::usable_min() == -32768);
+	CONSTEXPR_CHECK(fixed_point_t::epsilon() == 0.0000152587890625_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0() == 0);
+	CONSTEXPR_CHECK(fixed_point_t::_1() == 1);
+	CONSTEXPR_CHECK(fixed_point_t::_2() == 2);
+	CONSTEXPR_CHECK(fixed_point_t::_4() == 4);
+	CONSTEXPR_CHECK(fixed_point_t::_10() == 10);
+	CONSTEXPR_CHECK(fixed_point_t::_100() == 100);
+	CONSTEXPR_CHECK(fixed_point_t::_0_01() == 0.01_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_10() == 0.1_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_20() == 0.2_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_25() == 0.25_a);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50() == 0.5_a);
+	CONSTEXPR_CHECK(fixed_point_t::_1_50() == 1.5_a);
+	CONSTEXPR_CHECK(fixed_point_t::minus_one() == -1);
+	CONSTEXPR_CHECK(fixed_point_t::pi() == testing::approx(std::numbers::pi));
+	CONSTEXPR_CHECK(fixed_point_t::pi2() == testing::approx(std::numbers::pi * 2));
+	CONSTEXPR_CHECK(fixed_point_t::pi_quarter() == testing::approx(std::numbers::pi / 4));
+	CONSTEXPR_CHECK(fixed_point_t::pi_half() == testing::approx(std::numbers::pi / 2));
+	CONSTEXPR_CHECK(fixed_point_t::one_div_pi2() == testing::approx(1 / (std::numbers::pi * 2)));
+	CONSTEXPR_CHECK(fixed_point_t::deg2rad() == 0.0174407958984375_a);
+	CONSTEXPR_CHECK(fixed_point_t::rad2deg() == 57.2957763671875_a);
+	CONSTEXPR_CHECK(fixed_point_t::e() == testing::approx(std::numbers::e));
 }
 
 TEST_CASE("fixed_point_t Rounding methods", "[fixed_point_t][fixed_point_t-rounding]") {
-	const fixed_point_t neg_one = -1;
-	const fixed_point_t neg_two = -2;
-	const fixed_point_t neg_three = -3;
+	static constexpr fixed_point_t neg_one = -1;
+	static constexpr fixed_point_t neg_two = -2;
+	static constexpr fixed_point_t neg_three = -3;
 
-	const fixed_point_t _2_55 = fixed_point_t::_1_50() + fixed_point_t::_1() + fixed_point_t::_1() / 20;
-	const fixed_point_t neg_2_55 = -_2_55;
+	static constexpr fixed_point_t _2_55 = fixed_point_t::_1_50() + fixed_point_t::_1() + fixed_point_t::_1() / 20;
+	static constexpr fixed_point_t neg_2_55 = -_2_55;
 
-	CHECK(neg_one.abs() == 1);
-	CHECK(neg_two.abs() == 2);
-	CHECK(neg_three.abs() == 3);
-	CHECK(neg_2_55.abs() == 2.55_a);
+	CONSTEXPR_CHECK(neg_one.abs() == 1);
+	CONSTEXPR_CHECK(neg_two.abs() == 2);
+	CONSTEXPR_CHECK(neg_three.abs() == 3);
+	CONSTEXPR_CHECK(neg_2_55.abs() == 2.55_a);
 
-	CHECK(_2_55.floor() == 2);
-	CHECK(_2_55.ceil() == 3);
-	CHECK(_2_55.round_down_to_multiple(3) == 0);
-	CHECK(_2_55.round_up_to_multiple(5) == 5);
-	CHECK(_2_55.round_down_to_multiple(fixed_point_t::_0_25()) == 2.50_a);
-	CHECK(_2_55.round_up_to_multiple(fixed_point_t::_1_50()) == 3);
+	CONSTEXPR_CHECK(_2_55.floor() == 2);
+	CONSTEXPR_CHECK(_2_55.ceil() == 3);
+	CONSTEXPR_CHECK(_2_55.round_down_to_multiple(3) == 0);
+	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(5) == 5);
+	CONSTEXPR_CHECK(_2_55.round_down_to_multiple(fixed_point_t::_0_25()) == 2.50_a);
+	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(fixed_point_t::_1_50()) == 3);
 }
 
 TEST_CASE("fixed_point_t Parse methods", "[fixed_point_t][fixed_point_t-parse]") {
-	CHECK(fixed_point_t::parse(1) == 1);
-	CHECK(fixed_point_t::parse(2) == 2);
-	CHECK(fixed_point_t::parse(3) == 3);
-	CHECK(fixed_point_t::parse(4) == 4);
-	CHECK(fixed_point_t::parse(5) == 5);
-	CHECK(fixed_point_t::parse(6) == 6);
-	CHECK(fixed_point_t::parse(7) == 7);
-	CHECK(fixed_point_t::parse(8) == 8);
-	CHECK(fixed_point_t::parse(9) == 9);
-	CHECK(fixed_point_t::parse(10) == 10);
-	CHECK(fixed_point_t::parse_raw(10) == fixed_point_t::epsilon() * 10);
-	CHECK(fixed_point_t::parse(10) == 10);
+	CONSTEXPR_CHECK(fixed_point_t::parse(1) == 1);
+	CONSTEXPR_CHECK(fixed_point_t::parse(2) == 2);
+	CONSTEXPR_CHECK(fixed_point_t::parse(3) == 3);
+	CONSTEXPR_CHECK(fixed_point_t::parse(4) == 4);
+	CONSTEXPR_CHECK(fixed_point_t::parse(5) == 5);
+	CONSTEXPR_CHECK(fixed_point_t::parse(6) == 6);
+	CONSTEXPR_CHECK(fixed_point_t::parse(7) == 7);
+	CONSTEXPR_CHECK(fixed_point_t::parse(8) == 8);
+	CONSTEXPR_CHECK(fixed_point_t::parse(9) == 9);
+	CONSTEXPR_CHECK(fixed_point_t::parse(10) == 10);
+	CONSTEXPR_CHECK(fixed_point_t::parse_raw(10) == fixed_point_t::epsilon() * 10);
+	CONSTEXPR_CHECK(fixed_point_t::parse(10) == 10);
 
 	static constexpr std::string_view fixed_point_str = "4.5432"sv;
+	CONSTEXPR_CHECK(fixed_point_t::parse(fixed_point_str) == 4.5432_a);
 	bool fixed_point_str_success;
 	CHECK(fixed_point_t::parse(fixed_point_str, &fixed_point_str_success) == 4.5432_a);
 	CHECK(fixed_point_str_success);
 
 	static constexpr std::string_view neg_fixed_point_str = "-4.5432"sv;
+	CONSTEXPR_CHECK(fixed_point_t::parse(neg_fixed_point_str) == -4.5432_a);
 	CHECK(fixed_point_t::parse(neg_fixed_point_str, &fixed_point_str_success) == -4.5432_a);
 	CHECK(fixed_point_str_success);
 
 	static constexpr std::string_view plus_fixed_point_str = "+4.5432"sv;
+	CONSTEXPR_CHECK(fixed_point_t::parse(plus_fixed_point_str) == 4.5432_a);
 	CHECK(fixed_point_t::parse(plus_fixed_point_str, &fixed_point_str_success) == 4.5432_a);
 	CHECK(fixed_point_str_success);
 
 	fixed_point_t fp = fixed_point_t::_0();
-	CHECK(fp.from_chars(plus_fixed_point_str.data(), plus_fixed_point_str.data() + plus_fixed_point_str.size()).ec == std::errc::invalid_argument);
+	CHECK(
+		fp.from_chars(plus_fixed_point_str.data(), plus_fixed_point_str.data() + plus_fixed_point_str.size()).ec ==
+		std::errc::invalid_argument
+	);
 	CHECK(fp == 0.0_a);
-	CHECK(fp.from_chars_with_plus(plus_fixed_point_str.data(), plus_fixed_point_str.data() + plus_fixed_point_str.size()).ec == std::errc{});
+	CHECK(
+		fp.from_chars_with_plus(plus_fixed_point_str.data(), plus_fixed_point_str.data() + plus_fixed_point_str.size()).ec ==
+		std::errc {}
+	);
 	CHECK(fp == 4.5432_a);
 }
 
 TEST_CASE("fixed_point_t string methods", "[fixed_point_t][fixed_point_t-string]") {
-	const fixed_point_t constant_zero = fixed_point_t::_0();
-	const fixed_point_t one = 1;
-	const fixed_point_t constant_one = fixed_point_t::_1();
-	const fixed_point_t neg_one = -1;
-	const fixed_point_t neg_two = -2;
-	const fixed_point_t neg_three = -3;
-	const fixed_point_t _2_55 = fixed_point_t::_1_50() + fixed_point_t::_1() + fixed_point_t::_1() / 20;
-	const fixed_point_t neg_2_55 = -_2_55;
+	static constexpr fixed_point_t constant_zero = fixed_point_t::_0();
+	static constexpr fixed_point_t one = 1;
+	static constexpr fixed_point_t constant_one = fixed_point_t::_1();
+	static constexpr fixed_point_t neg_one = -1;
+	static constexpr fixed_point_t neg_two = -2;
+	static constexpr fixed_point_t neg_three = -3;
+	static constexpr fixed_point_t _2_55 = fixed_point_t::_1_50() + fixed_point_t::_1() + fixed_point_t::_1() / 20;
+	static constexpr fixed_point_t neg_2_55 = -_2_55;
 
-	CHECK(constant_zero.to_array() == "0"sv);
-	CHECK(one.to_array() == "1"sv);
-	CHECK(constant_one.to_array() == "1"sv);
-	CHECK(neg_one.to_array() == "-1"sv);
-	CHECK(neg_two.to_array() == "-2"sv);
-	CHECK(neg_three.to_array() == "-3"sv);
-	CHECK(_2_55.to_array() == "2.54998779296875"sv);
-	CHECK(neg_2_55.to_array() == "-2.54998779296875"sv);
-	CHECK(_2_55.to_array(2) == "2.55"sv);
-	CHECK(neg_2_55.to_array(2) == "-2.55"sv);
+	CONSTEXPR_CHECK(constant_zero.to_array() == "0"sv);
+	CONSTEXPR_CHECK(one.to_array() == "1"sv);
+	CONSTEXPR_CHECK(constant_one.to_array() == "1"sv);
+	CONSTEXPR_CHECK(neg_one.to_array() == "-1"sv);
+	CONSTEXPR_CHECK(neg_two.to_array() == "-2"sv);
+	CONSTEXPR_CHECK(neg_three.to_array() == "-3"sv);
+	CONSTEXPR_CHECK(_2_55.to_array() == "2.54998779296875"sv);
+	CONSTEXPR_CHECK(neg_2_55.to_array() == "-2.54998779296875"sv);
+	CONSTEXPR_CHECK(_2_55.to_array(2) == "2.55"sv);
+	CONSTEXPR_CHECK(neg_2_55.to_array(2) == "-2.55"sv);
 }
 
 TEST_CASE("fixed_point_t Other methods", "[fixed_point_t][fixed_point_t-other]") {
-	CHECK_FALSE(fixed_point_t::_1().is_negative());
-	CHECK(fixed_point_t::minus_one().is_negative());
-	CHECK(fixed_point_t::_1().is_integer());
-	CHECK(fixed_point_t::_2().is_integer());
-	CHECK(fixed_point_t::_4().is_integer());
-	CHECK_FALSE(fixed_point_t::_1_50().is_integer());
-	CHECK_FALSE(fixed_point_t::_0_50().is_integer());
-	CHECK_FALSE(fixed_point_t::_0_01().is_integer());
-	CHECK(fixed_point_t::_0_50().sqrt() == 0.7071075439453125_a);
-	CHECK((-fixed_point_t::_0_50()).sqrt() == 0);
+	CONSTEXPR_CHECK_FALSE(fixed_point_t::_1().is_negative());
+	CONSTEXPR_CHECK(fixed_point_t::minus_one().is_negative());
+	CONSTEXPR_CHECK(fixed_point_t::_1().is_integer());
+	CONSTEXPR_CHECK(fixed_point_t::_2().is_integer());
+	CONSTEXPR_CHECK(fixed_point_t::_4().is_integer());
+	CONSTEXPR_CHECK_FALSE(fixed_point_t::_1_50().is_integer());
+	CONSTEXPR_CHECK_FALSE(fixed_point_t::_0_50().is_integer());
+	CONSTEXPR_CHECK_FALSE(fixed_point_t::_0_01().is_integer());
+	CONSTEXPR_CHECK(fixed_point_t::_0_50().sqrt() == 0.7071075439453125_a);
+	CONSTEXPR_CHECK((-fixed_point_t::_0_50()).sqrt() == 0);
 }
 
 TEST_CASE("fixed_point_t Operators", "[fixed_point_t][fixed_point_t-operators]") {
-	const fixed_point_t decimal1 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
-	const fixed_point_t decimal2 = fixed_point_t::_0_20() * 6;
-	const fixed_point_t decimal3 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
-	const fixed_point_t decimal4 = fixed_point_t::_0_20() * 17;
+	static constexpr fixed_point_t decimal1 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t decimal2 = fixed_point_t::_0_20() * 6;
+	static constexpr fixed_point_t decimal3 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
+	static constexpr fixed_point_t decimal4 = fixed_point_t::_0_20() * 17;
 
-	const fixed_point_t power1 = fixed_point_t::_0_25() * 3;
-	const fixed_point_t power2 = fixed_point_t::_0_50();
-	const fixed_point_t power3 = fixed_point_t::_1_50();
-	const fixed_point_t power4 = fixed_point_t::_1() / 8;
+	static constexpr fixed_point_t power1 = fixed_point_t::_0_25() * 3;
+	static constexpr fixed_point_t power2 = fixed_point_t::_0_50();
+	static constexpr fixed_point_t power3 = fixed_point_t::_1_50();
+	static constexpr fixed_point_t power4 = fixed_point_t::_1() / 8;
 
-	const fixed_point_t int1 = 4;
-	const fixed_point_t int2 = 1;
-	const fixed_point_t int3 = 5;
-	const fixed_point_t int4 = 2;
+	static constexpr fixed_point_t int1 = 4;
+	static constexpr fixed_point_t int2 = 1;
+	static constexpr fixed_point_t int3 = 5;
+	static constexpr fixed_point_t int4 = 2;
 
-	CHECK(decimal1 + decimal2 == 3.5_a);
-	CHECK(decimal3 + decimal4 == 8.3_a);
-	CHECK(power1 + power2 == 1.25_a);
-	CHECK(power3 + power4 == 1.625_a);
-	CHECK(int1 + int2 == 5);
-	CHECK(int1 + int2 == 5.0);
-	CHECK(int3 + int4 == 7);
-	CHECK(int3 + int4 == 7.0);
+	CONSTEXPR_CHECK(decimal1 + decimal2 == 3.5_a);
+	CONSTEXPR_CHECK(decimal3 + decimal4 == 8.3_a);
+	CONSTEXPR_CHECK(power1 + power2 == 1.25_a);
+	CONSTEXPR_CHECK(power3 + power4 == 1.625_a);
+	CONSTEXPR_CHECK(int1 + int2 == 5);
+	CONSTEXPR_CHECK(int1 + int2 == 5.0);
+	CONSTEXPR_CHECK(int3 + int4 == 7);
+	CONSTEXPR_CHECK(int3 + int4 == 7.0);
 
-	CHECK(decimal1 - decimal2 == (1.1_a).epsilon(testing::INACCURATE_EPSILON));
-	CHECK(decimal3 - decimal4 == (1.5_a).epsilon(testing::INACCURATE_EPSILON));
-	CHECK(power1 - power2 == 0.25_a);
-	CHECK(power3 - power4 == 1.375_a);
-	CHECK(int1 - int2 == 3);
-	CHECK(int1 - int2 == 3.0);
-	CHECK(int4 - int3 == -3);
-	CHECK(int4 - int3 == -3.0);
+	CONSTEXPR_CHECK(decimal1 - decimal2 == (1.1_a).epsilon(testing::INACCURATE_EPSILON));
+	CONSTEXPR_CHECK(decimal3 - decimal4 == (1.5_a).epsilon(testing::INACCURATE_EPSILON));
+	CONSTEXPR_CHECK(power1 - power2 == 0.25_a);
+	CONSTEXPR_CHECK(power3 - power4 == 1.375_a);
+	CONSTEXPR_CHECK(int1 - int2 == 3);
+	CONSTEXPR_CHECK(int1 - int2 == 3.0);
+	CONSTEXPR_CHECK(int4 - int3 == -3);
+	CONSTEXPR_CHECK(int4 - int3 == -3.0);
 
-	CHECK(decimal1 * decimal2 == (2.76_a).epsilon(testing::INACCURATE_EPSILON));
-	CHECK(decimal3 * decimal4 == (16.66_a).epsilon(testing::INACCURATE_EPSILON));
-	CHECK(power1 * power2 == 0.375_a);
-	CHECK(power3 * power4 == 0.1875_a);
-	CHECK(int1 * int2 == 4);
-	CHECK(int3 * int4 == 10);
+	CONSTEXPR_CHECK(decimal1 * decimal2 == (2.76_a).epsilon(testing::INACCURATE_EPSILON));
+	CONSTEXPR_CHECK(decimal3 * decimal4 == (16.66_a).epsilon(testing::INACCURATE_EPSILON));
+	CONSTEXPR_CHECK(power1 * power2 == 0.375_a);
+	CONSTEXPR_CHECK(power3 * power4 == 0.1875_a);
+	CONSTEXPR_CHECK(int1 * int2 == 4);
+	CONSTEXPR_CHECK(int3 * int4 == 10);
 
-	CHECK(decimal1 / decimal2 == 1.91666666666666666_a);
-	CHECK(decimal3 / decimal4 == 1.44117647058823529_a);
-	CHECK(power1 / power2 == 1.5_a);
-	CHECK(power3 / power4 == 12);
-	CHECK(power3 / power4 == 12.0);
-	CHECK(int1 / int2 == 4);
-	CHECK(int1 / int2 == 4.0);
-	CHECK(int3 / int4 == 2.5_a);
+	CONSTEXPR_CHECK(decimal1 / decimal2 == 1.91666666666666666_a);
+	CONSTEXPR_CHECK(decimal3 / decimal4 == 1.44117647058823529_a);
+	CONSTEXPR_CHECK(power1 / power2 == 1.5_a);
+	CONSTEXPR_CHECK(power3 / power4 == 12);
+	CONSTEXPR_CHECK(power3 / power4 == 12.0);
+	CONSTEXPR_CHECK(int1 / int2 == 4);
+	CONSTEXPR_CHECK(int1 / int2 == 4.0);
+	CONSTEXPR_CHECK(int3 / int4 == 2.5_a);
 
-	CHECK(decimal1 * 2 == 4.6_a);
-	CHECK(decimal3 * 2 == 9.8_a);
-	CHECK(power1 * 2 == 1.5_a);
-	CHECK(power3 * 2 == 3);
-	CHECK(power3 * 2 == 3.0);
-	CHECK(int1 * 2 == 8);
-	CHECK(int1 * 2 == 8.0);
-	CHECK(int3 * 2 == 10);
-	CHECK(int3 * 2 == 10.0);
+	CONSTEXPR_CHECK(decimal1 * 2 == 4.6_a);
+	CONSTEXPR_CHECK(decimal3 * 2 == 9.8_a);
+	CONSTEXPR_CHECK(power1 * 2 == 1.5_a);
+	CONSTEXPR_CHECK(power3 * 2 == 3);
+	CONSTEXPR_CHECK(power3 * 2 == 3.0);
+	CONSTEXPR_CHECK(int1 * 2 == 8);
+	CONSTEXPR_CHECK(int1 * 2 == 8.0);
+	CONSTEXPR_CHECK(int3 * 2 == 10);
+	CONSTEXPR_CHECK(int3 * 2 == 10.0);
 
-	CHECK(decimal1 / 2 == 1.15_a);
-	CHECK(decimal3 / 2 == 2.45_a);
-	CHECK(power1 / 2 == 0.375_a);
-	CHECK(power3 / 2 == 0.75_a);
-	CHECK(int1 / 2 == 2);
-	CHECK(int1 / 2 == 2.0);
-	CHECK(int3 / 2 == 2.5_a);
+	CONSTEXPR_CHECK(decimal1 / 2 == 1.15_a);
+	CONSTEXPR_CHECK(decimal3 / 2 == 2.45_a);
+	CONSTEXPR_CHECK(power1 / 2 == 0.375_a);
+	CONSTEXPR_CHECK(power3 / 2 == 0.75_a);
+	CONSTEXPR_CHECK(int1 / 2 == 2);
+	CONSTEXPR_CHECK(int1 / 2 == 2.0);
+	CONSTEXPR_CHECK(int3 / 2 == 2.5_a);
 
-	CHECK(((int32_t)decimal1) == 2);
-	CHECK(((int32_t)decimal2) == 1);
-	CHECK(((int32_t)decimal3) == 4);
-	CHECK(((int32_t)decimal4) == 3);
+	CONSTEXPR_CHECK(((int32_t)decimal1) == 2);
+	CONSTEXPR_CHECK(((int32_t)decimal2) == 1);
+	CONSTEXPR_CHECK(((int32_t)decimal3) == 4);
+	CONSTEXPR_CHECK(((int32_t)decimal4) == 3);
 
-	CHECK(fixed_point_t::mul_div(
-		fixed_point_t::parse_raw(2),
-		fixed_point_t::parse_raw(3),
-		fixed_point_t::parse_raw(6)
-	) == fixed_point_t::parse_raw(1));
+	CONSTEXPR_CHECK(
+		fixed_point_t::mul_div(fixed_point_t::parse_raw(2), fixed_point_t::parse_raw(3), fixed_point_t::parse_raw(6)) ==
+		fixed_point_t::parse_raw(1)
+	);
 }

--- a/tests/src/types/Numeric.hpp
+++ b/tests/src/types/Numeric.hpp
@@ -21,7 +21,7 @@ namespace OpenVic::testing {
 }
 
 namespace snitch {
-	inline static bool append(snitch::small_string_span ss, OpenVic::fixed_point_t const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::fixed_point_t const& s) {
 		return append(ss, s.to_double());
 	}
 }

--- a/tests/src/types/Timespan.cpp
+++ b/tests/src/types/Timespan.cpp
@@ -6,11 +6,12 @@
 
 #include "Helper.hpp" // IWYU pragma: keep
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
 namespace snitch {
-	inline static bool append(snitch::small_string_span ss, OpenVic::Timespan const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::Timespan const& s) {
 		return append(ss, s.to_int());
 	}
 }
@@ -19,32 +20,32 @@ using namespace OpenVic;
 using namespace std::string_view_literals;
 
 TEST_CASE("Timespan Constructor method", "[Timespan][Timespan-constructor]") {
-	const Timespan empty = Timespan {};
-	const Timespan zero = Timespan { 0 };
+	static constexpr Timespan empty = Timespan {};
+	static constexpr Timespan zero = Timespan { 0 };
 
-	CHECK(empty == zero);
+	CONSTEXPR_CHECK(empty == zero);
 
-	const Timespan _30 = Timespan { 30 };
+	static constexpr Timespan _30 = Timespan { 30 };
 
-	CHECK(_30 == 30);
+	CONSTEXPR_CHECK(_30 == 30);
 
-	const Timespan _days = Timespan::from_days(5);
-	const Timespan _months = Timespan::from_months(20);
-	const Timespan _years = Timespan::from_years(4);
+	static constexpr Timespan _days = Timespan::from_days(5);
+	static constexpr Timespan _months = Timespan::from_months(20);
+	static constexpr Timespan _years = Timespan::from_years(4);
 
-	CHECK(_days == 5);
-	CHECK(_months == 608);
-	CHECK(_years == 365 * 4);
+	CONSTEXPR_CHECK(_days == 5);
+	CONSTEXPR_CHECK(_months == 608);
+	CONSTEXPR_CHECK(_years == 365 * 4);
 }
 
 TEST_CASE("Timespan Operators", "[Timespan][Timespan-operators]") {
-	const Timespan timespan1 = { 20 };
-	const Timespan timespan2 = { 35 };
+	static constexpr Timespan timespan1 = { 20 };
+	static constexpr Timespan timespan2 = { 35 };
 
-	CHECK((timespan1 + timespan2) == Timespan { 55 });
-	CHECK((timespan2 - timespan1) == Timespan { 15 });
-	CHECK((timespan1 * 3) == Timespan { 60 });
-	CHECK((timespan1 / 5) == Timespan { 4 });
+	CONSTEXPR_CHECK((timespan1 + timespan2) == Timespan { 55 });
+	CONSTEXPR_CHECK((timespan2 - timespan1) == Timespan { 15 });
+	CONSTEXPR_CHECK((timespan1 * 3) == Timespan { 60 });
+	CONSTEXPR_CHECK((timespan1 / 5) == Timespan { 4 });
 
 	Timespan Timespan_move = timespan1;
 	CHECK(Timespan_move++ == Timespan { 20 });
@@ -54,14 +55,14 @@ TEST_CASE("Timespan Operators", "[Timespan][Timespan-operators]") {
 	CHECK((Timespan_move += 5) == Timespan { 25 });
 	CHECK((Timespan_move -= 5) == Timespan { 20 });
 
-	CHECK(timespan1 < timespan2);
-	CHECK(timespan2 > timespan1);
-	CHECK(timespan1 != timespan2);
+	CONSTEXPR_CHECK(timespan1 < timespan2);
+	CONSTEXPR_CHECK(timespan2 > timespan1);
+	CONSTEXPR_CHECK(timespan1 != timespan2);
 }
 
 TEST_CASE("Timespan Conversion methods", "[Timespan][Timespan-conversion]") {
-	const Timespan timespan1 = 10;
+	static constexpr Timespan timespan1 = 10;
 
-	CHECK(timespan1.to_int() == 10);
+	CONSTEXPR_CHECK(timespan1.to_int() == 10);
 	CHECK(timespan1.to_string() == "10"sv);
 }

--- a/tests/src/types/Vector.hpp
+++ b/tests/src/types/Vector.hpp
@@ -64,17 +64,17 @@ namespace OpenVic::testing {
 
 namespace snitch {
 	template<typename T>
-	inline static bool append(snitch::small_string_span ss, OpenVic::vec2_t<T> const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::vec2_t<T> const& s) {
 		return append(ss, "(", s.x, ",", s.y, ")");
 	}
 
 	template<typename T>
-	inline static bool append(snitch::small_string_span ss, OpenVic::vec3_t<T> const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::vec3_t<T> const& s) {
 		return append(ss, "(", s.x, ",", s.y, ",", s.z, ")");
 	}
 
 	template<typename T>
-	inline static bool append(snitch::small_string_span ss, OpenVic::vec4_t<T> const& s) {
+	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::vec4_t<T> const& s) {
 		return append(ss, "(", s.x, ",", s.y, ",", s.z, ",", s.w, ")");
 	}
 }

--- a/tests/src/types/Vector2.cpp
+++ b/tests/src/types/Vector2.cpp
@@ -9,6 +9,7 @@
 #include "Numeric.hpp"
 #include "Vector.hpp"
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
@@ -18,155 +19,155 @@ using namespace OpenVic::testing::approx_literal;
 using VectorValueTypes = snitch::type_list<int32_t, OpenVic::fixed_point_t, double>;
 
 TEMPLATE_LIST_TEST_CASE("vec2_t Constructor methods", "[vec2_t][vec2_t-constructor]", VectorValueTypes) {
-	const vec2_t<TestType> vector_empty = vec2_t<TestType>();
-	const vec2_t<TestType> vector_zero = vec2_t<TestType>(0, 0);
-	CHECK(vector_empty == vector_zero);
+	static constexpr vec2_t<TestType> vector_empty = vec2_t<TestType>();
+	static constexpr vec2_t<TestType> vector_zero = vec2_t<TestType>(0, 0);
+	CONSTEXPR_CHECK(vector_empty == vector_zero);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec2_t Length methods", "[vec2_t][vec2_t-length]", VectorValueTypes) {
-	const vec2_t<TestType> vector1 = vec2_t<TestType>(10, 10);
-	const vec2_t<TestType> vector2 = vec2_t<TestType>(20, 30);
-	CHECK(vector1.length_squared() == 200);
-	CHECK(vector2.length_squared() == 1300);
-	CHECK(vector1.distance_squared(vector2) == 500);
+	static constexpr vec2_t<TestType> vector1 = vec2_t<TestType>(10, 10);
+	static constexpr vec2_t<TestType> vector2 = vec2_t<TestType>(20, 30);
+	CONSTEXPR_CHECK(vector1.length_squared() == 200);
+	CONSTEXPR_CHECK(vector2.length_squared() == 1300);
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2) == 500);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec2_t Operators", "[vec2_t][vec2_t-operators]", VectorValueTypes) {
-	const vec2_t<TestType> int1 = vec2_t<TestType>(4, 10);
-	const vec2_t<TestType> int2 = vec2_t<TestType>(2, 5);
+	static constexpr vec2_t<TestType> int1 = vec2_t<TestType>(4, 10);
+	static constexpr vec2_t<TestType> int2 = vec2_t<TestType>(2, 5);
 
-	CHECK((int1 + int2) == vec2_t<TestType>(6, 15));
-	CHECK((int1 - int2) == vec2_t<TestType>(2, 5));
-	CHECK((int1 * int2) == vec2_t<TestType>(8, 50));
-	CHECK((int1 / int2) == vec2_t<TestType>(2, 2));
+	CONSTEXPR_CHECK((int1 + int2) == vec2_t<TestType>(6, 15));
+	CONSTEXPR_CHECK((int1 - int2) == vec2_t<TestType>(2, 5));
+	CONSTEXPR_CHECK((int1 * int2) == vec2_t<TestType>(8, 50));
+	CONSTEXPR_CHECK((int1 / int2) == vec2_t<TestType>(2, 2));
 
-	CHECK((int1 * 2) == vec2_t<TestType>(8, 20));
-	CHECK((int1 / 2) == vec2_t<TestType>(2, 5));
+	CONSTEXPR_CHECK((int1 * 2) == vec2_t<TestType>(8, 20));
+	CONSTEXPR_CHECK((int1 / 2) == vec2_t<TestType>(2, 5));
 
-	CHECK(vec2_t<TestType>(ivec2_t(1, 2)) == vec2_t<TestType>(1, 2));
+	CONSTEXPR_CHECK(vec2_t<TestType>(ivec2_t(1, 2)) == vec2_t<TestType>(1, 2));
 
-	CHECK(int1 > int2);
+	CONSTEXPR_CHECK(int1 > int2);
 	CHECK_FALSE(int1 == int2);
-	CHECK(int1 != int2);
-	CHECK(int2 < int1);
+	CONSTEXPR_CHECK(int1 != int2);
+	CONSTEXPR_CHECK(int2 < int1);
 
-	CHECK_FALSE(vec2_t<TestType>{ 421, 2160 }.is_within_bound(vec2_t<TestType>{ 5616, 2160 }));
+	CHECK_FALSE(vec2_t<TestType> { 421, 2160 }.is_within_bound(vec2_t<TestType> { 5616, 2160 }));
 }
 
 TEMPLATE_LIST_TEST_CASE("vec2_t Rounding methods", "[vec2_t][vec2_t-rounding]", VectorValueTypes) {
-	const vec2_t<TestType> vector1 = vec2_t<TestType>(1, 5);
-	const vec2_t<TestType> vector2 = vec2_t<TestType>(1, -5);
-	CHECK(vector1.abs() == vector1);
-	CHECK(vector2.abs() == vector1);
+	static constexpr vec2_t<TestType> vector1 = vec2_t<TestType>(1, 5);
+	static constexpr vec2_t<TestType> vector2 = vec2_t<TestType>(1, -5);
+	CONSTEXPR_CHECK(vector1.abs() == vector1);
+	CONSTEXPR_CHECK(vector2.abs() == vector1);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec2_t Linear algebra methods", "[vec2_t][vec2_t-linear-algebra]", VectorValueTypes) {
-	const vec2_t<TestType> vector_x = vec2_t<TestType>(1, 0);
-	const vec2_t<TestType> vector_y = vec2_t<TestType>(0, 1);
-	const vec2_t<TestType> a = vec2_t<TestType>(3, 8);
-	const vec2_t<TestType> b = vec2_t<TestType>(5, 4);
-	CHECK(vector_x.dot(vector_y) == 0);
-	CHECK(vector_x.dot(vector_x) == 1);
-	CHECK((vector_x * 10).dot(vector_x * 10) == 100);
-	CHECK(a.dot(b) == 47);
-	CHECK(vec2_t<TestType>(-a.x, a.y).dot(vec2_t<TestType>(b.x, -b.y)) == -47);
+	static constexpr vec2_t<TestType> vector_x = vec2_t<TestType>(1, 0);
+	static constexpr vec2_t<TestType> vector_y = vec2_t<TestType>(0, 1);
+	static constexpr vec2_t<TestType> a = vec2_t<TestType>(3, 8);
+	static constexpr vec2_t<TestType> b = vec2_t<TestType>(5, 4);
+	CONSTEXPR_CHECK(vector_x.dot(vector_y) == 0);
+	CONSTEXPR_CHECK(vector_x.dot(vector_x) == 1);
+	CONSTEXPR_CHECK((vector_x * 10).dot(vector_x * 10) == 100);
+	CONSTEXPR_CHECK(a.dot(b) == 47);
+	CONSTEXPR_CHECK(vec2_t<TestType>(-a.x, a.y).dot(vec2_t<TestType>(b.x, -b.y)) == -47);
 }
 
 TEST_CASE("fvec2_t Length methods", "[vec2_t][fvec2_t][fvec2_t-length]") {
-	const fvec2_t vector1 = fvec2_t(10, 10);
-	const fvec2_t vector2 = fvec2_t(20, 30);
-	CHECK(vector1.length_squared().sqrt() == testing::approx(testing::SQRT2 * 10));
-	CHECK(vector2.length_squared().sqrt() == testing::approx(36.05551275463989293119));
-	CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(22.36067977499789696409));
+	static constexpr fvec2_t vector1 = fvec2_t(10, 10);
+	static constexpr fvec2_t vector2 = fvec2_t(20, 30);
+	CONSTEXPR_CHECK(vector1.length_squared().sqrt() == testing::approx(testing::SQRT2 * 10));
+	CONSTEXPR_CHECK(vector2.length_squared().sqrt() == testing::approx(36.05551275463989293119));
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(22.36067977499789696409));
 }
 
 TEST_CASE("dvec2_t Length methods", "[vec2_t][dvec2_t][dvec2_t-length]") {
-	const dvec2_t vector1 = dvec2_t(10, 10);
-	const dvec2_t vector2 = dvec2_t(20, 30);
+	static constexpr dvec2_t vector1 = dvec2_t(10, 10);
+	static constexpr dvec2_t vector2 = dvec2_t(20, 30);
 	CHECK(std::sqrt(vector1.length_squared()) == testing::approx(testing::SQRT2 * 10));
 	CHECK(std::sqrt(vector2.length_squared()) == testing::approx(36.05551275463989293119));
 	CHECK(std::sqrt(vector1.distance_squared(vector2)) == testing::approx(22.36067977499789696409));
 }
 
 TEST_CASE("fvec2_t Operators", "[vec2_t][fvec2_t][fvec2_t-operators]") {
-	const fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
-	const fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
-	const fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
-	const fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
-	const fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
-	const fixed_point_t _0_125 = fixed_point_t::_1() / 8;
+	static constexpr fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
+	static constexpr fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
+	static constexpr fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
+	static constexpr fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
+	static constexpr fixed_point_t _0_125 = fixed_point_t::_1() / 8;
 
-	const fvec2_t decimal1 = { _2_30, _4_90 };
-	const fvec2_t decimal2 = { _1_20, _3_40 };
-	const fvec2_t power1 = { _0_75, fixed_point_t::_1_50() };
-	const fvec2_t power2 = { fixed_point_t::_0_50(), _0_125 };
-	const fvec2_t int1 = fvec2_t(4, 5);
-	const fvec2_t int2 = fvec2_t(1, 2);
+	static constexpr fvec2_t decimal1 = { _2_30, _4_90 };
+	static constexpr fvec2_t decimal2 = { _1_20, _3_40 };
+	static constexpr fvec2_t power1 = { _0_75, fixed_point_t::_1_50() };
+	static constexpr fvec2_t power2 = { fixed_point_t::_0_50(), _0_125 };
+	static constexpr fvec2_t int1 = fvec2_t(4, 5);
+	static constexpr fvec2_t int2 = fvec2_t(1, 2);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec2 { 3.5, 8.3 });
-	CHECK(power1 + power2 == testing::approx_vec2 { 1.25, 1.625 });
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec2 { 3.5, 8.3 });
+	CONSTEXPR_CHECK(power1 + power2 == testing::approx_vec2 { 1.25, 1.625 });
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 - decimal2 ==
 		testing::approx_vec2 {
 			(1.1_a).epsilon(testing::INACCURATE_EPSILON), //
 			(1.5_a).epsilon(testing::INACCURATE_EPSILON) //
 		}
 	);
-	CHECK(power1 - power2 == testing::approx_vec2 { 0.25, 1.375 });
+	CONSTEXPR_CHECK(power1 - power2 == testing::approx_vec2 { 0.25, 1.375 });
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 * decimal2 ==
 		testing::approx_vec2 {
 			(2.76_a).epsilon(testing::INACCURATE_EPSILON), //
 			(16.66_a).epsilon(testing::INACCURATE_EPSILON) //
 		}
 	);
-	CHECK(power1 * power2 == testing::approx_vec2 { 0.375, 0.1875 });
+	CONSTEXPR_CHECK(power1 * power2 == testing::approx_vec2 { 0.375, 0.1875 });
 
-	CHECK(decimal1 / decimal2 == testing::approx_vec2 { 1.91666666666666666, 1.44117647058823529 });
-	CHECK(power1 / power2 == testing::approx_vec2 { 1.5, 12 });
-	CHECK(int1 / int2 == testing::approx_vec2 { 4, 2.5 });
+	CONSTEXPR_CHECK(decimal1 / decimal2 == testing::approx_vec2 { 1.91666666666666666, 1.44117647058823529 });
+	CONSTEXPR_CHECK(power1 / power2 == testing::approx_vec2 { 1.5, 12 });
+	CONSTEXPR_CHECK(int1 / int2 == testing::approx_vec2 { 4, 2.5 });
 
-	CHECK(decimal1 * 2 == testing::approx_vec2 { 4.6, 9.8 });
-	CHECK(power1 * 2 == testing::approx_vec2 { 1.5, 3 });
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec2 { 4.6, 9.8 });
+	CONSTEXPR_CHECK(power1 * 2 == testing::approx_vec2 { 1.5, 3 });
 
-	CHECK(decimal1 / 2 == testing::approx_vec2 { 1.15, 2.45 });
-	CHECK(power1 / 2 == testing::approx_vec2 { 0.375, 0.75 });
-	CHECK(int1 / 2 == testing::approx_vec2 { 2, 2.5 });
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec2 { 1.15, 2.45 });
+	CONSTEXPR_CHECK(power1 / 2 == testing::approx_vec2 { 0.375, 0.75 });
+	CONSTEXPR_CHECK(int1 / 2 == testing::approx_vec2 { 2, 2.5 });
 
-	CHECK(((ivec2_t)decimal1) == ivec2_t(2, 4));
-	CHECK(((ivec2_t)decimal2) == ivec2_t(1, 3));
+	CONSTEXPR_CHECK(((ivec2_t)decimal1) == ivec2_t(2, 4));
+	CONSTEXPR_CHECK(((ivec2_t)decimal2) == ivec2_t(1, 3));
 }
 
 TEST_CASE("dvec2_t Operators", "[vec2_t][dvec2_t][dvec2_t-operators]") {
-	const dvec2_t decimal1 = { 2.3, 4.9 };
-	const dvec2_t decimal2 = { 1.2, 3.4 };
-	const dvec2_t power1 = { 0.75, 1.5 };
-	const dvec2_t power2 = { 0.5, 0.125 };
-	const dvec2_t int1 = dvec2_t(4, 5);
-	const dvec2_t int2 = dvec2_t(1, 2);
+	static constexpr dvec2_t decimal1 = { 2.3, 4.9 };
+	static constexpr dvec2_t decimal2 = { 1.2, 3.4 };
+	static constexpr dvec2_t power1 = { 0.75, 1.5 };
+	static constexpr dvec2_t power2 = { 0.5, 0.125 };
+	static constexpr dvec2_t int1 = dvec2_t(4, 5);
+	static constexpr dvec2_t int2 = dvec2_t(1, 2);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec2 { 3.5, 8.3 });
-	CHECK(power1 + power2 == testing::approx_vec2 { 1.25, 1.625 });
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec2 { 3.5, 8.3 });
+	CONSTEXPR_CHECK(power1 + power2 == testing::approx_vec2 { 1.25, 1.625 });
 
-	CHECK(decimal1 - decimal2 == testing::approx_vec2 { 1.1, 1.5 });
-	CHECK(power1 - power2 == testing::approx_vec2 { 0.25, 1.375 });
+	CONSTEXPR_CHECK(decimal1 - decimal2 == testing::approx_vec2 { 1.1, 1.5 });
+	CONSTEXPR_CHECK(power1 - power2 == testing::approx_vec2 { 0.25, 1.375 });
 
-	CHECK(decimal1 * decimal2 == testing::approx_vec2 { 2.76, 16.66 });
-	CHECK(power1 * power2 == testing::approx_vec2 { 0.375, 0.1875 });
+	CONSTEXPR_CHECK(decimal1 * decimal2 == testing::approx_vec2 { 2.76, 16.66 });
+	CONSTEXPR_CHECK(power1 * power2 == testing::approx_vec2 { 0.375, 0.1875 });
 
-	CHECK(decimal1 / decimal2 == testing::approx_vec2 { 1.91666666666666666, 1.44117647058823529 });
-	CHECK(power1 / power2 == testing::approx_vec2 { 1.5, 12 });
-	CHECK(int1 / int2 == testing::approx_vec2 { 4, 2.5 });
+	CONSTEXPR_CHECK(decimal1 / decimal2 == testing::approx_vec2 { 1.91666666666666666, 1.44117647058823529 });
+	CONSTEXPR_CHECK(power1 / power2 == testing::approx_vec2 { 1.5, 12 });
+	CONSTEXPR_CHECK(int1 / int2 == testing::approx_vec2 { 4, 2.5 });
 
-	CHECK(decimal1 * 2 == testing::approx_vec2 { 4.6, 9.8 });
-	CHECK(power1 * 2 == testing::approx_vec2 { 1.5, 3 });
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec2 { 4.6, 9.8 });
+	CONSTEXPR_CHECK(power1 * 2 == testing::approx_vec2 { 1.5, 3 });
 
-	CHECK(decimal1 / 2 == testing::approx_vec2 { 1.15, 2.45 });
-	CHECK(power1 / 2 == testing::approx_vec2 { 0.375, 0.75 });
-	CHECK(int1 / 2 == testing::approx_vec2 { 2, 2.5 });
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec2 { 1.15, 2.45 });
+	CONSTEXPR_CHECK(power1 / 2 == testing::approx_vec2 { 0.375, 0.75 });
+	CONSTEXPR_CHECK(int1 / 2 == testing::approx_vec2 { 2, 2.5 });
 
-	CHECK(((ivec2_t)decimal1) == ivec2_t(2, 4));
-	CHECK(((ivec2_t)decimal2) == ivec2_t(1, 3));
+	CONSTEXPR_CHECK(((ivec2_t)decimal1) == ivec2_t(2, 4));
+	CONSTEXPR_CHECK(((ivec2_t)decimal2) == ivec2_t(1, 3));
 }

--- a/tests/src/types/Vector3.cpp
+++ b/tests/src/types/Vector3.cpp
@@ -9,6 +9,7 @@
 #include "Numeric.hpp"
 #include "Vector.hpp"
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
@@ -18,90 +19,90 @@ using namespace OpenVic::testing::approx_literal;
 using VectorValueTypes = snitch::type_list<int32_t, OpenVic::fixed_point_t, double>;
 
 TEMPLATE_LIST_TEST_CASE("vec3_t Constructor methods", "[vec3_t][vec3_t-constructor]", VectorValueTypes) {
-	const vec3_t<TestType> vector_empty = vec3_t<TestType>();
-	const vec3_t<TestType> vector_zero = vec3_t<TestType>(0, 0, 0);
-	CHECK(vector_empty == vector_zero);
+	static constexpr vec3_t<TestType> vector_empty = vec3_t<TestType>();
+	static constexpr vec3_t<TestType> vector_zero = vec3_t<TestType>(0, 0, 0);
+	CONSTEXPR_CHECK(vector_empty == vector_zero);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec3_t Length methods", "[vec3_t][vec3_t-length]", VectorValueTypes) {
-	const vec3_t<TestType> vector1 = vec3_t<TestType>(10, 10, 10);
-	const vec3_t<TestType> vector2 = vec3_t<TestType>(20, 30, 40);
-	CHECK(vector1.length_squared() == 300);
-	CHECK(vector2.length_squared() == 2900);
-	CHECK(vector1.distance_squared(vector2) == 1400);
+	static constexpr vec3_t<TestType> vector1 = vec3_t<TestType>(10, 10, 10);
+	static constexpr vec3_t<TestType> vector2 = vec3_t<TestType>(20, 30, 40);
+	CONSTEXPR_CHECK(vector1.length_squared() == 300);
+	CONSTEXPR_CHECK(vector2.length_squared() == 2900);
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2) == 1400);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec3_t Operators", "[vec3_t][vec3_t-operators]", VectorValueTypes) {
-	const vec3_t<TestType> int1 = vec3_t<TestType>(4, 5, 9);
-	const vec3_t<TestType> int2 = vec3_t<TestType>(1, 2, 3);
+	static constexpr vec3_t<TestType> int1 = vec3_t<TestType>(4, 5, 9);
+	static constexpr vec3_t<TestType> int2 = vec3_t<TestType>(1, 2, 3);
 
-	CHECK((int1 + int2) == vec3_t<TestType>(5, 7, 12));
-	CHECK((int1 - int2) == vec3_t<TestType>(3, 3, 6));
-	CHECK((int1 * int2) == vec3_t<TestType>(4, 10, 27));
-	CHECK((int1 * 2) == vec3_t<TestType>(8, 10, 18));
-	CHECK(vec3_t<TestType>(ivec3_t(1, 2, 3)) == vec3_t<TestType>(1, 2, 3));
+	CONSTEXPR_CHECK((int1 + int2) == vec3_t<TestType>(5, 7, 12));
+	CONSTEXPR_CHECK((int1 - int2) == vec3_t<TestType>(3, 3, 6));
+	CONSTEXPR_CHECK((int1 * int2) == vec3_t<TestType>(4, 10, 27));
+	CONSTEXPR_CHECK((int1 * 2) == vec3_t<TestType>(8, 10, 18));
+	CONSTEXPR_CHECK(vec3_t<TestType>(ivec3_t(1, 2, 3)) == vec3_t<TestType>(1, 2, 3));
 }
 
 TEMPLATE_LIST_TEST_CASE("vec3_t Rounding methods", "[vec3_t][vec3_t-rounding]", VectorValueTypes) {
-	const vec3_t<TestType> vector1 = vec3_t<TestType>(1, 3, 5);
-	const vec3_t<TestType> vector2 = vec3_t<TestType>(1, -3, -5);
-	CHECK(vector1.abs() == vector1);
-	CHECK(vector2.abs() == vector1);
+	static constexpr vec3_t<TestType> vector1 = vec3_t<TestType>(1, 3, 5);
+	static constexpr vec3_t<TestType> vector2 = vec3_t<TestType>(1, -3, -5);
+	CONSTEXPR_CHECK(vector1.abs() == vector1);
+	CONSTEXPR_CHECK(vector2.abs() == vector1);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec3_t Linear algebra methods", "[vec3_t][vec3_t-linear-algebra]", VectorValueTypes) {
-	const vec3_t<TestType> vector_x = vec3_t<TestType>(1, 0, 0);
-	const vec3_t<TestType> vector_y = vec3_t<TestType>(0, 1, 0);
-	const vec3_t<TestType> a = vec3_t<TestType>(3, 8, 2);
-	const vec3_t<TestType> b = vec3_t<TestType>(5, 4, 7);
+	static constexpr vec3_t<TestType> vector_x = vec3_t<TestType>(1, 0, 0);
+	static constexpr vec3_t<TestType> vector_y = vec3_t<TestType>(0, 1, 0);
+	static constexpr vec3_t<TestType> a = vec3_t<TestType>(3, 8, 2);
+	static constexpr vec3_t<TestType> b = vec3_t<TestType>(5, 4, 7);
 
-	CHECK(vector_x.dot(vector_y) == 0);
-	CHECK(vector_x.dot(vector_x) == 1);
-	CHECK((vector_x * 10).dot(vector_x * 10) == 100);
-	CHECK(a.dot(b) == 61);
-	CHECK(vec3_t<TestType>(-a.x, a.y, -a.z).dot(vec3_t<TestType>(b.x, -b.y, b.z)) == -61);
+	CONSTEXPR_CHECK(vector_x.dot(vector_y) == 0);
+	CONSTEXPR_CHECK(vector_x.dot(vector_x) == 1);
+	CONSTEXPR_CHECK((vector_x * 10).dot(vector_x * 10) == 100);
+	CONSTEXPR_CHECK(a.dot(b) == 61);
+	CONSTEXPR_CHECK(vec3_t<TestType>(-a.x, a.y, -a.z).dot(vec3_t<TestType>(b.x, -b.y, b.z)) == -61);
 }
 
 TEST_CASE("fvec3_t Length methods", "[vec3_t][fvec3_t][fvec3_t-length]") {
-	const fvec3_t vector1 = fvec3_t(10, 10, 10);
-	const fvec3_t vector2 = fvec3_t(20, 30, 40);
-	CHECK(vector1.length_squared().sqrt() == testing::approx(testing::SQRT3 * 10));
-	CHECK(vector2.length_squared().sqrt() == testing::approx(53.8516480713450403125));
-	CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(37.41657386773941385584));
+	static constexpr fvec3_t vector1 = fvec3_t(10, 10, 10);
+	static constexpr fvec3_t vector2 = fvec3_t(20, 30, 40);
+	CONSTEXPR_CHECK(vector1.length_squared().sqrt() == testing::approx(testing::SQRT3 * 10));
+	CONSTEXPR_CHECK(vector2.length_squared().sqrt() == testing::approx(53.8516480713450403125));
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(37.41657386773941385584));
 }
 
 TEST_CASE("dvec3_t Length methods", "[vec3_t][dvec3_t][dvec3_t-length]") {
-	const dvec3_t vector1 = dvec3_t(10, 10, 10);
-	const dvec3_t vector2 = dvec3_t(20, 30, 40);
+	static constexpr dvec3_t vector1 = dvec3_t(10, 10, 10);
+	static constexpr dvec3_t vector2 = dvec3_t(20, 30, 40);
 	CHECK(std::sqrt(vector1.length_squared()) == testing::approx(10 * testing::SQRT3));
 	CHECK(std::sqrt(vector2.length_squared()) == testing::approx(53.8516480713450403125));
 	CHECK(std::sqrt(vector1.distance_squared(vector2)) == testing::approx(37.41657386773941385584));
 }
 
 TEST_CASE("fvec3_t Operators", "[vec3_t][fvec3_t][fvec3_t-operators]") {
-	const fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
-	const fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
-	const fixed_point_t _7_80 = //
+	static constexpr fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
+	static constexpr fixed_point_t _7_80 = //
 		fixed_point_t::_4() + fixed_point_t::_2() + fixed_point_t::_1() + fixed_point_t::_0_50() + fixed_point_t::_0_20() +
 		fixed_point_t::_0_10();
-	const fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
-	const fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
-	const fixed_point_t _5_60 = fixed_point_t::_4() + fixed_point_t::_1_50() + fixed_point_t::_0_10();
-	const fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
-	const fixed_point_t _0_125 = fixed_point_t::_1() / 8;
-	const fixed_point_t _0_625 = fixed_point_t::_0_50() + _0_125;
+	static constexpr fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
+	static constexpr fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
+	static constexpr fixed_point_t _5_60 = fixed_point_t::_4() + fixed_point_t::_1_50() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
+	static constexpr fixed_point_t _0_125 = fixed_point_t::_1() / 8;
+	static constexpr fixed_point_t _0_625 = fixed_point_t::_0_50() + _0_125;
 
-	const fvec3_t decimal1 = { _2_30, _4_90, _7_80 };
-	const fvec3_t decimal2 = { _1_20, _3_40, _5_60 };
-	const fvec3_t power1 = { _0_75, fixed_point_t::_1_50(), _0_625 };
-	const fvec3_t power2 = { fixed_point_t::_0_50(), _0_125, fixed_point_t::_0_25() };
-	const fvec3_t int1 = fvec3_t(4, 5, 9);
-	const fvec3_t int2 = fvec3_t(1, 2, 3);
+	static constexpr fvec3_t decimal1 = { _2_30, _4_90, _7_80 };
+	static constexpr fvec3_t decimal2 = { _1_20, _3_40, _5_60 };
+	static constexpr fvec3_t power1 = { _0_75, fixed_point_t::_1_50(), _0_625 };
+	static constexpr fvec3_t power2 = { fixed_point_t::_0_50(), _0_125, fixed_point_t::_0_25() };
+	static constexpr fvec3_t int1 = fvec3_t(4, 5, 9);
+	static constexpr fvec3_t int2 = fvec3_t(1, 2, 3);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec3(3.5, 8.3, 13.4));
-	CHECK(power1 + power2 == testing::approx_vec3(1.25, 1.625, 0.875));
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec3(3.5, 8.3, 13.4));
+	CONSTEXPR_CHECK(power1 + power2 == testing::approx_vec3(1.25, 1.625, 0.875));
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 - decimal2 ==
 		testing::approx_vec3 {
 			(1.1_a).epsilon(testing::INACCURATE_EPSILON), //
@@ -109,9 +110,9 @@ TEST_CASE("fvec3_t Operators", "[vec3_t][fvec3_t][fvec3_t-operators]") {
 			(2.2_a).epsilon(testing::INACCURATE_EPSILON) //
 		}
 	);
-	CHECK(power1 - power2 == testing::approx_vec3(0.25, 1.375, 0.375));
+	CONSTEXPR_CHECK(power1 - power2 == testing::approx_vec3(0.25, 1.375, 0.375));
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 * decimal2 ==
 		testing::approx_vec3 {
 			(2.76_a).epsilon(testing::INACCURATE_EPSILON), //
@@ -119,51 +120,51 @@ TEST_CASE("fvec3_t Operators", "[vec3_t][fvec3_t][fvec3_t-operators]") {
 			(43.68_a).epsilon(testing::INACCURATE_EPSILON) //
 		}
 	);
-	CHECK(power1 * power2 == testing::approx_vec3(0.375, 0.1875, 0.15625));
+	CONSTEXPR_CHECK(power1 * power2 == testing::approx_vec3(0.375, 0.1875, 0.15625));
 
-	CHECK(int1 / int2 == testing::approx_vec3(4, 2.5, 3));
-	CHECK(decimal1 / decimal2 == testing::approx_vec3(1.91666666666666666, 1.44117647058823529, 1.39285714285714286));
-	CHECK(power1 / power2 == testing::approx_vec3(1.5, 12.0, 2.5));
+	CONSTEXPR_CHECK(int1 / int2 == testing::approx_vec3(4, 2.5, 3));
+	CONSTEXPR_CHECK(decimal1 / decimal2 == testing::approx_vec3(1.91666666666666666, 1.44117647058823529, 1.39285714285714286));
+	CONSTEXPR_CHECK(power1 / power2 == testing::approx_vec3(1.5, 12.0, 2.5));
 
-	CHECK(decimal1 * 2 == testing::approx_vec3(4.6, 9.8, 15.6));
-	CHECK(power1 * 2 == testing::approx_vec3(1.5, 3, 1.25));
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec3(4.6, 9.8, 15.6));
+	CONSTEXPR_CHECK(power1 * 2 == testing::approx_vec3(1.5, 3, 1.25));
 
-	CHECK(int1 / 2 == testing::approx_vec3(2, 2.5, 4.5));
-	CHECK(decimal1 / 2 == testing::approx_vec3(1.15, 2.45, 3.9));
-	CHECK(power1 / 2 == testing::approx_vec3(0.375, 0.75, 0.3125));
+	CONSTEXPR_CHECK(int1 / 2 == testing::approx_vec3(2, 2.5, 4.5));
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec3(1.15, 2.45, 3.9));
+	CONSTEXPR_CHECK(power1 / 2 == testing::approx_vec3(0.375, 0.75, 0.3125));
 
-	CHECK(((ivec3_t)decimal1) == ivec3_t(2, 4, 7));
-	CHECK(((ivec3_t)decimal2) == ivec3_t(1, 3, 5));
+	CONSTEXPR_CHECK(((ivec3_t)decimal1) == ivec3_t(2, 4, 7));
+	CONSTEXPR_CHECK(((ivec3_t)decimal2) == ivec3_t(1, 3, 5));
 }
 
 TEST_CASE("dvec3_t Operators", "[vec3_t][dvec3_t][dvec3_t-operators]") {
-	const dvec3_t decimal1 = dvec3_t(2.3, 4.9, 7.8);
-	const dvec3_t decimal2 = dvec3_t(1.2, 3.4, 5.6);
-	const dvec3_t power1 = dvec3_t(0.75, 1.5, 0.625);
-	const dvec3_t power2 = dvec3_t(0.5, 0.125, 0.25);
-	const dvec3_t int1 = dvec3_t(4, 5, 9);
-	const dvec3_t int2 = dvec3_t(1, 2, 3);
+	static constexpr dvec3_t decimal1 = dvec3_t(2.3, 4.9, 7.8);
+	static constexpr dvec3_t decimal2 = dvec3_t(1.2, 3.4, 5.6);
+	static constexpr dvec3_t power1 = dvec3_t(0.75, 1.5, 0.625);
+	static constexpr dvec3_t power2 = dvec3_t(0.5, 0.125, 0.25);
+	static constexpr dvec3_t int1 = dvec3_t(4, 5, 9);
+	static constexpr dvec3_t int2 = dvec3_t(1, 2, 3);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec3(3.5, 8.3, 13.4));
-	CHECK(power1 + power2 == dvec3_t(1.25, 1.625, 0.875));
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec3(3.5, 8.3, 13.4));
+	CONSTEXPR_CHECK(power1 + power2 == dvec3_t(1.25, 1.625, 0.875));
 
-	CHECK(decimal1 - decimal2 == testing::approx_vec3(1.1, 1.5, 2.2));
-	CHECK(power1 - power2 == dvec3_t(0.25, 1.375, 0.375));
+	CONSTEXPR_CHECK(decimal1 - decimal2 == testing::approx_vec3(1.1, 1.5, 2.2));
+	CONSTEXPR_CHECK(power1 - power2 == dvec3_t(0.25, 1.375, 0.375));
 
-	CHECK(decimal1 * decimal2 == testing::approx_vec3(2.76, 16.66, 43.68));
-	CHECK(power1 * power2 == dvec3_t(0.375, 0.1875, 0.15625));
+	CONSTEXPR_CHECK(decimal1 * decimal2 == testing::approx_vec3(2.76, 16.66, 43.68));
+	CONSTEXPR_CHECK(power1 * power2 == dvec3_t(0.375, 0.1875, 0.15625));
 
-	CHECK(int1 / int2 == dvec3_t(4, 2.5, 3));
-	CHECK(decimal1 / decimal2 == testing::approx_vec3(1.91666666666666666, 1.44117647058823529, 1.39285714285714286));
-	CHECK(power1 / power2 == dvec3_t(1.5, 12.0, 2.5));
+	CONSTEXPR_CHECK(int1 / int2 == dvec3_t(4, 2.5, 3));
+	CONSTEXPR_CHECK(decimal1 / decimal2 == testing::approx_vec3(1.91666666666666666, 1.44117647058823529, 1.39285714285714286));
+	CONSTEXPR_CHECK(power1 / power2 == dvec3_t(1.5, 12.0, 2.5));
 
-	CHECK(decimal1 * 2 == testing::approx_vec3(4.6, 9.8, 15.6));
-	CHECK(power1 * 2 == dvec3_t(1.5, 3, 1.25));
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec3(4.6, 9.8, 15.6));
+	CONSTEXPR_CHECK(power1 * 2 == dvec3_t(1.5, 3, 1.25));
 
-	CHECK(int1 / 2 == dvec3_t(2, 2.5, 4.5));
-	CHECK(decimal1 / 2 == testing::approx_vec3(1.15, 2.45, 3.9));
-	CHECK(power1 / 2 == dvec3_t(0.375, 0.75, 0.3125));
+	CONSTEXPR_CHECK(int1 / 2 == dvec3_t(2, 2.5, 4.5));
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec3(1.15, 2.45, 3.9));
+	CONSTEXPR_CHECK(power1 / 2 == dvec3_t(0.375, 0.75, 0.3125));
 
-	CHECK(((ivec3_t)decimal1) == ivec3_t(2, 4, 7));
-	CHECK(((ivec3_t)decimal2) == ivec3_t(1, 3, 5));
+	CONSTEXPR_CHECK(((ivec3_t)decimal1) == ivec3_t(2, 4, 7));
+	CONSTEXPR_CHECK(((ivec3_t)decimal2) == ivec3_t(1, 3, 5));
 }

--- a/tests/src/types/Vector4.cpp
+++ b/tests/src/types/Vector4.cpp
@@ -8,6 +8,7 @@
 #include "Helper.hpp" // IWYU pragma: keep
 #include "Numeric.hpp"
 #include <snitch/snitch_macros_check.hpp>
+#include <snitch/snitch_macros_constexpr.hpp>
 #include <snitch/snitch_macros_misc.hpp>
 #include <snitch/snitch_macros_test_case.hpp>
 
@@ -17,92 +18,92 @@ using namespace OpenVic::testing::approx_literal;
 using VectorValueTypes = snitch::type_list<int32_t, OpenVic::fixed_point_t, double>;
 
 TEMPLATE_LIST_TEST_CASE("vec4_t Constructor methods", "[vec4_t][vec4_t-constructor]", VectorValueTypes) {
-	const vec4_t<TestType> vector_empty = vec4_t<TestType>();
-	const vec4_t<TestType> vector_zero = vec4_t<TestType>(0, 0, 0, 0);
-	CHECK(vector_empty == vector_zero);
+	static constexpr vec4_t<TestType> vector_empty = vec4_t<TestType>();
+	static constexpr vec4_t<TestType> vector_zero = vec4_t<TestType>(0, 0, 0, 0);
+	CONSTEXPR_CHECK(vector_empty == vector_zero);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec4_t Length methods", "[vec4_t][vec4_t-length]", VectorValueTypes) {
-	const vec4_t<TestType> vector1 = vec4_t<TestType>(10, 10, 10, 10);
-	const vec4_t<TestType> vector2 = vec4_t<TestType>(20, 30, 40, 50);
-	CHECK(vector1.length_squared() == 400);
-	CHECK(vector2.length_squared() == 5400);
-	CHECK(vector1.distance_squared(vector2) == 3000);
+	static constexpr vec4_t<TestType> vector1 = vec4_t<TestType>(10, 10, 10, 10);
+	static constexpr vec4_t<TestType> vector2 = vec4_t<TestType>(20, 30, 40, 50);
+	CONSTEXPR_CHECK(vector1.length_squared() == 400);
+	CONSTEXPR_CHECK(vector2.length_squared() == 5400);
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2) == 3000);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec4_t Operators", "[vec4_t][vec4_t-operators]", VectorValueTypes) {
-	const vec4_t<TestType> int1 = vec4_t<TestType>(4, 5, 9, 2);
-	const vec4_t<TestType> int2 = vec4_t<TestType>(1, 2, 3, 1);
+	static constexpr vec4_t<TestType> int1 = vec4_t<TestType>(4, 5, 9, 2);
+	static constexpr vec4_t<TestType> int2 = vec4_t<TestType>(1, 2, 3, 1);
 
-	CHECK((int1 + int2) == vec4_t<TestType>(5, 7, 12, 3));
-	CHECK((int1 - int2) == vec4_t<TestType>(3, 3, 6, 1));
-	CHECK((int1 * int2) == vec4_t<TestType>(4, 10, 27, 2));
-	CHECK((int1 * 2) == vec4_t<TestType>(8, 10, 18, 4));
-	CHECK(vec4_t<TestType>(ivec4_t(1, 2, 3, 4)) == vec4_t<TestType>(1, 2, 3, 4));
+	CONSTEXPR_CHECK((int1 + int2) == vec4_t<TestType>(5, 7, 12, 3));
+	CONSTEXPR_CHECK((int1 - int2) == vec4_t<TestType>(3, 3, 6, 1));
+	CONSTEXPR_CHECK((int1 * int2) == vec4_t<TestType>(4, 10, 27, 2));
+	CONSTEXPR_CHECK((int1 * 2) == vec4_t<TestType>(8, 10, 18, 4));
+	CONSTEXPR_CHECK(vec4_t<TestType>(ivec4_t(1, 2, 3, 4)) == vec4_t<TestType>(1, 2, 3, 4));
 }
 
 TEMPLATE_LIST_TEST_CASE("vec4_t Rounding methods", "[vec4_t][vec4_t-rounding]", VectorValueTypes) {
-	const vec4_t<TestType> vector1 = vec4_t<TestType>(1, 3, 5, 1);
-	const vec4_t<TestType> vector2 = vec4_t<TestType>(1, -3, -5, -1);
-	CHECK(vector1.abs() == vector1);
-	CHECK(vector2.abs() == vector1);
+	static constexpr vec4_t<TestType> vector1 = vec4_t<TestType>(1, 3, 5, 1);
+	static constexpr vec4_t<TestType> vector2 = vec4_t<TestType>(1, -3, -5, -1);
+	CONSTEXPR_CHECK(vector1.abs() == vector1);
+	CONSTEXPR_CHECK(vector2.abs() == vector1);
 }
 
 TEMPLATE_LIST_TEST_CASE("vec4_t Linear algebra methods", "[vec4_t][vec4_t-linear-algebra]", VectorValueTypes) {
-	const vec4_t<TestType> vector_x = vec4_t<TestType>(1, 0, 0, 0);
-	const vec4_t<TestType> vector_y = vec4_t<TestType>(0, 1, 0, 0);
-	const vec4_t<TestType> a = vec4_t<TestType>(3, 8, 2, 9);
-	const vec4_t<TestType> b = vec4_t<TestType>(5, 4, 7, 2);
+	static constexpr vec4_t<TestType> vector_x = vec4_t<TestType>(1, 0, 0, 0);
+	static constexpr vec4_t<TestType> vector_y = vec4_t<TestType>(0, 1, 0, 0);
+	static constexpr vec4_t<TestType> a = vec4_t<TestType>(3, 8, 2, 9);
+	static constexpr vec4_t<TestType> b = vec4_t<TestType>(5, 4, 7, 2);
 
-	CHECK(vector_x.dot(vector_y) == 0);
-	CHECK(vector_x.dot(vector_x) == 1);
-	CHECK((vector_x * 10).dot(vector_x * 10) == 100);
-	CHECK(a.dot(b) == 79);
-	CHECK(vec4_t<TestType>(-a.x, a.y, -a.z, a.w).dot(vec4_t<TestType>(b.x, -b.y, b.z, b.w)) == -43);
+	CONSTEXPR_CHECK(vector_x.dot(vector_y) == 0);
+	CONSTEXPR_CHECK(vector_x.dot(vector_x) == 1);
+	CONSTEXPR_CHECK((vector_x * 10).dot(vector_x * 10) == 100);
+	CONSTEXPR_CHECK(a.dot(b) == 79);
+	CONSTEXPR_CHECK(vec4_t<TestType>(-a.x, a.y, -a.z, a.w).dot(vec4_t<TestType>(b.x, -b.y, b.z, b.w)) == -43);
 }
 
 TEST_CASE("fvec4_t Length methods", "[vec4_t][fvec4_t][fvec4_t-length]") {
-	const fvec4_t vector1 = fvec4_t(10, 10, 10, 10);
-	const fvec4_t vector2 = fvec4_t(20, 30, 40, 50);
-	CHECK(vector1.length_squared().sqrt() == 20);
-	CHECK(vector2.length_squared().sqrt() == testing::approx(73.484692283495));
-	CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(54.772255750517));
+	static constexpr fvec4_t vector1 = fvec4_t(10, 10, 10, 10);
+	static constexpr fvec4_t vector2 = fvec4_t(20, 30, 40, 50);
+	CONSTEXPR_CHECK(vector1.length_squared().sqrt() == 20);
+	CONSTEXPR_CHECK(vector2.length_squared().sqrt() == testing::approx(73.484692283495));
+	CONSTEXPR_CHECK(vector1.distance_squared(vector2).sqrt() == testing::approx(54.772255750517));
 }
 
 TEST_CASE("dvec4_t Length methods", "[vec4_t][dvec4_t][dvec4_t-length]") {
-	const dvec4_t vector1 = dvec4_t(10, 10, 10, 10);
-	const dvec4_t vector2 = dvec4_t(20, 30, 40, 50);
+	static constexpr dvec4_t vector1 = dvec4_t(10, 10, 10, 10);
+	static constexpr dvec4_t vector2 = dvec4_t(20, 30, 40, 50);
 	CHECK(std::sqrt(vector1.length_squared()) == 20);
 	CHECK(std::sqrt(vector2.length_squared()) == testing::approx(73.484692283495));
 	CHECK(std::sqrt(vector1.distance_squared(vector2)) == testing::approx(54.772255750517));
 }
 
 TEST_CASE("fvec4_t Operators", "[vec4_t][fvec4_t][fvec4_t-operators]") {
-	const fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
-	const fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
-	const fixed_point_t _7_80 = //
+	static constexpr fixed_point_t _2_30 = fixed_point_t::_2() + fixed_point_t::_0_20() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t _4_90 = fixed_point_t::_4() + fixed_point_t::_0_50() + fixed_point_t::_0_20() * 2;
+	static constexpr fixed_point_t _7_80 = //
 		fixed_point_t::_4() + fixed_point_t::_2() + fixed_point_t::_1() + fixed_point_t::_0_50() + fixed_point_t::_0_20() +
 		fixed_point_t::_0_10();
-	const fixed_point_t _3_20 = fixed_point_t::_2() + fixed_point_t::_1() + fixed_point_t::_0_20();
-	const fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
-	const fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
-	const fixed_point_t _5_60 = fixed_point_t::_4() + fixed_point_t::_1_50() + fixed_point_t::_0_10();
-	const fixed_point_t _1_70 = fixed_point_t::_1_50() + fixed_point_t::_0_20();
-	const fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
-	const fixed_point_t _0_125 = fixed_point_t::_1() / 8;
-	const fixed_point_t _0_625 = fixed_point_t::_0_50() + _0_125;
+	static constexpr fixed_point_t _3_20 = fixed_point_t::_2() + fixed_point_t::_1() + fixed_point_t::_0_20();
+	static constexpr fixed_point_t _1_20 = fixed_point_t::_0_20() * 6;
+	static constexpr fixed_point_t _3_40 = fixed_point_t::_0_20() * 17;
+	static constexpr fixed_point_t _5_60 = fixed_point_t::_4() + fixed_point_t::_1_50() + fixed_point_t::_0_10();
+	static constexpr fixed_point_t _1_70 = fixed_point_t::_1_50() + fixed_point_t::_0_20();
+	static constexpr fixed_point_t _0_75 = fixed_point_t::_0_25() * 3;
+	static constexpr fixed_point_t _0_125 = fixed_point_t::_1() / 8;
+	static constexpr fixed_point_t _0_625 = fixed_point_t::_0_50() + _0_125;
 
-	const fvec4_t decimal1 = { _2_30, _4_90, _7_80, _3_20 };
-	const fvec4_t decimal2 = { _1_20, _3_40, _5_60, _1_70 };
-	const fvec4_t power1 = { _0_75, fixed_point_t::_1_50(), _0_625, _0_125 };
-	const fvec4_t power2 = { fixed_point_t::_0_50(), _0_125, fixed_point_t::_0_25(), _0_75 };
-	const fvec4_t int1 = fvec4_t(4, 5, 9, 2);
-	const fvec4_t int2 = fvec4_t(1, 2, 3, 1);
+	static constexpr fvec4_t decimal1 = { _2_30, _4_90, _7_80, _3_20 };
+	static constexpr fvec4_t decimal2 = { _1_20, _3_40, _5_60, _1_70 };
+	static constexpr fvec4_t power1 = { _0_75, fixed_point_t::_1_50(), _0_625, _0_125 };
+	static constexpr fvec4_t power2 = { fixed_point_t::_0_50(), _0_125, fixed_point_t::_0_25(), _0_75 };
+	static constexpr fvec4_t int1 = fvec4_t(4, 5, 9, 2);
+	static constexpr fvec4_t int2 = fvec4_t(1, 2, 3, 1);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec4(3.5, 8.3, 13.4, 4.9));
-	CHECK(power1 + power2 == testing::approx_vec4(1.25, 1.625, 0.875, 0.875));
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec4(3.5, 8.3, 13.4, 4.9));
+	CONSTEXPR_CHECK(power1 + power2 == testing::approx_vec4(1.25, 1.625, 0.875, 0.875));
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 - decimal2 ==
 		testing::approx_vec4 {
 			(1.1_a).epsilon(testing::INACCURATE_EPSILON), //
@@ -112,9 +113,9 @@ TEST_CASE("fvec4_t Operators", "[vec4_t][fvec4_t][fvec4_t-operators]") {
 
 		}
 	);
-	CHECK(power1 - power2 == testing::approx_vec4(0.25, 1.375, 0.375, -0.625));
+	CONSTEXPR_CHECK(power1 - power2 == testing::approx_vec4(0.25, 1.375, 0.375, -0.625));
 
-	CHECK(
+	CONSTEXPR_CHECK(
 		decimal1 * decimal2 ==
 		testing::approx_vec4 {
 			(2.76_a).epsilon(testing::INACCURATE_EPSILON), //
@@ -123,56 +124,56 @@ TEST_CASE("fvec4_t Operators", "[vec4_t][fvec4_t][fvec4_t-operators]") {
 			(5.44_a).epsilon(testing::INACCURATE_EPSILON) //
 		}
 	);
-	CHECK(power1 * power2 == testing::approx_vec4(0.375, 0.1875, 0.15625, 0.09375));
+	CONSTEXPR_CHECK(power1 * power2 == testing::approx_vec4(0.375, 0.1875, 0.15625, 0.09375));
 
-	CHECK(int1 / int2 == testing::approx_vec4(4, 2.5, 3, 2));
-	CHECK(
+	CONSTEXPR_CHECK(int1 / int2 == testing::approx_vec4(4, 2.5, 3, 2));
+	CONSTEXPR_CHECK(
 		decimal1 / decimal2 ==
 		testing::approx_vec4(1.91666666666666666, 1.44117647058823529, 1.39285714285714286, 1.88235294118)
 	);
-	CHECK(power1 / power2 == testing::approx_vec4(1.5, 12.0, 2.5, 1.0 / 6.0));
+	CONSTEXPR_CHECK(power1 / power2 == testing::approx_vec4(1.5, 12.0, 2.5, 1.0 / 6.0));
 
-	CHECK(decimal1 * 2 == testing::approx_vec4(4.6, 9.8, 15.6, 6.4));
-	CHECK(power1 * 2 == testing::approx_vec4(1.5, 3, 1.25, 0.25));
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec4(4.6, 9.8, 15.6, 6.4));
+	CONSTEXPR_CHECK(power1 * 2 == testing::approx_vec4(1.5, 3, 1.25, 0.25));
 
-	CHECK(int1 / 2 == testing::approx_vec4(2, 2.5, 4.5, 1));
-	CHECK(decimal1 / 2 == testing::approx_vec4(1.15, 2.45, 3.9, 1.6));
-	CHECK(power1 / 2 == testing::approx_vec4(0.375, 0.75, 0.3125, 0.0625));
+	CONSTEXPR_CHECK(int1 / 2 == testing::approx_vec4(2, 2.5, 4.5, 1));
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec4(1.15, 2.45, 3.9, 1.6));
+	CONSTEXPR_CHECK(power1 / 2 == testing::approx_vec4(0.375, 0.75, 0.3125, 0.0625));
 
-	CHECK(((ivec4_t)decimal1) == ivec4_t(2, 4, 7, 3));
-	CHECK(((ivec4_t)decimal2) == ivec4_t(1, 3, 5, 1));
+	CONSTEXPR_CHECK(((ivec4_t)decimal1) == ivec4_t(2, 4, 7, 3));
+	CONSTEXPR_CHECK(((ivec4_t)decimal2) == ivec4_t(1, 3, 5, 1));
 }
 
 TEST_CASE("dvec4_t Operators", "[vec4_t][dvec4_t][dvec4_t-operators]") {
-	const dvec4_t decimal1 = dvec4_t(2.3, 4.9, 7.8, 3.2);
-	const dvec4_t decimal2 = dvec4_t(1.2, 3.4, 5.6, 1.7);
-	const dvec4_t power1 = dvec4_t(0.75, 1.5, 0.625, 0.125);
-	const dvec4_t power2 = dvec4_t(0.5, 0.125, 0.25, 0.75);
-	const dvec4_t int1 = dvec4_t(4, 5, 9, 2);
-	const dvec4_t int2 = dvec4_t(1, 2, 3, 1);
+	static constexpr dvec4_t decimal1 = dvec4_t(2.3, 4.9, 7.8, 3.2);
+	static constexpr dvec4_t decimal2 = dvec4_t(1.2, 3.4, 5.6, 1.7);
+	static constexpr dvec4_t power1 = dvec4_t(0.75, 1.5, 0.625, 0.125);
+	static constexpr dvec4_t power2 = dvec4_t(0.5, 0.125, 0.25, 0.75);
+	static constexpr dvec4_t int1 = dvec4_t(4, 5, 9, 2);
+	static constexpr dvec4_t int2 = dvec4_t(1, 2, 3, 1);
 
-	CHECK(decimal1 + decimal2 == testing::approx_vec4(3.5, 8.3, 13.4, 4.9));
-	CHECK(power1 + power2 == dvec4_t(1.25, 1.625, 0.875, 0.875));
+	CONSTEXPR_CHECK(decimal1 + decimal2 == testing::approx_vec4(3.5, 8.3, 13.4, 4.9));
+	CONSTEXPR_CHECK(power1 + power2 == dvec4_t(1.25, 1.625, 0.875, 0.875));
 
-	CHECK(decimal1 - decimal2 == testing::approx_vec4(1.1, 1.5, 2.2, 1.5));
-	CHECK(power1 - power2 == dvec4_t(0.25, 1.375, 0.375, -0.625));
+	CONSTEXPR_CHECK(decimal1 - decimal2 == testing::approx_vec4(1.1, 1.5, 2.2, 1.5));
+	CONSTEXPR_CHECK(power1 - power2 == dvec4_t(0.25, 1.375, 0.375, -0.625));
 
-	CHECK(decimal1 * decimal2 == testing::approx_vec4(2.76, 16.66, 43.68, 5.44));
-	CHECK(power1 * power2 == dvec4_t(0.375, 0.1875, 0.15625, 0.09375));
+	CONSTEXPR_CHECK(decimal1 * decimal2 == testing::approx_vec4(2.76, 16.66, 43.68, 5.44));
+	CONSTEXPR_CHECK(power1 * power2 == dvec4_t(0.375, 0.1875, 0.15625, 0.09375));
 
-	CHECK(int1 / int2 == dvec4_t(4, 2.5, 3, 2));
-	CHECK(
+	CONSTEXPR_CHECK(int1 / int2 == dvec4_t(4, 2.5, 3, 2));
+	CONSTEXPR_CHECK(
 		decimal1 / decimal2 == testing::approx_vec4(1.91666666666666666, 1.44117647058823529, 1.39285714285714286, 1.8823529411)
 	);
-	CHECK(power1 / power2 == dvec4_t(1.5, 12.0, 2.5, 1.0 / 6.0));
+	CONSTEXPR_CHECK(power1 / power2 == dvec4_t(1.5, 12.0, 2.5, 1.0 / 6.0));
 
-	CHECK(decimal1 * 2 == testing::approx_vec4(4.6, 9.8, 15.6, 6.4));
-	CHECK(power1 * 2 == dvec4_t(1.5, 3, 1.25, 0.25));
+	CONSTEXPR_CHECK(decimal1 * 2 == testing::approx_vec4(4.6, 9.8, 15.6, 6.4));
+	CONSTEXPR_CHECK(power1 * 2 == dvec4_t(1.5, 3, 1.25, 0.25));
 
-	CHECK(int1 / 2 == dvec4_t(2, 2.5, 4.5, 1));
-	CHECK(decimal1 / 2 == testing::approx_vec4(1.15, 2.45, 3.9, 1.6));
-	CHECK(power1 / 2 == dvec4_t(0.375, 0.75, 0.3125, 0.0625));
+	CONSTEXPR_CHECK(int1 / 2 == dvec4_t(2, 2.5, 4.5, 1));
+	CONSTEXPR_CHECK(decimal1 / 2 == testing::approx_vec4(1.15, 2.45, 3.9, 1.6));
+	CONSTEXPR_CHECK(power1 / 2 == dvec4_t(0.375, 0.75, 0.3125, 0.0625));
 
-	CHECK(((ivec4_t)decimal1) == ivec4_t(2, 4, 7, 3));
-	CHECK(((ivec4_t)decimal2) == ivec4_t(1, 3, 5, 1));
+	CONSTEXPR_CHECK(((ivec4_t)decimal1) == ivec4_t(2, 4, 7, 3));
+	CONSTEXPR_CHECK(((ivec4_t)decimal2) == ivec4_t(1, 3, 5, 1));
 }


### PR DESCRIPTION
Add constexpr support for `basic_colour_t::to_chars`
Fix constexpr support for `basic_colour_t::parse_from_chars`
Add constexpr support for `Date::to_chars`
Add constexpr support to `Date::from_string`
Add constexpr support to vector abs method
Fix constexpr support `StringUtils::from_chars`
Add constexpr support for `fixed_point_t::to_chars`
Fix constexpr support for `fixed_point_t::parse`
Fix constexpr support for fixed_point_t constants
Add Approx constexpr support
Add constexpr to_chars in StringUtils.hpp
Add constexpr abs in Utility.hpp