### PR TITLE
Fix log scope duplicated symbol error with clang

### DIFF
--- a/src/openvic-simulation/utility/Logger.cpp
+++ b/src/openvic-simulation/utility/Logger.cpp
@@ -1,0 +1,6 @@
+#include "Logger.hpp"
+
+using namespace OpenVic;
+
+thread_local std::vector<std::string_view> Logger::log_scope_stack {};
+thread_local size_t Logger::log_scope_index_plus_one = 0;

--- a/src/openvic-simulation/utility/Logger.hpp
+++ b/src/openvic-simulation/utility/Logger.hpp
@@ -69,8 +69,8 @@ namespace OpenVic {
 		};
 
 		static inline std::mutex log_mutex;
-		thread_local inline static std::vector<std::string_view> log_scope_stack {};
-		thread_local inline static size_t log_scope_index_plus_one = 0;
+		static thread_local std::vector<std::string_view> log_scope_stack;
+		static thread_local size_t log_scope_index_plus_one;
 
 		template<typename... Args>
 		struct log {


### PR DESCRIPTION
Fixes `ld: warning: duplicate symbol 'thread-local initialization routine for OpenVic::Logger::log_scope_stack'` issue when building on macOS with Clang 17.