### PR TITLE
Use index from HasIndex in IndexedMap

### DIFF
--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <string>
 #include <string_view>
 #include <ostream>
 
@@ -104,29 +103,4 @@ namespace OpenVic {
 
 	template<typename T>
 	concept HasGetIdentifierAndGetColour = HasGetIdentifier<T> && HasGetColour<T>;
-
-	template<typename TypeTag, std::integral IndexT = size_t>
-	class HasIndex {
-	public:
-		using index_t = IndexT;
-	private:
-		const index_t PROPERTY(index);
-
-	protected:
-		HasIndex(index_t new_index) : index { new_index } {}
-		HasIndex(HasIndex const&) = default;
-
-	public:
-		HasIndex(HasIndex&&) = default;
-		HasIndex& operator=(HasIndex const&) = delete;
-		HasIndex& operator=(HasIndex&&) = delete;
-		constexpr bool operator==(HasIndex const& rhs) const {
-			return index == rhs.index;
-		}
-	};
-
-	template<typename T>
-	concept HasGetIndex = requires(T const& t) {
-		{ t.get_index() } -> std::integral;
-	};
 }

--- a/src/openvic-simulation/types/HasIndex.hpp
+++ b/src/openvic-simulation/types/HasIndex.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <concepts>
+
+#include "openvic-simulation/utility/Getters.hpp"
+
+namespace OpenVic {
+	template<typename TypeTag, std::integral IndexT = size_t>
+	class HasIndex {
+	public:
+		using index_t = IndexT;
+	private:
+		const index_t PROPERTY(index);
+
+	protected:
+		HasIndex(index_t new_index) : index { new_index } {}
+		HasIndex(HasIndex const&) = default;
+
+	public:
+		HasIndex(HasIndex&&) = default;
+		HasIndex& operator=(HasIndex const&) = delete;
+		HasIndex& operator=(HasIndex&&) = delete;
+		constexpr bool operator==(HasIndex const& rhs) const {
+			return index == rhs.index;
+		}
+	};
+}

--- a/src/openvic-simulation/types/IndexedMap.hpp
+++ b/src/openvic-simulation/types/IndexedMap.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <concepts>
-#include <vector>
 
 #include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
+#include "openvic-simulation/types/HasIndex.hpp"
 #include "openvic-simulation/utility/ForwardableSpan.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
@@ -310,10 +310,14 @@ namespace OpenVic {
 		}
 
 		constexpr size_t get_index_from_item(key_ref_type key) const {
-			if (has_keys() && keys.data() <= &key && &key <= &keys.back()) {
-				return std::distance(keys.data(), &key);
+			if constexpr (utility::is_derived_from_specialization_of<Key, HasIndex>) {
+				return key.get_index();
 			} else {
-				return 0;
+				if (has_keys() && keys.data() <= &key && &key <= &keys.back()) {
+					return std::distance(keys.data(), &key);
+				} else {
+					return 0;
+				}
 			}
 		}
 


### PR DESCRIPTION
IndexedMap searches for an item to get the index.
If the item inherits from HasIndex, it has a `get_index()` method which should be used instead.
This is faster than searching.