### PR TITLE
Support multiple script nodes by combining them

### DIFF
--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -244,7 +244,7 @@ bool IssueManager::_load_reform(
 		modifier_manager.expect_base_country_modifier(values),
 		"administrative_multiplier", ZERO_OR_ONE, expect_fixed_point(assign_variable_callback(administrative_multiplier)),
 		"technology_cost", ZERO_OR_ONE, expect_uint(assign_variable_callback(technology_cost)),
-		"allow", ZERO_OR_ONE, allow.expect_script(),
+		"allow", ZERO_OR_MORE, allow.expect_script(),
 		"rules", ZERO_OR_ONE, rule_manager.expect_rule_set(move_variable_callback(rules)),
 		"on_execute", ZERO_OR_ONE, expect_dictionary_keys(
 			"trigger", ZERO_OR_ONE, on_execute_trigger.expect_script(),

--- a/src/openvic-simulation/scripts/Condition.cpp
+++ b/src/openvic-simulation/scripts/Condition.cpp
@@ -739,14 +739,14 @@ node_callback_t ConditionManager::expect_condition_node_list(
 	};
 }
 
-node_callback_t ConditionManager::expect_condition_script(
+bool ConditionManager::expect_condition_script(
 	DefinitionManager const& definition_manager, scope_type_t initial_scope, scope_type_t this_scope,
-	scope_type_t from_scope, callback_t<ConditionNode&&> callback
+	scope_type_t from_scope, NodeTools::callback_t<ConditionNode&&> callback, std::span<const ast::NodeCPtr> nodes
 ) const {
-	return [this, &definition_manager, initial_scope, this_scope, from_scope, callback](ast::NodeCPtr node) mutable -> bool {
-
-		ConditionNode::condition_list_t conds;
-		bool ret = expect_condition_node_list(
+	ConditionNode::condition_list_t conds;
+	bool ret = true;
+	for (const ast::NodeCPtr node : nodes) {
+		ret &= expect_condition_node_list(
 			definition_manager,
 			initial_scope,
 			this_scope,
@@ -754,9 +754,9 @@ node_callback_t ConditionManager::expect_condition_script(
 			NodeTools::vector_callback(conds),
 			true
 		)(node);
+	}
 
-		ret &= callback({ root_condition, std::move(conds), true });
+	ret &= callback({ root_condition, std::move(conds), true });
 
-		return ret;
-	};
+	return ret;
 }

--- a/src/openvic-simulation/scripts/Condition.hpp
+++ b/src/openvic-simulation/scripts/Condition.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ostream>
+#include <span>
 #include <string_view>
 #include <variant>
 
@@ -273,9 +274,9 @@ namespace OpenVic {
 	public:
 		bool setup_conditions(DefinitionManager const& definition_manager);
 
-		NodeTools::node_callback_t expect_condition_script(
+		bool expect_condition_script(
 			DefinitionManager const& definition_manager, scope_type_t initial_scope, scope_type_t this_scope,
-			scope_type_t from_scope, NodeTools::callback_t<ConditionNode&&> callback
+			scope_type_t from_scope, NodeTools::callback_t<ConditionNode&&> callback, std::span<const ast::NodeCPtr> nodes
 		) const;
 	};
 }

--- a/src/openvic-simulation/scripts/ConditionScript.cpp
+++ b/src/openvic-simulation/scripts/ConditionScript.cpp
@@ -9,12 +9,13 @@ ConditionScript::ConditionScript(
 	scope_type_t new_initial_scope, scope_type_t new_this_scope, scope_type_t new_from_scope
 ) : initial_scope { new_initial_scope }, this_scope { new_this_scope }, from_scope { new_from_scope } {}
 
-bool ConditionScript::_parse_script(ast::NodeCPtr root, DefinitionManager const& definition_manager) {
+bool ConditionScript::_parse_script(std::span<const ast::NodeCPtr> nodes, DefinitionManager const& definition_manager) {
 	return definition_manager.get_script_manager().get_condition_manager().expect_condition_script(
 		definition_manager,
 		initial_scope,
 		this_scope,
 		from_scope,
-		move_variable_callback(condition_root)
-	)(root);
+		move_variable_callback(condition_root),
+		nodes
+	);
 }

--- a/src/openvic-simulation/scripts/ConditionScript.hpp
+++ b/src/openvic-simulation/scripts/ConditionScript.hpp
@@ -15,7 +15,7 @@ namespace OpenVic {
 		scope_type_t PROPERTY(from_scope);
 
 	protected:
-		bool _parse_script(ast::NodeCPtr root, DefinitionManager const& definition_manager) override;
+		bool _parse_script(std::span<const ast::NodeCPtr> nodes, DefinitionManager const& definition_manager) override;
 
 	public:
 		ConditionScript(scope_type_t new_initial_scope, scope_type_t new_this_scope, scope_type_t new_from_scope);

--- a/src/openvic-simulation/scripts/EffectScript.cpp
+++ b/src/openvic-simulation/scripts/EffectScript.cpp
@@ -2,7 +2,7 @@
 
 using namespace OpenVic;
 
-bool EffectScript::_parse_script(ast::NodeCPtr root, DefinitionManager const& definition_manager) {
+bool EffectScript::_parse_script(std::span<const ast::NodeCPtr> nodes, DefinitionManager const& definition_manager) {
 	// TODO - parse effect script
 	return true;
 }

--- a/src/openvic-simulation/scripts/EffectScript.hpp
+++ b/src/openvic-simulation/scripts/EffectScript.hpp
@@ -7,6 +7,6 @@ namespace OpenVic {
 
 	struct EffectScript final : Script<DefinitionManager const&> {
 	protected:
-		bool _parse_script(ast::NodeCPtr root, DefinitionManager const& definition_manager) override;
+		bool _parse_script(std::span<const ast::NodeCPtr> nodes, DefinitionManager const& definition_manager) override;
 	};
 }


### PR DESCRIPTION
In vanilla, event 16000 (A House Divided) has multiple `immediate` effect nodes. They need to be combined.
Third Age uses multiple `allow` nodes for a political reform. Victoria 2 simply combines them via AND.

To support this, scripts now store a vector of nodes instead of a single one.