### PR TITLE
Improve invalid key message in history

### DIFF
--- a/src/openvic-simulation/history/CountryHistory.cpp
+++ b/src/openvic-simulation/history/CountryHistory.cpp
@@ -71,9 +71,17 @@ bool CountryHistoryMap::_load_history_entry(
 		};
 	};
 
-	return expect_dictionary_keys_and_default(
-		[this, &definition_manager, &dataloader, &deployment_manager, &issue_manager, &technology_manager, &invention_manager,
-			&country_definition_manager, &entry](std::string_view key, ast::NodeCPtr value) -> bool {
+	return expect_dictionary_keys_and_default_map(
+		[
+			this, &definition_manager, &dataloader,
+			&deployment_manager, &issue_manager,
+			&technology_manager, &invention_manager,
+			&country_definition_manager, &entry
+		](
+			template_key_map_t<StringMapCaseSensitive> const& key_map,
+			std::string_view key,
+			ast::NodeCPtr value
+		) -> bool {
 			ReformGroup const* reform_group = issue_manager.get_reform_group_by_identifier(key);
 			if (reform_group != nullptr) {
 				return issue_manager.expect_reform_identifier([&entry, reform_group](Reform const& reform) -> bool {
@@ -112,7 +120,7 @@ bool CountryHistoryMap::_load_history_entry(
 			}
 
 			return _load_history_sub_entry_callback(
-				definition_manager, dataloader, deployment_manager, entry.get_date(), value, key, value
+				definition_manager, dataloader, deployment_manager, entry.get_date(), value, key_map, key, value
 			);
 		},
 		"capital", ZERO_OR_ONE, definition_manager.get_map_definition().expect_province_definition_identifier(

--- a/src/openvic-simulation/history/HistoryMap.hpp
+++ b/src/openvic-simulation/history/HistoryMap.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <system_error>
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"
@@ -60,8 +59,13 @@ namespace OpenVic {
 		}
 
 		bool _load_history_sub_entry_callback(
-			DefinitionManager const& definition_manager, Args... args, Date date, ast::NodeCPtr root, std::string_view key,
-			ast::NodeCPtr value, NodeTools::key_value_callback_t default_callback = NodeTools::key_value_invalid_callback
+			DefinitionManager const& definition_manager,
+			Args... args,
+			Date date,
+			ast::NodeCPtr root,
+			NodeTools::template_key_map_t<StringMapCaseSensitive> const& key_map,
+			std::string_view key,
+			ast::NodeCPtr value
 		) {
 			/* Date blocks (loaded into the corresponding HistoryEntry) */
 			Date::from_chars_result result;
@@ -80,8 +84,8 @@ namespace OpenVic {
 					return false;
 				}
 			}
-
-			return default_callback(key, value);
+			
+			return NodeTools::map_key_value_invalid_callback<NodeTools::template_key_map_t<StringMapCaseSensitive>>(key_map, key, value);
 		}
 
 		/* Returns history entry at specific date, if date doesn't have an entry creates one, if that fails returns nullptr. */

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -64,9 +64,12 @@ bool ProvinceHistoryMap::_load_history_entry(
 	constexpr bool allow_empty_true = true;
 	constexpr bool do_warn = true;
 
-	return expect_dictionary_keys_and_default(
+	return expect_dictionary_keys_and_default_map(
 		[this, &definition_manager, &building_type_manager, &entry](
-			std::string_view key, ast::NodeCPtr value) -> bool {
+			template_key_map_t<StringMapCaseSensitive> const& key_map,
+			std::string_view key,
+			ast::NodeCPtr value
+		) -> bool {
 			// used for province buildings like forts or railroads
 			BuildingType const* building_type = building_type_manager.get_building_type_by_identifier(key);
 			if (building_type != nullptr) {
@@ -85,7 +88,7 @@ bool ProvinceHistoryMap::_load_history_entry(
 				}
 			}
 
-			return _load_history_sub_entry_callback(definition_manager, entry.get_date(), value, key, value);
+			return _load_history_sub_entry_callback(definition_manager, entry.get_date(), value, key_map, key, value);
 		},
 		"owner", ZERO_OR_ONE, country_definition_manager.expect_country_definition_identifier(
 			assign_variable_callback_pointer_opt(entry.owner, true)


### PR DESCRIPTION
```
Invalid dictionary key "civilised". Valid values are [capital, primary_culture, culture, remove_culture, religion, government, plurality, nationalvalue, civilized, prestige, ruling_party, 
last_election, upper_house, oob, schools, foreign_investment, literacy, non_state_culture_literacy, consciousness, nonstate_consciousness, is_releasable_vassal, decision, govt_flag, colonial_points, set_country_flag, 
clr_country_flag, set_global_flag, clr_global_flag]
```

Instead of `Invalid dictionary key "civilised".` only.