### PR TITLE
Added get_strata_taxable_income to CountryInstance

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -373,6 +373,17 @@ fixed_point_t CountryInstance::get_religion_proportion(Religion const& religion)
 	}
 }
 
+fixed_point_t CountryInstance::get_strata_taxable_income(Strata const& strata) const {
+	fixed_point_t running_total = 0;
+	for (auto const& [pop_type, taxable_income] : taxable_income_by_pop_type) {
+		if (pop_type.get_strata() == strata) {
+			running_total += taxable_income;
+		}
+	}
+	
+	return running_total;
+}
+
 #define ADD_AND_REMOVE(item) \
 	bool CountryInstance::add_##item(std::remove_pointer_t<decltype(item##s)::value_type>& new_item) { \
 		if (!item##s.emplace(&new_item).second) { \

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -496,6 +496,7 @@ namespace OpenVic {
 		constexpr fixed_point_t get_strata_luxury_needs_fulfilled(Strata const& strata) const {
 			return luxury_needs_fulfilled_by_strata[strata];
 		}
+		fixed_point_t get_strata_taxable_income(Strata const& strata) const;
 
 		bool add_owned_province(ProvinceInstance& new_province);
 		bool remove_owned_province(ProvinceInstance const& province_to_remove);


### PR DESCRIPTION
The budget menu requires taxable income per strata for the projected tax income.
CountryInstance stores taxable income per pop type. A simple filtered sum should suffice.