### PR TITLE
Support == for HasIndex using type tagging

### DIFF
--- a/src/openvic-simulation/country/CountryDefinition.hpp
+++ b/src/openvic-simulation/country/CountryDefinition.hpp
@@ -42,7 +42,7 @@ namespace OpenVic {
 	};
 
 	/* Generic information about a TAG */
-	struct CountryDefinition : HasIdentifierAndColour, HasIndex<> {
+	struct CountryDefinition : HasIdentifierAndColour, HasIndex<CountryDefinition> {
 		friend struct CountryDefinitionManager;
 
 		using unit_names_map_t = ordered_map<UnitType const*, name_list_t>;

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -309,12 +309,12 @@ void CountryInstance::set_embassy_banned_from(CountryInstance& country, Date unt
 
 bool CountryInstance::can_army_units_enter(CountryInstance const& country) const {
 	// TODO: include war allies, puppets
-	return this == &country || is_at_war_with(country) || has_military_access_to(country);
+	return *this == country || is_at_war_with(country) || has_military_access_to(country);
 }
 
 bool CountryInstance::can_navy_units_enter(CountryInstance const& country) const {
 	// TODO: include war allies, puppets
-	return this == &country || has_military_access_to(country);
+	return *this == country || has_military_access_to(country);
 }
 
 fixed_point_t CountryInstance::get_script_variable(std::string const& variable_name) const {
@@ -968,8 +968,10 @@ fixed_point_t CountryInstance::get_research_progress() const {
 
 bool CountryInstance::can_research_tech(Technology const& technology, Date today) const {
 	if (
-		technology.get_year() > today.get_year() || !is_civilised() || is_technology_unlocked(technology) ||
-		&technology == current_research
+		technology.get_year() > today.get_year()
+		|| !is_civilised()
+		|| is_technology_unlocked(technology)
+		|| (current_research && technology == *current_research)
 	) {
 		return false;
 	}

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -61,7 +61,7 @@ namespace OpenVic {
 
 	/* Representation of a country's mutable attributes, with a CountryDefinition that is unique at any single time
 	 * but can be swapped with other CountryInstance's CountryDefinition when switching tags. */
-	struct CountryInstance : FlagStrings, HasIndex<> {
+	struct CountryInstance : FlagStrings, HasIndex<CountryInstance> {
 		friend struct CountryInstanceManager;
 
 		/*

--- a/src/openvic-simulation/economy/GoodDefinition.hpp
+++ b/src/openvic-simulation/economy/GoodDefinition.hpp
@@ -30,7 +30,7 @@ namespace OpenVic {
 	 * ECON-238, ECON-239, ECON-240, ECON-241, ECON-242, ECON-243, ECON-244, ECON-245, ECON-246, ECON-247, ECON-248, ECON-249,
 	 * ECON-250, ECON-251, ECON-252, ECON-253, ECON-254, ECON-255, ECON-256, ECON-257, ECON-258, ECON-259, ECON-260, ECON-261
 	 */
-	struct GoodDefinition : HasIdentifierAndColour, HasIndex<> {
+	struct GoodDefinition : HasIdentifierAndColour, HasIndex<GoodDefinition> {
 		friend struct GoodDefinitionManager;
 
 		using good_definition_map_t = fixed_point_map_t<GoodDefinition const*>;

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -93,7 +93,7 @@ void ArtisanalProducer::artisan_tick(
 					consumed_quantity
 				);
 			}
-			if (input_good_ptr == &production_type.get_output_good()) {
+			if (*input_good_ptr == production_type.get_output_good()) {
 				if (OV_unlikely(consumed_quantity > produce_left_to_sell)) {
 					consumed_quantity -= produce_left_to_sell;
 					produce_left_to_sell = 0;

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -202,7 +202,8 @@ void ResourceGatheringOperation::hire() {
 	for (Pop& pop : location.get_mutable_pops()){
 		PopType const& pop_type = *pop.get_type();
 		for (Job const& job : jobs) {
-			if (job.get_pop_type() == &pop_type) {
+			PopType const* const job_pop_type = job.get_pop_type();
+			if (job_pop_type && *job_pop_type == pop_type) {
 				const pop_size_t pop_size_to_hire = static_cast<pop_size_t>((proportion_to_hire * pop.get_size()).floor());
 				if (pop_size_to_hire <= 0) {
 					continue;

--- a/src/openvic-simulation/history/Bookmark.hpp
+++ b/src/openvic-simulation/history/Bookmark.hpp
@@ -9,7 +9,7 @@
 namespace OpenVic {
 	struct BookmarkManager;
 
-	struct Bookmark : HasIdentifier, HasIndex<> {
+	struct Bookmark : HasIdentifier, HasIndex<Bookmark> {
 		friend struct BookmarkManager;
 
 	private:

--- a/src/openvic-simulation/history/DiplomaticHistory.cpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.cpp
@@ -258,11 +258,12 @@ bool DiplomaticHistoryManager::load_war_history_file(DefinitionManager const& de
 				"add_attacker", ZERO_OR_MORE,
 					definition_manager.get_country_definition_manager().expect_country_definition_identifier(
 						[&current_date, &name](CountryDefinition const& country) -> bool {
-							for (auto const& attacker : attackers) {
-								if (attacker.get_country() == &country) {
+							for (WarHistory::war_participant_t const& attacker : attackers) {
+								CountryDefinition const* const attacker_country = attacker.get_country();
+								if (attacker_country && *attacker_country == country) {
 									Logger::error(
 										"In history of war ", name, " at date ", current_date.to_string(),
-										": Attempted to add attacking country ", attacker.get_country()->get_identifier(),
+										": Attempted to add attacking country ", attacker_country->get_identifier(),
 										" which is already present!"
 									);
 									return false;
@@ -276,11 +277,12 @@ bool DiplomaticHistoryManager::load_war_history_file(DefinitionManager const& de
 				"add_defender", ZERO_OR_MORE,
 					definition_manager.get_country_definition_manager().expect_country_definition_identifier(
 						[&current_date, &name](CountryDefinition const& country) -> bool {
-							for (auto const& defender : defenders) {
-								if (defender.get_country() == &country) {
+							for (WarHistory::war_participant_t const& defender : defenders) {
+								CountryDefinition const* const defender_country = defender.get_country();
+								if (defender_country && *defender_country == country) {
 									Logger::error(
 										"In history of war ", name, " at date ", current_date.to_string(),
-										": Attempted to add defending country ", defender.get_country()->get_identifier(),
+										": Attempted to add defending country ", defender_country->get_identifier(),
 										" which is already present!"
 									);
 									return false;
@@ -296,8 +298,9 @@ bool DiplomaticHistoryManager::load_war_history_file(DefinitionManager const& de
 						[&current_date, &name](CountryDefinition const& country) -> bool {
 							WarHistory::war_participant_t* participant_to_remove = nullptr;
 
-							for (auto& attacker : attackers) {
-								if (attacker.country == &country) {
+							for (WarHistory::war_participant_t& attacker : attackers) {
+								CountryDefinition const* const attacker_country = attacker.get_country();
+								if (attacker_country && *attacker_country == country) {
 									participant_to_remove = &attacker;
 									break;
 								}
@@ -320,8 +323,9 @@ bool DiplomaticHistoryManager::load_war_history_file(DefinitionManager const& de
 						[&current_date, &name](CountryDefinition const& country) -> bool {
 							WarHistory::war_participant_t* participant_to_remove = nullptr;
 
-							for (auto& defender : defenders) {
-								if (defender.country == &country) {
+							for (WarHistory::war_participant_t& defender : defenders) {
+								CountryDefinition const* const defender_country = defender.get_country();
+								if (defender_country && *defender_country == country) {
 									participant_to_remove = &defender;
 									break;
 								}

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -343,7 +343,7 @@ bool MapmodeManager::setup_mapmodes() {
 				if (selected_province != nullptr) {
 					ProvinceDefinition const& selected_province_definition = selected_province->get_province_definition();
 
-					if (selected_province == &province) {
+					if (*selected_province == province) {
 						return (0xFFFFFF_argb).with_alpha(ALPHA_VALUE);
 					}
 

--- a/src/openvic-simulation/map/Mapmode.hpp
+++ b/src/openvic-simulation/map/Mapmode.hpp
@@ -12,7 +12,7 @@ namespace OpenVic {
 	struct ProvinceInstance;
 	struct CountryInstance;
 
-	struct Mapmode : HasIdentifier, HasIndex<int32_t> {
+	struct Mapmode : HasIdentifier, HasIndex<Mapmode, int32_t> {
 		friend struct MapmodeManager;
 
 		/* Bottom 32 bits are the base colour, top 32 are the stripe colour, both in ARGB format with the alpha channels

--- a/src/openvic-simulation/map/ProvinceDefinition.cpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.cpp
@@ -26,10 +26,6 @@ ProvinceDefinition::ProvinceDefinition(
 	default_terrain_type { nullptr },
 	positions {} {}
 
-bool ProvinceDefinition::operator==(ProvinceDefinition const& other) const {
-	return this == &other;
-}
-
 std::string ProvinceDefinition::to_string() const {
 	return fmt::format("(#{}, {}, 0x{})", get_index(), get_identifier(), get_colour());
 }

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -24,7 +24,7 @@ namespace OpenVic {
 	 * MAP-5, MAP-7, MAP-8, MAP-43, MAP-47
 	 * POP-22
 	 */
-	struct ProvinceDefinition : HasIdentifierAndColour, HasIndex<uint16_t> {
+	struct ProvinceDefinition : HasIdentifierAndColour, HasIndex<ProvinceDefinition, uint16_t> {
 		friend struct MapDefinition;
 
 		using distance_t = fixed_point_t; // should this go inside adjacency_t?
@@ -105,7 +105,6 @@ namespace OpenVic {
 	public:
 		ProvinceDefinition(ProvinceDefinition&&) = default;
 
-		bool operator==(ProvinceDefinition const& other) const;
 		std::string to_string() const;
 
 		inline constexpr bool has_region() const {

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -44,7 +44,7 @@ namespace OpenVic {
 	using ArmyInstance = UnitInstanceGroupBranched<UnitType::branch_t::LAND>;
 	using NavyInstance = UnitInstanceGroupBranched<UnitType::branch_t::NAVAL>;
 
-	struct ProvinceInstance : HasIdentifierAndColour, HasIndex<>, FlagStrings {
+	struct ProvinceInstance : HasIdentifierAndColour, HasIndex<ProvinceInstance>, FlagStrings {
 		friend struct MapInstance;
 
 		using life_rating_t = int8_t;

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -11,7 +11,7 @@ namespace OpenVic {
 	struct Issue;
 
 	// Issue group (i.e. trade_policy)
-	struct IssueGroup : HasIdentifier, HasIndex<> {
+	struct IssueGroup : HasIdentifier, HasIndex<IssueGroup> {
 		friend struct IssueManager;
 
 	private:

--- a/src/openvic-simulation/politics/Rule.hpp
+++ b/src/openvic-simulation/politics/Rule.hpp
@@ -8,7 +8,7 @@ namespace OpenVic {
 	struct BuildingTypeManager;
 
 	/* The index of the Rule within its group, used to determine precedence in mutually exclusive rule groups. */
-	struct Rule : HasIdentifier, HasIndex<> {
+	struct Rule : HasIdentifier, HasIndex<Rule> {
 		friend struct RuleManager;
 
 		enum class rule_group_t : uint8_t {

--- a/src/openvic-simulation/pop/PopType.cpp
+++ b/src/openvic-simulation/pop/PopType.cpp
@@ -478,7 +478,7 @@ bool PopManager::load_delayed_parse_pop_type_data(
 
 		if (promote_to_node != nullptr && !expect_pop_type_dictionary(
 			[pop_type](PopType const& type, ast::NodeCPtr node) -> bool {
-				if (pop_type == &type) {
+				if (pop_type && type == *pop_type) {
 					Logger::error("Pop type ", type, " cannot have promotion weight to itself!");
 					return false;
 				}

--- a/src/openvic-simulation/pop/PopType.hpp
+++ b/src/openvic-simulation/pop/PopType.hpp
@@ -19,7 +19,7 @@ namespace OpenVic {
 	struct IssueManager;
 	struct PopBase;
 
-	struct Strata : HasIdentifier, HasIndex<> {
+	struct Strata : HasIdentifier, HasIndex<Strata> {
 		friend struct PopManager;
 
 	private:
@@ -34,7 +34,7 @@ namespace OpenVic {
 	/* REQUIREMENTS:
 	 * POP-15, POP-16, POP-17, POP-26
 	 */
-	struct PopType : HasIdentifierAndColour, HasIndex<> {
+	struct PopType : HasIdentifierAndColour, HasIndex<PopType> {
 		friend struct PopManager;
 
 		/* This is a bitfield - PopTypes can have up to one of each income source for each need category. */

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -13,7 +13,7 @@
 namespace OpenVic {
 	struct TechnologyArea;
 
-	struct TechnologyFolder : HasIdentifier, HasIndex<> {
+	struct TechnologyFolder : HasIdentifier, HasIndex<TechnologyFolder> {
 		friend struct TechnologyManager;
 
 	private:
@@ -41,7 +41,7 @@ namespace OpenVic {
 		TechnologyArea(TechnologyArea&&) = default;
 	};
 
-	struct Technology : Modifier, HasIndex<> {
+	struct Technology : Modifier, HasIndex<Technology> {
 		friend struct TechnologyManager;
 
 		using area_index_t = uint8_t;

--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -105,11 +105,10 @@ namespace OpenVic {
 	template<typename T>
 	concept HasGetIdentifierAndGetColour = HasGetIdentifier<T> && HasGetColour<T>;
 
-	template<std::integral T = size_t>
+	template<typename TypeTag, std::integral IndexT = size_t>
 	class HasIndex {
 	public:
-		using index_t = T;
-
+		using index_t = IndexT;
 	private:
 		const index_t PROPERTY(index);
 
@@ -121,6 +120,9 @@ namespace OpenVic {
 		HasIndex(HasIndex&&) = default;
 		HasIndex& operator=(HasIndex const&) = delete;
 		HasIndex& operator=(HasIndex&&) = delete;
+		constexpr bool operator==(HasIndex const& rhs) const {
+			return index == rhs.index;
+		}
 	};
 
 	template<typename T>


### PR DESCRIPTION
Before there was no way to use `==` with 2 references.
The developer had to decide whether to convert both to pointers or compare their indices (or their identifiers (if applicable)).
While comparing the pointers works and so far is the standard, support `==` directly using the indices is easier to use and still correct. Index + type is unique.

This does require tagging HasIndex with the type for context.