### PR TITLE
Fix CowVector.hpp and Pop.cpp not compiling under apple clang 17

### DIFF
--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -1,5 +1,4 @@
 #include <cstddef>
-#include <utility>
 
 #define KEEP_DO_FOR_ALL_TYPES_OF_INCOME
 #define KEEP_DO_FOR_ALL_TYPES_OF_EXPENSES
@@ -423,7 +422,7 @@ void Pop::pop_tick_without_cleanup(
 	employed = 0;
 	//import subsidies are based on yesterday
 	yesterdays_import_value = 0;
-	std::span<const GoodDefinition> const& good_keys = shared_values.reusable_goods_mask.get_keys();
+	utility::forwardable_span<const GoodDefinition> good_keys = shared_values.reusable_goods_mask.get_keys();
 	memory::vector<fixed_point_t>& reusable_vector_0 = reusable_vectors[0];
 	memory::vector<fixed_point_t>& reusable_vector_1 = reusable_vectors[1];
 	memory::vector<fixed_point_t>& max_quantity_to_buy_per_good = reusable_vectors[2];

--- a/src/openvic-simulation/types/CowVector.hpp
+++ b/src/openvic-simulation/types/CowVector.hpp
@@ -130,7 +130,7 @@ namespace OpenVic {
 				self_writer = this->write();
 				tmp_writer = tmp.write();
 
-				self_writer->_assign_aux(
+				self_writer._assign_aux(
 					std::make_move_iterator(tmp_writer.begin()), std::make_move_iterator(tmp_writer.end()),
 					std::random_access_iterator_tag()
 				);


### PR DESCRIPTION
Fixes two issues preventing builds on latest macOS with latest Xcode toolchain.
Blocker for my progress on #470.