### PR TITLE
Domestic market & imports

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -178,6 +178,7 @@ bool InstanceManager::setup() {
 
 	thread_pool.initialise_threadpool(
 		definition_manager.get_define_manager().get_pops_defines(),
+		country_instance_manager.get_country_instances(),
 		definition_manager.get_pop_manager().get_stratas(),
 		good_instance_manager.get_good_instances(),
 		map_instance.get_province_instances()

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -136,9 +136,9 @@ namespace OpenVic {
 
 		/* Budget */
 		// TODO - cash stockpile change over last 30 days
+		fixed_point_t PROPERTY(gold_income);
 		moveable_atomic_fixed_point_t PROPERTY(cash_stockpile);
 		std::unique_ptr<std::mutex> taxable_income_mutex;
-		fixed_point_t PROPERTY(gold_income);
 		IndexedMap<PopType, fixed_point_t> PROPERTY(taxable_income_by_pop_type);
 		IndexedMap<Strata, fixed_point_t> PROPERTY(effective_tax_rate_by_strata);
 		IndexedMap<Strata, SliderValue> PROPERTY(tax_rate_slider_value_by_strata);
@@ -172,7 +172,10 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(projected_unemployment_subsidies_spending_unscaled_by_slider);
 
 		SliderValue PROPERTY(tariff_rate_slider_value);
-		//TODO actual & projected tariff income/expense
+		fixed_point_t PROPERTY(effective_tariff_rate);
+		std::unique_ptr<std::mutex> import_value_mutex;
+		fixed_point_t PROPERTY(import_value); //>= 0
+		fixed_point_t PROPERTY(actual_net_tariffs);
 
 		//TODO actual factory subsidies
 		//projected cost is UI only and lists the different factories
@@ -635,6 +638,7 @@ namespace OpenVic {
 		void report_output(ProductionType const& production_type, const fixed_point_t quantity);
 		void request_salaries_and_welfare(Pop& pop) const;
 		fixed_point_t calculate_minimum_wage_base(PopType const& pop_type) const;
+		fixed_point_t apply_tariff(const fixed_point_t money_spent_on_imports);
 	};
 
 	struct CountryDefinitionManager;

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -24,6 +24,7 @@ ArtisanalProducer::ArtisanalProducer(
 
 void ArtisanalProducer::artisan_tick(
 	Pop& pop,
+	const fixed_point_t max_cost_multiplier,
 	GoodDefinition::good_definition_map_t& pop_max_quantity_to_buy_per_good,
 	GoodDefinition::good_definition_map_t& pop_money_to_spend_per_good,
 	GoodDefinition::good_definition_map_t& reusable_map_0,
@@ -114,7 +115,7 @@ void ArtisanalProducer::artisan_tick(
 	}
 
 	//executed once per pop while nothing else uses it.
-	const fixed_point_t total_cash_to_spend = pop.get_cash().get_copy_of_value();
+	const fixed_point_t total_cash_to_spend = pop.get_cash().get_copy_of_value() / max_cost_multiplier;
 	MarketInstance const& market_instance = pop.get_market_instance();
 
 	if (total_cash_to_spend > fixed_point_t::_0() && !goods_to_buy_and_max_price.empty()) {

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.hpp
@@ -31,6 +31,7 @@ namespace OpenVic {
 
 		void artisan_tick(
 			Pop& pop,
+			const fixed_point_t max_cost_multiplier,
 			GoodDefinition::good_definition_map_t& pop_max_quantity_to_buy_per_good,
 			GoodDefinition::good_definition_map_t& pop_money_to_spend_per_good,
 			GoodDefinition::good_definition_map_t& reusable_map_0,

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -148,7 +148,7 @@ void ResourceGatheringOperation::rgo_tick(std::vector<fixed_point_t>& reusable_v
 
 	output_quantity_yesterday = produce();
 	if (output_quantity_yesterday > fixed_point_t::_0()) {
-		CountryInstance* country_to_report_economy_nullable = location.get_country_to_report_economy();
+		CountryInstance* const country_to_report_economy_nullable = location.get_country_to_report_economy();
 		if (country_to_report_economy_nullable != nullptr) {
 			country_to_report_economy_nullable->report_output(production_type, output_quantity_yesterday);
 		}
@@ -156,6 +156,7 @@ void ResourceGatheringOperation::rgo_tick(std::vector<fixed_point_t>& reusable_v
 		market_instance.place_market_sell_order(
 			{
 				production_type.get_output_good(),
+				country_to_report_economy_nullable,
 				output_quantity_yesterday,
 				this,
 				after_sell,

--- a/src/openvic-simulation/economy/trading/BuyResult.hpp
+++ b/src/openvic-simulation/economy/trading/BuyResult.hpp
@@ -9,18 +9,21 @@ namespace OpenVic {
 	private:
 		GoodDefinition const& PROPERTY(good_definition);
 		const fixed_point_t PROPERTY(quantity_bought);
-		const fixed_point_t PROPERTY(money_spent);
+		const fixed_point_t PROPERTY(money_spent_total);
+		const fixed_point_t PROPERTY(money_spent_on_imports);
 	public:
 		constexpr BuyResult(
 			GoodDefinition const& new_good_definition,
 			const fixed_point_t new_quantity_bought,
-			const fixed_point_t new_money_spent
+			const fixed_point_t new_money_spent_total,
+			const fixed_point_t new_money_spent_on_imports
 		) : good_definition { new_good_definition },
 			quantity_bought { new_quantity_bought },
-			money_spent { new_money_spent } {}
+			money_spent_total { new_money_spent_total },
+			money_spent_on_imports { new_money_spent_on_imports } {}
 
 		static constexpr BuyResult no_purchase_result(GoodDefinition const& good_definition) {
-			return { good_definition, fixed_point_t::_0(), fixed_point_t::_0() };
+			return { good_definition, fixed_point_t::_0(), fixed_point_t::_0(), fixed_point_t::_0() };
 		}
 	};
 }

--- a/src/openvic-simulation/economy/trading/BuyUpToOrder.hpp
+++ b/src/openvic-simulation/economy/trading/BuyUpToOrder.hpp
@@ -4,23 +4,28 @@
 #include "openvic-simulation/utility/Getters.hpp"
 
 namespace OpenVic {
+	struct CountryInstance;
+
 	struct GoodBuyUpToOrder {
 		using actor_t = void*;
-		using callback_t = void(*)(actor_t, BuyResult const&);
+		using callback_t = void(*)(const actor_t, BuyResult const&);
 
 	private:
+		CountryInstance const* const PROPERTY(country_nullable);
 		const fixed_point_t PROPERTY(max_quantity);
 		const fixed_point_t PROPERTY(money_to_spend);
-		actor_t actor;
-		callback_t after_trade;
+		const actor_t actor;
+		const callback_t after_trade;
 
 	public:
 		constexpr GoodBuyUpToOrder(
+			CountryInstance const* const new_country_nullable,
 			const fixed_point_t new_max_quantity,
 			const fixed_point_t new_money_to_spend,
-			actor_t new_actor,
-			callback_t new_after_trade
-		) : max_quantity { new_max_quantity },
+			const actor_t new_actor,
+			const callback_t new_after_trade
+		) : country_nullable { new_country_nullable },
+			max_quantity { new_max_quantity },
 			money_to_spend { new_money_to_spend },
 			actor { new_actor },
 			after_trade { new_after_trade }
@@ -43,11 +48,13 @@ namespace OpenVic {
 	public:
 		constexpr BuyUpToOrder(
 			GoodDefinition const& new_good,
+			CountryInstance const* const new_country_nullable,
 			const fixed_point_t new_max_quantity,
 			const fixed_point_t new_money_to_spend,
-			actor_t new_actor,
-			callback_t new_after_trade
+			const actor_t new_actor,
+			const callback_t new_after_trade
 		) : GoodBuyUpToOrder {
+				new_country_nullable,
 				new_max_quantity,
 				new_money_to_spend,
 				new_actor,

--- a/src/openvic-simulation/economy/trading/GoodMarket.hpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.hpp
@@ -6,9 +6,11 @@
 #include "openvic-simulation/economy/trading/BuyUpToOrder.hpp"
 #include "openvic-simulation/economy/trading/MarketSellOrder.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/ValueHistory.hpp"
 
 namespace OpenVic {
+	struct CountryInstance;
 	struct GameRulesManager;
 
 	struct GoodMarket {
@@ -25,6 +27,13 @@ namespace OpenVic {
 		//only used during day tick (from actors placing order until execute_orders())
 		std::vector<GoodBuyUpToOrder> buy_up_to_orders;
 		std::vector<GoodMarketSellOrder> market_sell_orders;
+
+		void execute_buy_orders(
+			const fixed_point_t new_price,
+			IndexedMap<CountryInstance, fixed_point_t> const& actual_bought_per_country,
+			IndexedMap<CountryInstance, fixed_point_t> const& supply_per_country,
+			std::vector<fixed_point_t> const& quantity_bought_per_order
+		);
 
 	protected:
 		bool PROPERTY_ACCESS(is_available, protected);
@@ -50,7 +59,12 @@ namespace OpenVic {
 		void add_market_sell_order(GoodMarketSellOrder&& market_sell_order);
 
 		//not thread safe
-		void execute_orders(std::vector<fixed_point_t>& reusable_vector_0, std::vector<fixed_point_t>& reusable_vector_1);
+		void execute_orders(
+			IndexedMap<CountryInstance, fixed_point_t>& reusable_country_map_0,
+			IndexedMap<CountryInstance, fixed_point_t>& reusable_country_map_1,
+			std::vector<fixed_point_t>& reusable_vector_0,
+			std::vector<fixed_point_t>& reusable_vector_1
+		);
 		void on_use_exponential_price_changes_changed();
 		void record_price_history();
 	};

--- a/src/openvic-simulation/economy/trading/MarketSellOrder.hpp
+++ b/src/openvic-simulation/economy/trading/MarketSellOrder.hpp
@@ -6,6 +6,7 @@
 #include "openvic-simulation/utility/Getters.hpp"
 
 namespace OpenVic {
+	struct CountryInstance;
 	struct GoodDefinition;
 
 	struct GoodMarketSellOrder {
@@ -13,16 +14,19 @@ namespace OpenVic {
 		using callback_t = void (*)(actor_t, SellResult const&, std::vector<fixed_point_t>&);
 
 	private:
+		CountryInstance const* const PROPERTY(country_nullable);
 		const fixed_point_t PROPERTY(quantity);
-		actor_t actor;
-		callback_t after_trade;
+		const actor_t actor;
+		const callback_t after_trade;
 
 	public:
 		constexpr GoodMarketSellOrder(
+			CountryInstance const* const new_country_nullable,
 			const fixed_point_t new_quantity,
-			actor_t new_actor,
-			callback_t new_after_trade
-		) : quantity { new_quantity },
+			const actor_t new_actor,
+			const callback_t new_after_trade
+		) : country_nullable { new_country_nullable },
+			quantity { new_quantity },
 			actor { new_actor },
 			after_trade { new_after_trade }
 			{}
@@ -39,10 +43,16 @@ namespace OpenVic {
 	public:
 		constexpr MarketSellOrder(
 			GoodDefinition const& new_good,
+			CountryInstance const* const new_country_nullable,
 			const fixed_point_t new_quantity,
-			actor_t new_actor,
-			callback_t new_after_trade
-		) : GoodMarketSellOrder { new_quantity, new_actor, new_after_trade },
+			const actor_t new_actor,
+			const callback_t new_after_trade
+		) : GoodMarketSellOrder {
+				new_country_nullable,
+				new_quantity,
+				new_actor,
+				new_after_trade
+			},
 			good { new_good }
 			{}
 	};

--- a/src/openvic-simulation/utility/ThreadPool.cpp
+++ b/src/openvic-simulation/utility/ThreadPool.cpp
@@ -9,10 +9,13 @@ using namespace OpenVic;
 void ThreadPool::loop_until_cancelled(
 	work_t& work_type,
 	PopsDefines const& pop_defines,
+	std::vector<CountryInstance> const& country_keys,
 	std::vector<Strata> const& strata_keys,
 	std::span<GoodInstance> goods_chunk,
 	std::span<ProvinceInstance> provinces_chunk
 ) {
+	IndexedMap<CountryInstance, fixed_point_t> reusable_country_map_0 { &country_keys },
+		reusable_country_map_1 { &country_keys};
 	std::vector<fixed_point_t> reusable_vector_0 {}, reusable_vector_1 {};
 	PopValuesFromProvince reusable_pop_values { pop_defines, strata_keys };
 
@@ -40,6 +43,8 @@ void ThreadPool::loop_until_cancelled(
 			case work_t::GOOD_EXECUTE_ORDERS:
 				for (GoodMarket& good : goods_chunk) {
 					good.execute_orders(
+						reusable_country_map_0,
+						reusable_country_map_1,
 						reusable_vector_0,
 						reusable_vector_1
 					);
@@ -112,6 +117,7 @@ ThreadPool::~ThreadPool() {
 
 void ThreadPool::initialise_threadpool(
 	PopsDefines const& pop_defines,
+	std::vector<CountryInstance> const& country_keys,
 	std::vector<Strata> const& strata_keys,
 	std::span<GoodInstance> goods,
 	std::span<ProvinceInstance> provinces
@@ -147,6 +153,7 @@ void ThreadPool::initialise_threadpool(
 				this,
 				&work_for_thread = work_per_thread[i],
 				&pop_defines,
+				&country_keys,
 				&strata_keys,
 				goods_begin, goods_end,
 				provinces_begin, provinces_end
@@ -154,6 +161,7 @@ void ThreadPool::initialise_threadpool(
 				loop_until_cancelled(
 					work_for_thread,
 					pop_defines,
+					country_keys,
 					strata_keys,
 					std::span<GoodInstance>{ goods_begin, goods_end },
 					std::span<ProvinceInstance>{ provinces_begin, provinces_end }

--- a/src/openvic-simulation/utility/ThreadPool.hpp
+++ b/src/openvic-simulation/utility/ThreadPool.hpp
@@ -10,6 +10,7 @@
 #include "openvic-simulation/types/Date.hpp"
 
 namespace OpenVic {
+	struct CountryInstance;
 	struct GoodInstance;
 	struct PopsDefines;
 	struct Strata;
@@ -26,6 +27,7 @@ namespace OpenVic {
 		void loop_until_cancelled(
 			work_t& work_type,
 			PopsDefines const& pop_defines,
+			std::vector<CountryInstance> const& country_keys,
 			std::vector<Strata> const& strata_keys,
 			std::span<GoodInstance> goods_chunk,
 			std::span<ProvinceInstance> provinces_chunk
@@ -50,6 +52,7 @@ namespace OpenVic {
 
 		void initialise_threadpool(
 			PopsDefines const& pop_defines,
+			std::vector<CountryInstance> const& country_keys,
 			std::vector<Strata> const& strata_keys,
 			std::span<GoodInstance> goods,
 			std::span<ProvinceInstance> provinces


### PR DESCRIPTION
- [x] Add `money_spent_on_imports` in BuyResult.
- [x] Calculate `money_spent_on_imports` in GoodsMarket.
- [x] Calculate and store `effective_tariff_rate` in CountryInstance.
- [x] Add `max_cost_multiplier` and use it to reduce spendable cash.
- [x] Take `effective_tariff_rate` into account for `max_cost_multiplier`
- [x] Store `import_value` in CountryInstance (for budget screen projections).
- [x] Store `actual_net_tariffs` in CountryInstance.
- [x] Collect tariffs on imports.