### PR TITLE
Add AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,55 @@
+# OpenVic Simulation authors
+
+This file does not strictly reflect copyright ownership for the simulation
+source code. For this, refer to the Git history to know which contributor
+wrote which part of the codebase.
+
+GitHub usernames are indicated in parentheses, or as sole entry when no other
+name is available.
+
+Consultants have not necessarily contributed code but have contributed in other
+ways to development of the simulation.
+
+## Senior Developers
+
+    Hop311
+    George L. Albany (Spartan322)
+    BrickPi
+
+## Developers
+
+    General WVPM (wvpm)
+    Nemrav
+    zaaarf
+    Arturo
+    BetterBite
+    FarmingtonS9
+
+## Contributors
+
+    joethepro36
+    ZincLadder (ClarkeCode)
+    random person (unique-usernames-are-annoying)
+    Losethos
+    Julius
+    Gone2Daly
+    Giovanni Karra (GiovanniKarra)
+    Frédéric Van Aken
+    Conor (conboy137)
+    k0uneli
+    fxrmi (Fxrmillan)
+
+## Consultants
+
+    Spudgun
+    Catylist
+    motionsense
+    Mr_StuG
+    Manters
+    wyrm
+    Nurse_Reno
+    Dempsey
+    kiwi
+    Zombie_Freak115
+    FakeByte
+    Valerus9

--- a/SConstruct
+++ b/SConstruct
@@ -43,6 +43,19 @@ Default(
         env.Run(env.license_builder), name_prefix="sim"
     )
 )
+Default(
+    env.CommandNoCache(
+        "src/openvic-simulation/gen/author_info.gen.hpp",
+        "#AUTHORS.md",
+        env.Run(env.author_builder), name_prefix="sim",
+        sections = {
+            "Senior Developers": "AUTHORS_SENIOR_DEVELOPERS",
+            "Developers": "AUTHORS_DEVELOPERS",
+            "Contributors": "AUTHORS_CONTRIBUTORS",
+            "Consultants": "AUTHORS_CONSULTANTS"
+        }
+    )
+)
 
 # For future reference:
 # - CCFLAGS are compilation flags shared between C and C++


### PR DESCRIPTION
- Depends on #477 

Add compile-time author info generator

Reference for generated data is
```cpp
namespace OpenVic {
	static constexpr std::array<std::string_view> SIM_AUTHORS_SENIOR_DEVELOPERS;
	static constexpr std::array<std::string_view> SIM_AUTHORS_DEVELOPERS;
	static constexpr std::array<std::string_view> SIM_AUTHORS_CONTRIBUTORS;
	static constexpr std::array<std::string_view> SIM_AUTHORS_CONSULTANTS;
}
```

Note: This is not an exhaustive list of correct information, especially for consultants, if any information should be corrected or changed I would recommend contacting me, I have left any non-usernames out aside from mine even if it is identified with the email or Github account to minimize overstepping the desired boundaries. If anyone would like their proper (full or partial) name included, you can put it here. 