### PR TITLE
Round fixed_point_t to int away from zero

### DIFF
--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -200,6 +200,19 @@ namespace OpenVic {
 			return static_cast<int32_t>(to_int64_t());
 		}
 
+		//away from zero
+		constexpr int64_t to_int64_t_rounded() const {
+			const fixed_point_t fp = *this;
+			if (fp >= 0) {
+				return (fp + _0_50).value >> PRECISION;
+			} else {
+				return (fp - _0_50).value >> PRECISION;
+			}
+		}
+		constexpr int32_t to_int32_t_rounded() const {
+			return static_cast<int32_t>(to_int64_t_rounded());
+		}
+
 		template<std::integral T>
 		constexpr T to() const {
 			return static_cast<T>(to_int64_t());

--- a/tests/src/types/FixedPoint.cpp
+++ b/tests/src/types/FixedPoint.cpp
@@ -99,6 +99,20 @@ TEST_CASE("fixed_point_t Rounding methods", "[fixed_point_t][fixed_point_t-round
 	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(5) == 5);
 	CONSTEXPR_CHECK(_2_55.round_down_to_multiple(fixed_point_t::_0_25) == 2.50_a);
 	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(fixed_point_t::_1_50) == 3);
+
+	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).to_int32_t_rounded() == 0);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50.to_int32_t_rounded() == 1);
+	CONSTEXPR_CHECK((-fixed_point_t::_0_50).to_int32_t_rounded() == -1);
+	CONSTEXPR_CHECK(fixed_point_t::_1_50.to_int32_t_rounded() == 2);
+	CONSTEXPR_CHECK((-fixed_point_t::_1_50).to_int32_t_rounded() == -2);
+	CONSTEXPR_CHECK(_2_55.to_int32_t_rounded() == 3);
+
+	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).to_int64_t_rounded() == 0);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50.to_int64_t_rounded() == 1);
+	CONSTEXPR_CHECK((-fixed_point_t::_0_50).to_int64_t_rounded() == -1);
+	CONSTEXPR_CHECK(fixed_point_t::_1_50.to_int64_t_rounded() == 2);
+	CONSTEXPR_CHECK((-fixed_point_t::_1_50).to_int64_t_rounded() == -2);
+	CONSTEXPR_CHECK(_2_55.to_int64_t_rounded() == 3);
 }
 
 TEST_CASE("fixed_point_t Parse methods", "[fixed_point_t][fixed_point_t-parse]") {


### PR DESCRIPTION
fixed_point_t only supported truncating to int32_t and int64_t.
Rounding before truncating could be done via explicit `floor()` or `ceil()`.

This PR just adds `to_int64_t_rounded()` which rounds away from zero.
There is also a `to_int32_t_rounded()` which merely casts the int64 to int32.