### PR TITLE
Use IndexedMap for HasIndex types

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -170,6 +170,7 @@ bool InstanceManager::setup() {
 		definition_manager.get_military_manager().get_unit_type_manager().get_regiment_types(),
 		definition_manager.get_military_manager().get_unit_type_manager().get_ship_types(),
 		definition_manager.get_pop_manager().get_stratas(),
+		country_instance_manager.get_country_definition_manager().get_country_definitions(),
 		game_rules_manager,
 		country_relation_manager,
 		good_instance_manager,
@@ -181,6 +182,7 @@ bool InstanceManager::setup() {
 		definition_manager.get_define_manager().get_pops_defines(),
 		country_instance_manager.get_country_instances(),
 		definition_manager.get_pop_manager().get_stratas(),
+		good_instance_manager.get_good_definition_manager().get_good_definitions(),
 		good_instance_manager.get_good_instances(),
 		map_instance.get_province_instances()
 	);
@@ -222,6 +224,7 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 		country_instance_manager,
 		// TODO - the following argument is for generating test pop attributes
 		definition_manager.get_politics_manager().get_issue_manager(),
+		good_instance_manager.get_good_definition_manager().get_good_definitions(),
 		market_instance,
 		artisanal_producer_factory_pattern
 	);

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -134,7 +134,7 @@ namespace OpenVic {
 		memory::vector<std::pair<State const*, fixed_point_t>> PROPERTY(industrial_power_from_states);
 		memory::vector<std::pair<CountryInstance const*, fixed_point_t>> PROPERTY(industrial_power_from_investments);
 		size_t PROPERTY(industrial_rank, 0);
-		fixed_point_map_t<CountryInstance const*> PROPERTY(foreign_investments);
+		IndexedMap<CountryDefinition, fixed_point_t> PROPERTY(foreign_investments);
 		IndexedMap<BuildingType, unlock_level_t> PROPERTY(building_type_unlock_levels);
 		// TODO - total amount of each good produced
 
@@ -199,7 +199,7 @@ namespace OpenVic {
 		Date PROPERTY(expected_research_completion_date);
 		fixed_point_t PROPERTY(research_point_stockpile);
 		fixed_point_t PROPERTY(daily_research_points);
-		fixed_point_map_t<PopType const*> PROPERTY(research_points_from_pop_types);
+		IndexedMap<PopType, fixed_point_t> PROPERTY(research_points_from_pop_types);
 		fixed_point_t PROPERTY(national_literacy);
 		TechnologySchool const* PROPERTY(tech_school, nullptr);
 		// TODO - cached possible inventions with %age chance
@@ -316,7 +316,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(max_ship_supply);
 		fixed_point_t PROPERTY_RW(leadership_point_stockpile);
 		fixed_point_t PROPERTY(monthly_leadership_points);
-		fixed_point_map_t<PopType const*> PROPERTY(leadership_points_from_pop_types);
+		IndexedMap<PopType, fixed_point_t> PROPERTY(leadership_points_from_pop_types);
 		int32_t PROPERTY(create_leader_count, 0);
 		// War exhaustion is stored as a raw decimal rather than a proportion, it is usually in the range 0-100.
 		// The current war exhaustion value should only ever be modified via change_war_exhaustion(delta) which also
@@ -358,6 +358,7 @@ namespace OpenVic {
 			decltype(regiment_type_unlock_levels)::keys_span_type regiment_type_unlock_levels_keys,
 			decltype(ship_type_unlock_levels)::keys_span_type ship_type_unlock_levels_keys,
 			decltype(tax_rate_slider_value_by_strata)::keys_span_type strata_keys,
+			decltype(foreign_investments)::keys_span_type country_definition_keys,
 			GameRulesManager const& new_game_rules_manager,
 			CountryRelationManager& new_country_relations_manager,
 			SharedCountryValues const& new_shared_country_values,
@@ -606,15 +607,15 @@ namespace OpenVic {
 		void start_research(Technology const& technology, InstanceManager const& instance_manager);
 
 		// Sets the investment of each country in the map (rather than adding to them), leaving the rest unchanged.
-		void apply_foreign_investments(
-			fixed_point_map_t<CountryDefinition const*> const& investments,
-			CountryInstanceManager const& country_instance_manager
-		);
+		void apply_foreign_investments(IndexedMap<CountryDefinition, fixed_point_t> const& investments);
 
 		bool apply_history_to_country(CountryHistoryEntry const& entry, InstanceManager& instance_manager);
 
 	private:
-		void _update_production(DefineManager const& define_manager);
+		void _update_production(
+			CountryInstanceManager const& country_instance_manager,
+			DefineManager const& define_manager
+		);
 		void _update_effective_tax_rate_by_strata(Strata const& strata);
 		void _update_budget();
 
@@ -749,6 +750,7 @@ namespace OpenVic {
 			decltype(CountryInstance::regiment_type_unlock_levels)::keys_span_type regiment_type_unlock_levels_keys,
 			decltype(CountryInstance::ship_type_unlock_levels)::keys_span_type ship_type_unlock_levels_keys,
 			decltype(CountryInstance::tax_rate_slider_value_by_strata):: keys_span_type strata_keys,
+			decltype(CountryInstance::foreign_investments)::keys_span_type country_definition_keys,
 			GameRulesManager const& game_rules_manager,
 			CountryRelationManager& country_relations_manager,
 			GoodInstanceManager& good_instance_manager,

--- a/src/openvic-simulation/country/SharedCountryValues.cpp
+++ b/src/openvic-simulation/country/SharedCountryValues.cpp
@@ -31,8 +31,8 @@ void SharedPopTypeValues::update_costs(PopType const& pop_type, PopsDefines cons
 
 	#define UPDATE_NEED_COSTS(need_category) \
 		base_##need_category##_need_costs = 0; \
-		for (auto const& [good_definition_ptr, quantity] : pop_type.get_##need_category##_needs()) { \
-			GoodInstance const& good_instance = good_instance_manager.get_good_instance_from_definition(*good_definition_ptr); \
+		for (auto const& [good_definition, quantity] : pop_type.get_##need_category##_needs()) { \
+			GoodInstance const& good_instance = good_instance_manager.get_good_instance_from_definition(good_definition); \
 			base_##need_category##_need_costs += good_instance.get_price() * quantity; \
 		} \
 		base_##need_category##_need_costs *= pop_defines.get_base_goods_demand(); \

--- a/src/openvic-simulation/economy/GoodDefinition.hpp
+++ b/src/openvic-simulation/economy/GoodDefinition.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
+#include "openvic-simulation/types/IndexedMap.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
@@ -34,7 +36,7 @@ namespace OpenVic {
 	struct GoodDefinition : HasIdentifierAndColour, HasIndex<GoodDefinition> {
 		friend struct GoodDefinitionManager;
 
-		using good_definition_map_t = fixed_point_map_t<GoodDefinition const*>;
+		using good_definition_map_t = IndexedMap<GoodDefinition, fixed_point_t>;
 
 	private:
 		GoodCategory const& PROPERTY(category);

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -1,6 +1,9 @@
 #include "ArtisanalProducer.hpp"
+
+#include <cstddef>
 #include <cstdint>
 
+#include "openvic-simulation/economy/GoodDefinition.hpp"
 #include "openvic-simulation/economy/production/ProductionType.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/modifier/ModifierEffectCache.hpp"
@@ -17,10 +20,9 @@ ArtisanalProducer::ArtisanalProducer(
 ) : modifier_effect_cache { new_modifier_effect_cache },
 	stockpile { std::move(new_stockpile) },
 	production_type { new_production_type },
-	current_production { new_current_production }
-	{
-		max_quantity_to_buy_per_good.reserve(new_production_type.get_input_goods().size());
-	}
+	current_production { new_current_production },
+	max_quantity_to_buy_per_good { new_production_type.get_input_goods().get_keys() }
+	{ }
 
 void ArtisanalProducer::artisan_tick(
 	Pop& pop,
@@ -39,8 +41,8 @@ void ArtisanalProducer::artisan_tick(
 	fixed_point_t inputs_bought_fraction = 1,
 		inputs_bought_numerator= 1,
 		inputs_bought_denominator= 1;
-	for (auto const& [input_good_ptr, base_desired_quantity] : production_type.get_input_goods()) {
-		const fixed_point_t desired_quantity = demand[input_good_ptr] = base_desired_quantity * pop.get_size() / production_type.get_base_workforce_size();
+	for (auto const& [input_good, base_desired_quantity] : production_type.get_input_goods()) {
+		const fixed_point_t desired_quantity = demand[input_good] = base_desired_quantity * pop.get_size() / production_type.get_base_workforce_size();
 		if (desired_quantity == fixed_point_t::_0) {
 			continue;
 		}
@@ -48,12 +50,12 @@ void ArtisanalProducer::artisan_tick(
 		if (country_to_report_economy_nullable != nullptr) {
 			country_to_report_economy_nullable->report_input_demand(
 				production_type,
-				*input_good_ptr,
+				input_good,
 				desired_quantity
 			);
 		}
 
-		const fixed_point_t stockpiled_quantity = stockpile[input_good_ptr];
+		const fixed_point_t stockpiled_quantity = stockpile[input_good];
 		const fixed_point_t good_bought_fraction = stockpiled_quantity / desired_quantity;
 		if (good_bought_fraction < inputs_bought_fraction) {
 			inputs_bought_fraction = good_bought_fraction;
@@ -61,7 +63,7 @@ void ArtisanalProducer::artisan_tick(
 			inputs_bought_denominator = desired_quantity;
 		}
 
-		goods_to_buy_and_max_price[input_good_ptr] = pop.get_market_instance().get_max_next_price(*input_good_ptr);
+		goods_to_buy_and_max_price[input_good] = pop.get_market_instance().get_max_next_price(input_good);
 	}
 
 	//Produce output
@@ -76,9 +78,9 @@ void ArtisanalProducer::artisan_tick(
 	}
 
 	if (inputs_bought_fraction > fixed_point_t::_0) {
-		for (auto const& [input_good_ptr, base_desired_quantity] : production_type.get_input_goods()) {
-			const fixed_point_t desired_quantity = demand[input_good_ptr];
-			fixed_point_t& good_stockpile = stockpile[input_good_ptr];
+		for (auto const& [input_good, base_desired_quantity] : production_type.get_input_goods()) {
+			const fixed_point_t desired_quantity = demand[input_good];
+			fixed_point_t& good_stockpile = stockpile[input_good];
 
 			//Consume input good
 			fixed_point_t consumed_quantity = fixed_point_t::mul_div(
@@ -89,11 +91,11 @@ void ArtisanalProducer::artisan_tick(
 			if (country_to_report_economy_nullable != nullptr) {
 				country_to_report_economy_nullable->report_input_consumption(
 					production_type,
-					*input_good_ptr,
+					input_good,
 					consumed_quantity
 				);
 			}
-			if (*input_good_ptr == production_type.get_output_good()) {
+			if (input_good == production_type.get_output_good()) {
 				if (OV_unlikely(consumed_quantity > produce_left_to_sell)) {
 					consumed_quantity -= produce_left_to_sell;
 					produce_left_to_sell = 0;
@@ -107,10 +109,6 @@ void ArtisanalProducer::artisan_tick(
 				fixed_point_t::_0,
 				good_stockpile - consumed_quantity
 			);
-
-			if (good_stockpile >= desired_quantity) {
-				goods_to_buy_and_max_price.erase(input_good_ptr);
-			}
 		}
 	}
 
@@ -118,7 +116,7 @@ void ArtisanalProducer::artisan_tick(
 	const fixed_point_t total_cash_to_spend = pop.get_cash().get_copy_of_value() / max_cost_multiplier;
 	MarketInstance const& market_instance = pop.get_market_instance();
 
-	if (total_cash_to_spend > fixed_point_t::_0 && !goods_to_buy_and_max_price.empty()) {
+	if (total_cash_to_spend > fixed_point_t::_0) {
 		//Figure out the optimal amount of goods to buy based on their price, stockpiled quantiy & demand
 		fixed_point_t max_possible_satisfaction_numerator= 1,
 			max_possible_satisfaction_denominator= 1;
@@ -128,17 +126,25 @@ void ArtisanalProducer::artisan_tick(
 			at_or_below_optimum = true;
 			fixed_point_t total_demand_value = 0;
 			fixed_point_t total_stockpile_value = 0;
-			for (auto const& [input_good_ptr, max_price] : goods_to_buy_and_max_price) {
-				total_demand_value += max_price * demand[input_good_ptr];
-				total_stockpile_value += max_price * stockpile[input_good_ptr];
+			size_t goods_with_demand_count = 0;
+			for (auto const& [input_good, demand_quantity] : demand) {
+				const fixed_point_t stockpiled_quantity = stockpile[input_good];
+				if (demand_quantity <= stockpiled_quantity) {
+					continue;
+				}
+
+				goods_with_demand_count++;
+				const fixed_point_t max_price = goods_to_buy_and_max_price[input_good];
+				total_demand_value += max_price * demand_quantity;
+				total_stockpile_value += max_price * stockpiled_quantity;
 			}
 
-			if ( total_demand_value == fixed_point_t::_0) {
+			if (total_demand_value == fixed_point_t::_0) {
 				max_possible_satisfaction_numerator = 1;
 				max_possible_satisfaction_denominator = 1;
 			} else {
 				//epsilon is the minimum costs for a trade.
-				const fixed_point_t flat_costs = fixed_point_t::epsilon * static_cast<int32_t>(goods_to_buy_and_max_price.size());
+				const fixed_point_t flat_costs = fixed_point_t::epsilon * static_cast<int32_t>(goods_with_demand_count);
 				max_possible_satisfaction_numerator = total_stockpile_value + total_cash_to_spend - flat_costs;
 				max_possible_satisfaction_denominator = total_demand_value + flat_costs;
 				if (max_possible_satisfaction_numerator >= max_possible_satisfaction_denominator) {
@@ -147,49 +153,48 @@ void ArtisanalProducer::artisan_tick(
 				}
 			}
 
-			erase_if(goods_to_buy_and_max_price, [
-				this,
-				&demand,
-				&at_or_below_optimum,
-				max_possible_satisfaction_numerator,
-				max_possible_satisfaction_denominator
-			](auto const& pair)->bool {
-				GoodDefinition const* const input_good_ptr = pair.first;
+			for (auto const& [input_good, demand_quantity] : demand) {
+				if (demand_quantity <= 0) {
+					continue;
+				}
+
 				const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
-					demand[input_good_ptr],
+					demand_quantity,
 					max_possible_satisfaction_numerator,
 					max_possible_satisfaction_denominator
 				);
-				if (stockpile[input_good_ptr] < optimal_quantity) {
-					return false;
+
+				if (stockpile[input_good] >= optimal_quantity) {
+					at_or_below_optimum = false;
+					break;
 				}
-				at_or_below_optimum = false;
-				return true;
-			});
+			}
 		}
 
 		fixed_point_t debug_cash_left = total_cash_to_spend;
 		//Place buy orders for each input
-		for (auto const& [input_good_ptr, _] : goods_to_buy_and_max_price) {
-			const fixed_point_t good_demand = demand[input_good_ptr];
-			fixed_point_t& good_stockpile = stockpile[input_good_ptr];
+		for (auto const& [input_good, _] : goods_to_buy_and_max_price) {
+			const fixed_point_t good_demand = demand[input_good];
+			fixed_point_t& good_stockpile = stockpile[input_good];
 			const fixed_point_t max_quantity_to_buy = good_demand - good_stockpile;
-			if (max_quantity_to_buy > fixed_point_t::_0) {
-				const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
-					good_demand,
-					max_possible_satisfaction_numerator,
-					max_possible_satisfaction_denominator
-				);
-				const fixed_point_t money_to_spend = market_instance.get_max_money_to_allocate_to_buy_quantity(
-					*input_good_ptr,
-					optimal_quantity - good_stockpile
-				);
-				max_quantity_to_buy_per_good[input_good_ptr] = max_quantity_to_buy;
-				pop.allocate_cash_for_artisanal_spending(money_to_spend);
-				pop_max_quantity_to_buy_per_good[input_good_ptr] += max_quantity_to_buy;
-				pop_money_to_spend_per_good[input_good_ptr] += money_to_spend;
-				debug_cash_left -= money_to_spend;
+			if (max_quantity_to_buy <= fixed_point_t::_0) {
+				continue;
 			}
+
+			const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
+				good_demand,
+				max_possible_satisfaction_numerator,
+				max_possible_satisfaction_denominator
+			);
+			const fixed_point_t money_to_spend = market_instance.get_max_money_to_allocate_to_buy_quantity(
+				input_good,
+				optimal_quantity - good_stockpile
+			);
+			max_quantity_to_buy_per_good[input_good] = max_quantity_to_buy;
+			pop.allocate_cash_for_artisanal_spending(money_to_spend);
+			pop_max_quantity_to_buy_per_good[input_good] += max_quantity_to_buy;
+			pop_money_to_spend_per_good[input_good] += money_to_spend;
+			debug_cash_left -= money_to_spend;
 		}
 
 		if (OV_unlikely(debug_cash_left < fixed_point_t::_0)) {
@@ -208,14 +213,13 @@ fixed_point_t ArtisanalProducer::add_to_stockpile(GoodDefinition const& good, co
 		return 0;
 	}
 
-	auto it = max_quantity_to_buy_per_good.find(&good);
-	if (it == max_quantity_to_buy_per_good.end()) {
+	fixed_point_t& max_quantity_to_buy = max_quantity_to_buy_per_good[good];
+	if (max_quantity_to_buy == 0) {
 		return 0;
 	}
 
-	fixed_point_t& max_quantity_to_buy = it.value();
 	const fixed_point_t quantity_added_to_stockpile = std::min(quantity, max_quantity_to_buy);
-	stockpile.at(&good) += quantity_added_to_stockpile;
+	stockpile[good] += quantity_added_to_stockpile;
 	max_quantity_to_buy -= quantity_added_to_stockpile;
 	return quantity_added_to_stockpile;
 }

--- a/src/openvic-simulation/economy/production/ArtisanalProducerFactoryPattern.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducerFactoryPattern.cpp
@@ -28,7 +28,7 @@ memory::unique_ptr<ArtisanalProducer> ArtisanalProducerFactoryPattern::CreateNew
 
 	return memory::make_unique<ArtisanalProducer>(
 		modifier_effect_cache,
-		GoodDefinition::good_definition_map_t{},
+		GoodDefinition::good_definition_map_t{ good_instance_manager.get_good_definition_manager().get_good_definitions() },
 		*random_artisanal_production_type,
 		0
 	);

--- a/src/openvic-simulation/economy/production/ArtisanalProducerFactoryPattern.hpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducerFactoryPattern.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 
 #include "openvic-simulation/economy/production/ArtisanalProducer.hpp"
 #include "openvic-simulation/economy/production/ProductionType.hpp"

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -7,7 +7,6 @@
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
-#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
@@ -49,7 +48,7 @@ namespace OpenVic {
 		std::optional<TechnologySchool const*> PROPERTY(tech_school);
 		ordered_map<Technology const*, CountryInstance::unlock_level_t> PROPERTY(technologies);
 		ordered_map<Invention const*, bool> PROPERTY(inventions);
-		fixed_point_map_t<CountryDefinition const*> PROPERTY(foreign_investment);
+		IndexedMap<CountryDefinition, fixed_point_t> PROPERTY(foreign_investment);
 		std::optional<fixed_point_t> PROPERTY(consciousness);
 		std::optional<fixed_point_t> PROPERTY(nonstate_consciousness);
 		std::optional<fixed_point_t> PROPERTY(literacy);

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -96,6 +96,7 @@ bool MapInstance::apply_history_to_provinces(
 	const Date date,
 	CountryInstanceManager& country_manager,
 	IssueManager const& issue_manager,
+	utility::forwardable_span<const GoodDefinition> good_definition_keys,
 	MarketInstance& market_instance,
 	ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 ) {
@@ -134,6 +135,7 @@ bool MapInstance::apply_history_to_provinces(
 				} else {
 					ret &= province.add_pop_vec(
 						pop_history_entry->get_pops(),
+						good_definition_keys,
 						market_instance,
 						artisanal_producer_factory_pattern
 					);

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -71,6 +71,7 @@ namespace OpenVic {
 			const Date date,
 			CountryInstanceManager& country_manager,
 			IssueManager const& issue_manager,
+			utility::forwardable_span<const GoodDefinition> good_definition_keys,
 			MarketInstance& market_instance,
 			ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 		);

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -221,6 +221,7 @@ bool ProvinceInstance::add_pop(Pop&& pop) {
 
 bool ProvinceInstance::add_pop_vec(
 	std::span<const PopBase> pop_vec,
+	utility::forwardable_span<const GoodDefinition> good_definition_keys,
 	MarketInstance& market_instance,
 	ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 ) {
@@ -230,6 +231,7 @@ bool ProvinceInstance::add_pop_vec(
 			_add_pop(Pop {
 				pop,
 				ideology_distribution.get_keys(),
+				good_definition_keys,
 				market_instance,
 				artisanal_producer_factory_pattern
 			});

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -227,6 +227,7 @@ namespace OpenVic {
 		bool add_pop(Pop&& pop);
 		bool add_pop_vec(
 			std::span<const PopBase> pop_vec,
+			utility::forwardable_span<const GoodDefinition> good_definition_keys,
 			MarketInstance& market_instance,
 			ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 		);

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -23,8 +23,8 @@ NationalFocus::NationalFocus(
 	Ideology const* new_loyalty_ideology,
 	fixed_point_t new_loyalty_value,
 	fixed_point_t new_encourage_railroads,
-	fixed_point_map_t<GoodDefinition const*>&& new_encourage_goods,
-	fixed_point_map_t<PopType const*>&& new_encourage_pop_types,
+	IndexedMap<GoodDefinition, fixed_point_t>&& new_encourage_goods,
+	IndexedMap<PopType, fixed_point_t>&& new_encourage_pop_types,
 	ConditionScript&& new_limit
 ) : Modifier { new_identifier, std::move(new_modifiers), modifier_type_t::NATIONAL_FOCUS },
 	group { new_group },
@@ -66,8 +66,8 @@ inline bool NationalFocusManager::add_national_focus(
 	Ideology const* loyalty_ideology,
 	fixed_point_t loyalty_value,
 	fixed_point_t encourage_railroads,
-	fixed_point_map_t<GoodDefinition const*>&& encourage_goods,
-	fixed_point_map_t<PopType const*>&& encourage_pop_types,
+	IndexedMap<GoodDefinition, fixed_point_t>&& encourage_goods,
+	IndexedMap<PopType, fixed_point_t>&& encourage_pop_types,
 	ConditionScript&& limit
 ) {
 	const LogScope log_scope { fmt::format("national focus {}", identifier) };
@@ -131,8 +131,8 @@ bool NationalFocusManager::load_national_foci_file(
 					Ideology const* loyalty_ideology = nullptr;
 					fixed_point_t loyalty_value = 0;
 					fixed_point_t encourage_railroads = 0;
-					fixed_point_map_t<GoodDefinition const*> encourage_goods;
-					fixed_point_map_t<PopType const*> encourage_pop_types;
+					IndexedMap<GoodDefinition, fixed_point_t> encourage_goods { good_definition_manager.get_good_definitions() };
+					IndexedMap<PopType, fixed_point_t> encourage_pop_types { pop_manager.get_pop_types() };
 					ConditionScript limit {
 						PROVINCE | COUNTRY, PROVINCE | COUNTRY, NO_SCOPE
 					};

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -32,8 +32,8 @@ namespace OpenVic {
 		Ideology const* PROPERTY(loyalty_ideology);
 		fixed_point_t PROPERTY(loyalty_value);
 		fixed_point_t PROPERTY(encourage_railroads);
-		fixed_point_map_t<GoodDefinition const*> PROPERTY(encourage_goods);
-		fixed_point_map_t<PopType const*> PROPERTY(encourage_pop_types);
+		IndexedMap<GoodDefinition, fixed_point_t> PROPERTY(encourage_goods);
+		IndexedMap<PopType, fixed_point_t> PROPERTY(encourage_pop_types);
 		ConditionScript PROPERTY(limit);
 
 		NationalFocus(
@@ -48,8 +48,8 @@ namespace OpenVic {
 			Ideology const* new_loyalty_ideology,
 			fixed_point_t new_loyalty_value,
 			fixed_point_t new_encourage_railroads,
-			fixed_point_map_t<GoodDefinition const*>&& new_encourage_goods,
-			fixed_point_map_t<PopType const*>&& new_encourage_pop_types,
+			IndexedMap<GoodDefinition, fixed_point_t>&& new_encourage_goods,
+			IndexedMap<PopType, fixed_point_t>&& new_encourage_pop_types,
 			ConditionScript&& new_limit
 		);
 
@@ -83,8 +83,8 @@ namespace OpenVic {
 			Ideology const* loyalty_ideology,
 			fixed_point_t loyalty_value,
 			fixed_point_t encourage_railroads,
-			fixed_point_map_t<GoodDefinition const*>&& encourage_goods,
-			fixed_point_map_t<PopType const*>&& encourage_pop_types,
+			IndexedMap<GoodDefinition, fixed_point_t>&& encourage_goods,
+			IndexedMap<PopType, fixed_point_t>&& encourage_pop_types,
 			ConditionScript&& limit
 		);
 

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -8,6 +8,7 @@
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/types/PopSize.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
+#include "economy/GoodDefinition.hpp"
 
 namespace OpenVic {
 	struct CountryInstance;
@@ -146,6 +147,7 @@ namespace OpenVic {
 		Pop(
 			PopBase const& pop_base,
 			decltype(ideology_distribution)::keys_span_type ideology_keys,
+			utility::forwardable_span<const GoodDefinition> good_definition_keys,
 			MarketInstance& new_market_instance,
 			ArtisanalProducerFactoryPattern& artisanal_producer_factory_pattern
 		);

--- a/src/openvic-simulation/pop/PopValuesFromProvince.cpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.cpp
@@ -38,10 +38,15 @@ void PopStrataValuesFromProvince::update_pop_strata_values_from_province(
 
 PopValuesFromProvince::PopValuesFromProvince(
 	PopsDefines const& new_defines,
-	decltype(effects_per_strata)::keys_span_type strata_keys
+	decltype(effects_per_strata)::keys_span_type strata_keys,
+	decltype(reusable_maps)::value_type::keys_span_type good_definition_keys
 ) : defines { new_defines },
 	effects_per_strata { strata_keys }
-	{}
+	{
+		for (size_t i = 0; i < reusable_maps.size(); i++) {
+			reusable_maps[i] = decltype(reusable_maps)::value_type { good_definition_keys };
+		}
+	}
 
 void PopValuesFromProvince::update_pop_values_from_province(ProvinceInstance const& province) {
 	for (auto [strata, values] : effects_per_strata) {

--- a/src/openvic-simulation/pop/PopValuesFromProvince.hpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.hpp
@@ -1,13 +1,10 @@
 #pragma once
 
 #include <array>
-#include <vector>
 
 #include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
-#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
-#include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
 	struct GoodDefinition;
@@ -36,11 +33,12 @@ namespace OpenVic {
 		IndexedMap<Strata, PopStrataValuesFromProvince> PROPERTY(effects_per_strata);
 	public:
 	 	//public field as mutable references are required.
-		std::array<fixed_point_map_t<GoodDefinition const*>, MAPS_FOR_POP> reusable_maps {};
+		std::array<IndexedMap<GoodDefinition, fixed_point_t>, MAPS_FOR_POP> reusable_maps;
 
 		PopValuesFromProvince(
 			PopsDefines const& new_defines,
-			decltype(effects_per_strata)::keys_span_type strata_keys
+			decltype(effects_per_strata)::keys_span_type strata_keys,
+			decltype(reusable_maps)::value_type::keys_span_type good_definition_keys
 		);
 		PopValuesFromProvince(PopValuesFromProvince&&) = default;
 

--- a/src/openvic-simulation/types/InheritsFromHasIndex.hpp
+++ b/src/openvic-simulation/types/InheritsFromHasIndex.hpp
@@ -61,4 +61,6 @@ namespace OpenVic {
 	
 	template <typename T>
 	struct InheritsFromHasIndex : public _detail::is_has_index_with_tag_final<T, T> {};
+	template <typename T>
+	concept NotHasIndexWithTag = !_detail::is_has_index_with_tag_final<T, T>::value;
 }

--- a/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
-#include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/InheritsFromHasIndex.hpp"
+#include "openvic-simulation/types/OrderedContainers.hpp"
 
 namespace OpenVic {
-
-	template<typename T>
+	// use IndexedMap<T, fixed_point_t> if you inherit from HasIndex<T, Any>
+	template<NotHasIndexWithTag T>
 	using fixed_point_map_t = ordered_map<T, fixed_point_t>;
 
-	template<typename T>
+	template<NotHasIndexWithTag T>
 	using fixed_point_map_value_t = typename fixed_point_map_t<T>::value_type;
 
-	template<typename T>
+	template<NotHasIndexWithTag T>
 	using fixed_point_map_const_iterator_t = typename fixed_point_map_t<T>::const_iterator;
 
 	template<typename T, std::derived_from<T> U>

--- a/src/openvic-simulation/utility/ThreadPool.cpp
+++ b/src/openvic-simulation/utility/ThreadPool.cpp
@@ -10,15 +10,20 @@ using namespace OpenVic;
 void ThreadPool::loop_until_cancelled(
 	work_t& work_type,
 	PopsDefines const& pop_defines,
-	std::span<const CountryInstance> country_keys,
-	std::span<const Strata> strata_keys,
+	utility::forwardable_span<const CountryInstance> country_keys,
+	utility::forwardable_span<const Strata> strata_keys,
+	utility::forwardable_span<const GoodDefinition> good_definition_keys,
 	std::span<GoodInstance> goods_chunk,
 	std::span<ProvinceInstance> provinces_chunk
 ) {
 	IndexedMap<CountryInstance, fixed_point_t> reusable_country_map_0 { country_keys },
 		reusable_country_map_1 { country_keys };
 	memory::vector<fixed_point_t> reusable_vector_0 {}, reusable_vector_1 {};
-	PopValuesFromProvince reusable_pop_values { pop_defines, strata_keys };
+	PopValuesFromProvince reusable_pop_values { 
+		pop_defines,
+		strata_keys,
+		good_definition_keys
+	};
 
 	while (!is_cancellation_requested) {
 		work_t work_type_copy;
@@ -118,8 +123,9 @@ ThreadPool::~ThreadPool() {
 
 void ThreadPool::initialise_threadpool(
 	PopsDefines const& pop_defines,
-	std::span<const CountryInstance> country_keys,
-	std::span<const Strata> strata_keys,
+	utility::forwardable_span<const CountryInstance> country_keys,
+	utility::forwardable_span<const Strata> strata_keys,
+	utility::forwardable_span<const GoodDefinition> good_definition_keys,
 	std::span<GoodInstance> goods,
 	std::span<ProvinceInstance> provinces
 ) {
@@ -156,6 +162,7 @@ void ThreadPool::initialise_threadpool(
 				&pop_defines,
 				country_keys,
 				strata_keys,
+				good_definition_keys,
 				goods_begin, goods_end,
 				provinces_begin, provinces_end
 			]() -> void {
@@ -164,6 +171,7 @@ void ThreadPool::initialise_threadpool(
 					pop_defines,
 					country_keys,
 					strata_keys,
+					good_definition_keys,
 					std::span<GoodInstance>{ goods_begin, goods_end },
 					std::span<ProvinceInstance>{ provinces_begin, provinces_end }
 				);

--- a/src/openvic-simulation/utility/ThreadPool.hpp
+++ b/src/openvic-simulation/utility/ThreadPool.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 #include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/Date.hpp"
@@ -12,6 +11,7 @@
 
 namespace OpenVic {
 	struct CountryInstance;
+	struct GoodDefinition;
 	struct GoodInstance;
 	struct PopsDefines;
 	struct Strata;
@@ -28,8 +28,9 @@ namespace OpenVic {
 		void loop_until_cancelled(
 			work_t& work_type,
 			PopsDefines const& pop_defines,
-			std::span<const CountryInstance> country_keys,
-			std::span<const Strata> strata_keys,
+			utility::forwardable_span<const CountryInstance> country_keys,
+			utility::forwardable_span<const Strata> strata_keys,
+			utility::forwardable_span<const GoodDefinition> good_definition_keys,
 			std::span<GoodInstance> goods_chunk,
 			std::span<ProvinceInstance> provinces_chunk
 		);
@@ -53,8 +54,9 @@ namespace OpenVic {
 
 		void initialise_threadpool(
 			PopsDefines const& pop_defines,
-			std::span<const CountryInstance> country_keys,
-			std::span<const Strata> strata_keys,
+			utility::forwardable_span<const CountryInstance> country_keys,
+			utility::forwardable_span<const Strata> strata_keys,
+			utility::forwardable_span<const GoodDefinition> good_definition_keys,
 			std::span<GoodInstance> goods,
 			std::span<ProvinceInstance> provinces
 		);


### PR DESCRIPTION
Depends on #496 
Thanks to #496 IndexedMap uses the index directly from HasIndex and doesn't have to search for keys.
This makes IndexedMap faster than `tsl::ordered_map`.

This PR makes all maps with key types that implement HasIndex use IndexedMap instead of `tsl::ordered_map`.
Note IndexedMap should be created with all possible keys. In most cases this comes from `IdentifierRegistry.hpp` `expect_item_decimal_indexed_map`. The ThreadPool gets the keys explicitly (via instance manager).

Dropped in favour of #499 