### PR TITLE
Subtract expenses from cash_stockpile in country_tick_before_map

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1883,6 +1883,15 @@ void CountryInstance::country_tick_before_map(InstanceManager& instance_manager)
 		actual_net_tariffs = 0;
 	}
 	taxable_income_by_pop_type.fill(0);
+	const fixed_point_t total_expenses = actual_import_subsidies
+		+ actual_administration_spending
+		+ actual_education_spending
+		+ actual_military_spending
+		+ actual_social_spending;
+		//TODO: + factory subsidies
+		//TODO: + interest
+		//TODO: + diplomatic costs
+	cash_stockpile -= total_expenses;
 }
 
 void CountryInstance::country_tick_after_map(InstanceManager& instance_manager) {


### PR DESCRIPTION
Expenses didn't impact the `cash_stockpile` of a country. The code was simply never implemented.
This PR subtracts expenses from cash_stockpile in `country_tick_before_map`.

An alternative implementation is to subtract it per pop in `request_salaries_and_welfare_and_import_subsidies`.
Since `cash_stockpile` is a `moveable_atomic_fixed_point_t` and that method would be executed per pop, that would result in significantly more overhead. The benefit from that approach would be subtracting the exact costs per pop.

The approach of this PR has the downside of letting the country pay for rounding errors.
Pop salaries, welfare & import subsidies are truncated. The differences should be minimal and acceptable.