### PR TITLE
Negative tariffs

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -171,11 +171,15 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(projected_pensions_spending_unscaled_by_slider);
 		fixed_point_t PROPERTY(projected_unemployment_subsidies_spending_unscaled_by_slider);
 
+		fixed_point_t PROPERTY(yesterdays_import_value); //>= 0
 		SliderValue PROPERTY(tariff_rate_slider_value);
 		fixed_point_t PROPERTY(effective_tariff_rate);
-		std::unique_ptr<std::mutex> import_value_mutex;
-		fixed_point_t PROPERTY(import_value); //>= 0
+		std::unique_ptr<std::mutex> actual_net_tariffs_mutex;
+		fixed_point_t PROPERTY(projected_import_subsidies);
 		fixed_point_t PROPERTY(actual_net_tariffs);
+		constexpr bool has_import_subsidies() const {
+			return effective_tariff_rate < fixed_point_t::_0();
+		}
 
 		//TODO actual factory subsidies
 		//projected cost is UI only and lists the different factories
@@ -636,7 +640,7 @@ namespace OpenVic {
 		void report_input_consumption(ProductionType const& production_type, GoodDefinition const& good, const fixed_point_t quantity);
 		void report_input_demand(ProductionType const& production_type, GoodDefinition const& good, const fixed_point_t quantity);
 		void report_output(ProductionType const& production_type, const fixed_point_t quantity);
-		void request_salaries_and_welfare(Pop& pop) const;
+		void request_salaries_and_welfare_and_import_subsidies(Pop& pop) const;
 		fixed_point_t calculate_minimum_wage_base(PopType const& pop_type) const;
 		fixed_point_t apply_tariff(const fixed_point_t money_spent_on_imports);
 	};

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -249,6 +249,7 @@ size_t ProvinceInstance::get_pop_count() const {
  */
 void ProvinceInstance::_update_pops(DefineManager const& define_manager) {
 	total_population = 0;
+	yesterdays_import_value = fixed_point_t::_0();
 	average_literacy = 0;
 	average_consciousness = 0;
 	average_militancy = 0;
@@ -292,6 +293,7 @@ void ProvinceInstance::_update_pops(DefineManager const& define_manager) {
 		const fixed_point_t pop_size_f = fixed_point_t::parse(pop_size_s);
 
 		total_population += pop_size_s;
+		yesterdays_import_value += pop.get_yesterdays_import_value().get_copy_of_value();
 		average_literacy += pop.get_literacy() * pop_size_f;
 		average_consciousness += pop.get_consciousness() * pop_size_f;
 		average_militancy += pop.get_militancy() * pop_size_f;

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -110,6 +110,7 @@ namespace OpenVic {
 	private:
 		plf::colony<Pop> PROPERTY(pops); // TODO - replace with a more easily vectorisable container?
 		pop_size_t PROPERTY(total_population, 0);
+		fixed_point_t PROPERTY(yesterdays_import_value);
 		// TODO - population change (growth + migration), monthly totals + breakdown by source/destination
 		fixed_point_t PROPERTY(average_literacy);
 		fixed_point_t PROPERTY(average_consciousness);

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -82,6 +82,7 @@ fixed_point_t State::get_religion_proportion(Religion const& religion) const {
 
 void State::update_gamestate() {
 	total_population = 0;
+	yesterdays_import_value = fixed_point_t::_0();
 	average_literacy = 0;
 	average_consciousness = 0;
 	average_militancy = 0;
@@ -108,6 +109,7 @@ void State::update_gamestate() {
 
 	for (ProvinceInstance const* const province : provinces) {
 		total_population += province->get_total_population();
+		yesterdays_import_value += province->get_yesterdays_import_value();
 
 		// TODO - change casting if pop_size_t changes type
 		const fixed_point_t province_population = fixed_point_t::parse(province->get_total_population());

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -26,6 +26,7 @@ namespace OpenVic {
 		ProvinceInstance::colony_status_t PROPERTY(colony_status);
 
 		pop_size_t PROPERTY(total_population, 0);
+		fixed_point_t PROPERTY(yesterdays_import_value);
 		fixed_point_t PROPERTY(average_literacy);
 		fixed_point_t PROPERTY(average_consciousness);
 		fixed_point_t PROPERTY(average_militancy);

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -61,7 +61,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(money_type);
 
 	#define DECLARE_POP_MONEY_STORE_FUNCTIONS(name) \
-		void add_##name(fixed_point_t amount);
+		void add_##name(const fixed_point_t amount);
 
 	/* REQUIREMENTS:
 	 * POP-18, POP-19, POP-20, POP-21, POP-34, POP-35, POP-36, POP-37
@@ -125,6 +125,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(savings);
 		moveable_atomic_fixed_point_t PROPERTY(cash);
 		moveable_atomic_fixed_point_t PROPERTY(expenses); //positive value means POP paid for goods. This is displayed * -1 in UI.
+		moveable_atomic_fixed_point_t PROPERTY(yesterdays_import_value);
 
 		#define NEED_MEMBERS(need_category) \
 			moveable_atomic_fixed_point_t need_category##_needs_acquired_quantity, need_category##_needs_desired_quantity; \
@@ -191,6 +192,7 @@ namespace OpenVic {
 
 		DO_FOR_ALL_TYPES_OF_POP_INCOME(DECLARE_POP_MONEY_STORE_FUNCTIONS)
 		DO_FOR_ALL_TYPES_OF_POP_EXPENSES(DECLARE_POP_MONEY_STORE_FUNCTIONS)
+		DECLARE_POP_MONEY_STORE_FUNCTIONS(import_subsidies)
 		#undef DECLARE_POP_MONEY_STORE_FUNCTIONS
 		void pop_tick(PopValuesFromProvince& shared_values, std::vector<fixed_point_t>& reusable_vector);
 		void allocate_cash_for_artisanal_spending(const fixed_point_t money_to_spend);


### PR DESCRIPTION
Negative tariffs are handled with a 1 tick delay.
This allows the game to accurately project the cost and ensure the actual costs never exceed the projected costs (which might lead to bankruptcy otherwise).

In `Pop::after_buy` the pop keeps a running total of `yesterdays_import_value`.
This is cleared after calling `CountryInstance::request_salaries_and_welfare_and_import_subsidies` in `Pop::pop_tick`.

In the `update_gamestate` methods, `yesterdays_import_value` is propagated from province via state to country, just like total population.

In `CountryInstance::country_tick_before_map` the `projected_import_subsidies` are calculated and `actual_import_subsidies` is determined after handling budget cuts due to cash shortages.

`CountryInstance::request_salaries_and_welfare_and_import_subsidies` then calculates the subsidies per pop and adds them to the pop's cash (not income as it isn't taxed).


For alternative implementations and the discussion, see https://discord.com/channels/1063392556160909312/1064542494114725909/1376923223094067360
This PR implements option B.