### PR TITLE
Graceful handling of provinces with multiple regions

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -237,6 +237,16 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 		definition_manager.get_politics_manager().get_ideology_manager().get_ideologies()
 	);
 
+	bool all_has_state = true;
+	for (ProvinceInstance const& province_instance : map_instance.get_province_instances()) {
+		if (!province_instance.get_province_definition().is_water() && OV_unlikely(province_instance.get_state() == nullptr)) {
+			all_has_state = false;
+			Logger::error(fmt::format("Province {} has no state.", province_instance.get_identifier()));
+			continue;
+		}
+	}
+	OV_ERR_FAIL_COND_V_MSG(!all_has_state, false, "At least one land province has no state");
+
 	update_modifier_sums();
 	country_instance_manager.update_gamestate(*this);
 	map_instance.initialise_for_new_game(*this);

--- a/src/openvic-simulation/map/Region.cpp
+++ b/src/openvic-simulation/map/Region.cpp
@@ -99,5 +99,5 @@ bool ProvinceSet::contains_province(ProvinceDefinition const* province) const {
 ProvinceSetModifier::ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type)
 	: Modifier { new_identifier, std::move(new_values), new_type } {}
 
-Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_meta)
-	: HasIdentifierAndColour { new_identifier, new_colour, false }, meta { new_meta } {}
+Region::Region(std::string_view new_identifier, colour_t new_colour, bool new_is_meta)
+	: HasIdentifierAndColour { new_identifier, new_colour, false }, is_meta { new_is_meta } {}

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -62,12 +62,11 @@ namespace OpenVic {
 
 	private:
 		/* A meta region cannot be the template for a state.
-		 * Any region containing a province already listed in a
-		 * previously defined region is considered a meta region.
+		 * Any region without provinces or containing water provinces is considered a meta region.
 		 */
-		const bool PROPERTY(meta);
+		const bool PROPERTY(is_meta);
 
-		Region(std::string_view new_identifier, colour_t new_colour, bool new_meta);
+		Region(std::string_view new_identifier, colour_t new_colour, bool new_is_meta);
 
 	public:
 		Region(Region&&) = default;

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -7,6 +7,7 @@
 #include "openvic-simulation/map/Region.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/StringUtils.hpp"
+#include "openvic-simulation/utility/ErrorMacros.hpp"
 
 using namespace OpenVic;
 
@@ -204,15 +205,8 @@ bool StateManager::add_state_set(
 	decltype(State::pop_type_distribution)::keys_span_type pop_type_keys,
 	decltype(State::ideology_distribution)::keys_span_type ideology_keys
 ) {
-	if (region.get_meta()) {
-		Logger::error("Cannot use meta region \"", region.get_identifier(), "\" as state template!");
-		return false;
-	}
-
-	if (region.empty()) {
-		Logger::error("Cannot use empty region \"", region.get_identifier(), "\" as state template!");
-		return false;
-	}
+	OV_ERR_FAIL_COND_V_MSG(region.get_is_meta(), false, fmt::format("Cannot use meta region \"{}\" as state template!", region.get_identifier()));
+	OV_ERR_FAIL_COND_V_MSG(region.empty(), false, fmt::format("Cannot use empty region \"{}\" as state template!", region.get_identifier()));
 
 	std::vector<std::vector<ProvinceInstance*>> temp_provinces;
 
@@ -282,7 +276,7 @@ bool StateManager::generate_states(
 	size_t state_count = 0;
 
 	for (Region const& region : map_definition.get_regions()) {
-		if (!region.get_meta()) {
+		if (!region.get_is_meta()) {
 			if (add_state_set(map_instance, region, strata_keys, pop_type_keys, ideology_keys)) {
 				state_count += state_sets.back().get_state_count();
 			} else {


### PR DESCRIPTION
Previously when a province was assigned to multiple regions in a mod, the game would simply crash.
Now it reports which province is assigned to which regions and asserts that all land provinces have a state.