### PR TITLE
Ignore foonathan/memory gen files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,4 @@
 [submodule "deps/memory"]
 	path = deps/memory
 	url = https://github.com/foonathan/memory
+	ignore = dirty


### PR DESCRIPTION
foonathan/memory has an incomplete .gitignore and marks generated files as dirty.
The generated files marked as dirty:
- include/foonathan/memory/config_impl.hpp
- include/foonathan/memory/detail/container_node_sizes_impl.hpp
- *.obj

This PR ignores all changes in that submodule.