### PR TITLE
Move const reference vectors to span

### DIFF
--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -1,5 +1,6 @@
 #include "ResourceGatheringOperation.hpp"
 
+#include <span>
 #include <vector>
 
 #include "openvic-simulation/economy/production/Employee.hpp"
@@ -68,7 +69,7 @@ void ResourceGatheringOperation::initialise_rgo_size_multiplier() {
 	ProvinceInstance& location = *location_ptr;
 	ModifierEffectCache const& modifier_effect_cache = location.get_modifier_effect_cache();
 	ProductionType const& production_type = *production_type_nullable;
-	std::vector<Job> const& jobs = production_type.get_jobs();
+	std::span<const Job> jobs = production_type.get_jobs();
 	IndexedMap<PopType, pop_size_t> const& province_pop_type_distribution = location.get_pop_type_distribution();
 
 	pop_size_t total_worker_count_in_province = 0; //not counting equivalents
@@ -127,7 +128,7 @@ void ResourceGatheringOperation::rgo_tick(std::vector<fixed_point_t>& reusable_v
 	}
 
 	ProductionType const& production_type = *production_type_nullable;
-	std::vector<Job> const& jobs = production_type.get_jobs();
+	std::span<const Job> jobs = production_type.get_jobs();
 	IndexedMap<PopType, pop_size_t> const& province_pop_type_distribution = location.get_pop_type_distribution();
 
 	total_worker_count_in_province_cache = 0; //not counting equivalents
@@ -197,7 +198,7 @@ void ResourceGatheringOperation::hire() {
 		proportion_to_hire = max_worker_count_real / available_worker_count_real;
 	}
 
-	std::vector<Job> const& jobs = production_type.get_jobs();
+	std::span<const Job> jobs = production_type.get_jobs();
 	for (Pop& pop : location.get_mutable_pops()){
 		PopType const& pop_type = *pop.get_type();
 		for (Job const& job : jobs) {

--- a/src/openvic-simulation/economy/trading/GoodMarket.cpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.cpp
@@ -393,7 +393,7 @@ void GoodMarket::execute_buy_orders(
 	const fixed_point_t new_price,
 	IndexedMap<CountryInstance, fixed_point_t> const& actual_bought_per_country,
 	IndexedMap<CountryInstance, fixed_point_t> const& supply_per_country,
-	std::vector<fixed_point_t> const& quantity_bought_per_order
+	std::span<const fixed_point_t> quantity_bought_per_order
 ) {
 	quantity_traded_yesterday = fixed_point_t::_0();
 	for (size_t i = 0; i < buy_up_to_orders.size(); i++) {

--- a/src/openvic-simulation/economy/trading/GoodMarket.hpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.hpp
@@ -32,7 +32,7 @@ namespace OpenVic {
 			const fixed_point_t new_price,
 			IndexedMap<CountryInstance, fixed_point_t> const& actual_bought_per_country,
 			IndexedMap<CountryInstance, fixed_point_t> const& supply_per_country,
-			std::vector<fixed_point_t> const& quantity_bought_per_order
+			std::span<const fixed_point_t> quantity_bought_per_order
 		);
 
 	protected:

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -172,7 +172,7 @@ void ProvinceHistoryManager::reserve_more_province_histories(size_t size) {
 }
 
 void ProvinceHistoryManager::lock_province_histories(MapDefinition const& map_definition, bool detailed_errors) {
-	std::vector<ProvinceDefinition> const& provinces = map_definition.get_province_definitions();
+	std::span<const ProvinceDefinition> provinces = map_definition.get_province_definitions();
 
 	std::vector<bool> province_checklist(provinces.size());
 	for (auto [province, history_map] : mutable_iterator(province_histories)) {

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <charconv>
 #include <cstdint>
+#include <span>
 #include <system_error>
 #include <vector>
 
@@ -497,7 +498,7 @@ static bool _parse_province_colour(colour_t& colour, std::array<std::string_view
 	return ret;
 }
 
-bool MapDefinition::load_province_definitions(std::vector<LineObject> const& lines) {
+bool MapDefinition::load_province_definitions(std::span<const LineObject> lines) {
 	bool ret = true;
 
 	if (lines.empty()) {
@@ -568,7 +569,7 @@ bool MapDefinition::load_region_colours(ast::NodeCPtr root, std::vector<colour_t
 	})(root);
 }
 
-bool MapDefinition::load_region_file(ast::NodeCPtr root, std::vector<colour_t> const& colours) {
+bool MapDefinition::load_region_file(ast::NodeCPtr root, std::span<const colour_t> colours) {
 	const bool ret = expect_dictionary_reserve_length(
 		regions,
 		[this, &colours](std::string_view region_identifier, ast::NodeCPtr region_node) -> bool {
@@ -992,7 +993,7 @@ bool MapDefinition::_generate_standard_province_adjacencies() {
 	return changed;
 }
 
-bool MapDefinition::generate_and_load_province_adjacencies(std::vector<LineObject> const& additional_adjacencies) {
+bool MapDefinition::generate_and_load_province_adjacencies(std::span<const LineObject> additional_adjacencies) {
 	bool ret = _generate_standard_province_adjacencies();
 	if (!ret) {
 		Logger::error("Failed to generate standard province adjacencies!");

--- a/src/openvic-simulation/map/MapDefinition.hpp
+++ b/src/openvic-simulation/map/MapDefinition.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <span>
 #include <string_view>
 #include <vector>
 
@@ -121,13 +122,13 @@ namespace OpenVic {
 
 		bool add_region(std::string_view identifier, std::vector<ProvinceDefinition const*>&& provinces, colour_t colour);
 
-		bool load_province_definitions(std::vector<ovdl::csv::LineObject> const& lines);
+		bool load_province_definitions(std::span<const ovdl::csv::LineObject> lines);
 		/* Must be loaded after adjacencies so we know what provinces are coastal, and so can have a port */
 		bool load_province_positions(BuildingTypeManager const& building_type_manager, ast::NodeCPtr root);
 		static bool load_region_colours(ast::NodeCPtr root, std::vector<colour_t>& colours);
-		bool load_region_file(ast::NodeCPtr root, std::vector<colour_t> const& colours);
+		bool load_region_file(ast::NodeCPtr root, std::span<const colour_t> colours);
 		bool load_map_images(fs::path const& province_path, fs::path const& terrain_path, fs::path const& rivers_path, bool detailed_errors);
-		bool generate_and_load_province_adjacencies(std::vector<ovdl::csv::LineObject> const& additional_adjacencies);
+		bool generate_and_load_province_adjacencies(std::span<const ovdl::csv::LineObject> additional_adjacencies);
 		bool load_climate_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 		bool load_continent_file(ModifierManager const& modifier_manager, ast::NodeCPtr root);
 	};

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -1,5 +1,7 @@
 #include "ProvinceInstance.hpp"
 
+#include <span>
+
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/defines/Define.hpp"
 #include "openvic-simulation/DefinitionManager.hpp"
@@ -219,7 +221,7 @@ bool ProvinceInstance::add_pop(Pop&& pop) {
 }
 
 bool ProvinceInstance::add_pop_vec(
-	std::vector<PopBase> const& pop_vec,
+	std::span<const PopBase> pop_vec,
 	MarketInstance& market_instance,
 	ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 ) {
@@ -410,7 +412,7 @@ fixed_point_t ProvinceInstance::get_modifier_effect_value(ModifierEffect const& 
 
 bool ProvinceInstance::convert_rgo_worker_pops_to_equivalent(ProductionType const& production_type) {
 	bool is_valid_operation = true;
-	std::vector<Job> const& jobs = production_type.get_jobs();
+	std::span<const Job> jobs = production_type.get_jobs();
 	for (Pop& pop : pops) {
 		for (Job const& job : jobs) {
 			PopType const* const job_pop_type = job.get_pop_type();

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include <plf_colony.h>
 
 #include "openvic-simulation/country/CountryInstance.hpp"
@@ -223,7 +225,7 @@ namespace OpenVic {
 
 		bool add_pop(Pop&& pop);
 		bool add_pop_vec(
-			std::vector<PopBase> const& pop_vec,
+			std::span<const PopBase> pop_vec,
 			MarketInstance& market_instance,
 			ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 		);

--- a/src/openvic-simulation/utility/BMP.cpp
+++ b/src/openvic-simulation/utility/BMP.cpp
@@ -1,6 +1,7 @@
 #include "BMP.hpp"
 
 #include <cstring>
+#include <span>
 
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
@@ -181,7 +182,7 @@ uint16_t BMP::get_bits_per_pixel() const {
 	return header.bits_per_pixel;
 }
 
-std::vector<BMP::palette_colour_t> const& BMP::get_palette() const {
+std::span<const BMP::palette_colour_t> BMP::get_palette() const {
 	if (!palette_read) {
 		Logger::warning("Trying to get BMP palette before loading");
 	}
@@ -218,7 +219,7 @@ bool BMP::read_pixel_data() {
 	return pixel_data_read;
 }
 
-std::vector<uint8_t> const& BMP::get_pixel_data() const {
+std::span<const uint8_t> BMP::get_pixel_data() const {
 	if (!pixel_data_read) {
 		Logger::warning("Trying to get BMP pixel data before loading");
 	}

--- a/src/openvic-simulation/utility/BMP.hpp
+++ b/src/openvic-simulation/utility/BMP.hpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <span>
 #include <vector>
 
 namespace OpenVic {
@@ -56,7 +57,7 @@ namespace OpenVic {
 		int32_t get_width() const;
 		int32_t get_height() const;
 		uint16_t get_bits_per_pixel() const;
-		std::vector<palette_colour_t> const& get_palette() const;
-		std::vector<uint8_t> const& get_pixel_data() const;
+		std::span<const palette_colour_t> get_palette() const;
+		std::span<const uint8_t> get_pixel_data() const;
 	};
 }


### PR DESCRIPTION
"Everywhere that you use std::vector<T> const& could you instead use std::span<T> as it reduces indirection and generalizes the use case instead of being dependent on the vector type being passed. It would allow any contiguous finite array of elements, dynamic or static, to be passed in and also doesn't depend on an allocator to describe the type."
https://github.com/OpenVicProject/OpenVic-Simulation/pull/291#issuecomment-2961121242