### PR TITLE
Match ProvinceIndex index_t with ProvinceDefinition

### DIFF
--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -46,7 +46,8 @@ namespace OpenVic {
 	using ArmyInstance = UnitInstanceGroupBranched<UnitType::branch_t::LAND>;
 	using NavyInstance = UnitInstanceGroupBranched<UnitType::branch_t::NAVAL>;
 
-	struct ProvinceInstance : HasIdentifierAndColour, HasIndex<ProvinceInstance>, FlagStrings {
+	//HasIndex index_t must match ProvinceDefinition's index_t
+	struct ProvinceInstance : HasIdentifierAndColour, HasIndex<ProvinceInstance, uint16_t>, FlagStrings {
 		friend struct MapInstance;
 
 		using life_rating_t = int8_t;


### PR DESCRIPTION
ProvinceDefinition uses `uint16_t` as the type for its index.
ProvinceInstance simply uses the index from ProvinceDefinition as its index, so the types should be the same.