### PR TITLE
Clearly distinguish between 0- & 1-based indexing

### DIFF
--- a/src/openvic-simulation/console/ConsoleInstance.cpp
+++ b/src/openvic-simulation/console/ConsoleInstance.cpp
@@ -208,7 +208,7 @@ ProvinceInstance* ConsoleInstance::validate_province_index(std::string_view valu
 		return nullptr;
 	}
 
-	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index(*result);
+	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index_1_based(*result);
 
 	if (province == nullptr) {
 		write_error("Unknown province id");

--- a/src/openvic-simulation/history/ProvinceHistory.cpp
+++ b/src/openvic-simulation/history/ProvinceHistory.cpp
@@ -181,7 +181,7 @@ void ProvinceHistoryManager::lock_province_histories(MapDefinition const& map_de
 
 	memory::vector<bool> province_checklist(provinces.size());
 	for (auto [province, history_map] : mutable_iterator(province_histories)) {
-		province_checklist[province->get_index() - 1] = true;
+		province_checklist[province->get_index()] = true;
 
 		history_map.sort_entries();
 	}

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -58,17 +58,17 @@ bool MapDefinition::add_province_definition(std::string_view identifier, colour_
 		return false;
 	}
 	ProvinceDefinition new_province {
-		identifier, colour, static_cast<ProvinceDefinition::index_t>(province_definitions.size() + 1)
+		identifier, colour, static_cast<ProvinceDefinition::index_t>(province_definitions.size())
 	};
-	const ProvinceDefinition::index_t index = get_index_from_colour(colour);
-	if (index != ProvinceDefinition::NULL_INDEX) {
+	const ProvinceDefinition::index_t index_1_based = get_index_1_based_from_colour(colour);
+	if (index_1_based != ProvinceDefinition::NULL_INDEX) {
 		Logger::error(
-			"Duplicate province colours: ", get_province_definition_by_index(index)->to_string(), " and ",
+			"Duplicate province colours: ", get_province_definition_by_index_1_based(index_1_based)->to_string(), " and ",
 			new_province.to_string()
 		);
 		return false;
 	}
-	colour_index_map[new_province.get_colour()] = new_province.get_index();
+	colour_index_map[new_province.get_colour()] = new_province.get_index_1_based();
 	return province_definitions.add_item(std::move(new_province));
 }
 
@@ -125,37 +125,37 @@ bool MapDefinition::add_standard_adjacency(ProvinceDefinition& from, ProvinceDef
 		to.coastal = !to.is_water();
 
 		if (from.is_water()) {
-			path_map_sea.try_add_point(to.get_index(), { to.centre.x, to.centre.y });
+			path_map_sea.try_add_point(to.get_index_1_based(), { to.centre.x, to.centre.y });
 		} else {
-			path_map_sea.try_add_point(from.get_index(), { from.centre.x, from.centre.y });
+			path_map_sea.try_add_point(from.get_index_1_based(), { from.centre.x, from.centre.y });
 		}
 		/* Connect points on pathfinding map */
-		path_map_sea.connect_points(from.get_index(), to.get_index());
+		path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
 		/* Land units can use transports to path on the sea */
-		path_map_land.connect_points(from.get_index(), to.get_index());
+		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 		/* Sea points are only valid for land units with a transport */
 		if (from.is_water()) {
-			path_map_land.set_point_disabled(from.get_index());
+			path_map_land.set_point_disabled(from.get_index_1_based());
 		} else {
-			path_map_land.set_point_disabled(to.get_index());
+			path_map_land.set_point_disabled(to.get_index_1_based());
 		}
 	} else if (from.is_water()) {
 		/* Water-to-water adjacency */
 		type = WATER;
 
 		/* Connect points on pathfinding map */
-		path_map_sea.connect_points(from.get_index(), to.get_index());
+		path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
 		/* Land units can use transports to path on the sea */
-		path_map_land.connect_points(from.get_index(), to.get_index());
+		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 		/* Sea points are only valid for land units with a transport */
 		if (from.is_water()) {
-			path_map_land.set_point_disabled(from.get_index());
+			path_map_land.set_point_disabled(from.get_index_1_based());
 		} else {
-			path_map_land.set_point_disabled(to.get_index());
+			path_map_land.set_point_disabled(to.get_index_1_based());
 		}
 	} else {
 		/* Connect points on pathfinding map */
-		path_map_land.connect_points(from.get_index(), to.get_index());
+		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 	}
 
 	if (from_needs_adjacency) {
@@ -283,17 +283,17 @@ bool MapDefinition::add_special_adjacency(
 			}
 			*existing_adjacency = { &to, distance, type, through, data };
 			if (from.is_water() && to.is_water()) {
-				path_map_sea.connect_points(from.get_index(), to.get_index());
+				path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
 			} else {
-				path_map_land.connect_points(from.get_index(), to.get_index());
+				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 			}
 
 			if (from.is_water() || to.is_water()) {
-				path_map_land.connect_points(from.get_index(), to.get_index());
+				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 				if (from.is_water()) {
-					path_map_land.set_point_disabled(from.get_index());
+					path_map_land.set_point_disabled(from.get_index_1_based());
 				} else {
-					path_map_land.set_point_disabled(to.get_index());
+					path_map_land.set_point_disabled(to.get_index_1_based());
 				}
 			}
 			return true;
@@ -305,17 +305,17 @@ bool MapDefinition::add_special_adjacency(
 		} else {
 			from.adjacencies.emplace_back(&to, distance, type, through, data);
 			if (from.is_water() && to.is_water()) {
-				path_map_sea.connect_points(from.get_index(), to.get_index());
+				path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
 			} else {
-				path_map_land.connect_points(from.get_index(), to.get_index());
+				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 			}
 
 			if (from.is_water() || to.is_water()) {
-				path_map_land.connect_points(from.get_index(), to.get_index());
+				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
 				if (from.is_water()) {
-					path_map_land.set_point_disabled(from.get_index());
+					path_map_land.set_point_disabled(from.get_index_1_based());
 				} else {
-					path_map_land.set_point_disabled(to.get_index());
+					path_map_land.set_point_disabled(to.get_index_1_based());
 				}
 			}
 			return true;
@@ -346,7 +346,7 @@ bool MapDefinition::set_water_province(std::string_view identifier) {
 		return false;
 	}
 	province->water = true;
-	path_map_sea.try_add_point(province->get_index(), path_map_land.get_point_position(province->get_index()));
+	path_map_sea.try_add_point(province->get_index_1_based(), path_map_land.get_point_position(province->get_index_1_based()));
 	return true;
 }
 
@@ -430,7 +430,7 @@ bool MapDefinition::add_region(std::string_view identifier, memory::vector<Provi
 	return ret;
 }
 
-ProvinceDefinition::index_t MapDefinition::get_index_from_colour(colour_t colour) const {
+ProvinceDefinition::index_t MapDefinition::get_index_1_based_from_colour(colour_t colour) const {
 	const colour_index_map_t::const_iterator it = colour_index_map.find(colour);
 	if (it != colour_index_map.end()) {
 		return it->second;
@@ -438,19 +438,19 @@ ProvinceDefinition::index_t MapDefinition::get_index_from_colour(colour_t colour
 	return ProvinceDefinition::NULL_INDEX;
 }
 
-ProvinceDefinition::index_t MapDefinition::get_province_index_at(ivec2_t pos) const {
+ProvinceDefinition::index_t MapDefinition::get_province_index_1_based_at(ivec2_t pos) const {
 	if (pos.nonnegative() && pos.is_within_bound(dims)) {
-		return province_shape_image[get_pixel_index_from_pos(pos)].index;
+		return province_shape_image[get_pixel_index_from_pos(pos)].index_1_based;
 	}
 	return ProvinceDefinition::NULL_INDEX;
 }
 
 ProvinceDefinition* MapDefinition::get_province_definition_at(ivec2_t pos) {
-	return get_province_definition_by_index(get_province_index_at(pos));
+	return get_province_definition_by_index_1_based(get_province_index_1_based_at(pos));
 }
 
 ProvinceDefinition const* MapDefinition::get_province_definition_at(ivec2_t pos) const {
-	return get_province_definition_by_index(get_province_index_at(pos));
+	return get_province_definition_by_index_1_based(get_province_index_1_based_at(pos));
 }
 
 bool MapDefinition::set_max_provinces(ProvinceDefinition::index_t new_max_provinces) {
@@ -544,7 +544,7 @@ bool MapDefinition::load_province_definitions(std::span<const LineObject> lines)
 					}
 
 					ProvinceDefinition const& definition = province_definitions.back();
-					ret &= path_map_land.try_add_point(definition.get_index(), { definition.centre.x, definition.centre.y });
+					ret &= path_map_land.try_add_point(definition.get_index_1_based(), { definition.centre.x, definition.centre.y });
 					if (!ret) {
 						Logger::error("Province ", identifier, " could not be added to " _OV_STR(path_map_land));
 					}
@@ -810,12 +810,12 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 		for (pos.x = 0; pos.x < get_width(); ++pos.x) {
 			const size_t pixel_index = get_pixel_index_from_pos(pos);
 			const colour_t province_colour = colour_at(province_data, pixel_index);
-			ProvinceDefinition::index_t province_index = ProvinceDefinition::NULL_INDEX;
+			ProvinceDefinition::index_t province_index_1_based = ProvinceDefinition::NULL_INDEX;
 
 			if (pos.x > 0) {
 				const size_t jdx = pixel_index - 1;
 				if (colour_at(province_data, jdx) == province_colour) {
-					province_index = province_shape_image[jdx].index;
+					province_index_1_based = province_shape_image[jdx].index_1_based;
 					goto index_found;
 				}
 			}
@@ -823,14 +823,14 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			if (pos.y > 0) {
 				const size_t jdx = pixel_index - get_width();
 				if (colour_at(province_data, jdx) == province_colour) {
-					province_index = province_shape_image[jdx].index;
+					province_index_1_based = province_shape_image[jdx].index_1_based;
 					goto index_found;
 				}
 			}
 
-			province_index = get_index_from_colour(province_colour);
+			province_index_1_based = get_index_1_based_from_colour(province_colour);
 
-			if (province_index == ProvinceDefinition::NULL_INDEX && !unrecognised_province_colours.contains(province_colour)) {
+			if (province_index_1_based == ProvinceDefinition::NULL_INDEX && !unrecognised_province_colours.contains(province_colour)) {
 				unrecognised_province_colours.insert(province_colour);
 				if (detailed_errors) {
 					Logger::warning(
@@ -840,10 +840,10 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			}
 
 		index_found:
-			province_shape_image[pixel_index].index = province_index;
+			province_shape_image[pixel_index].index_1_based = province_index_1_based;
 
-			if (province_index != ProvinceDefinition::NULL_INDEX) {
-				const ProvinceDefinition::index_t array_index = province_index - 1;
+			if (province_index_1_based != ProvinceDefinition::NULL_INDEX) {
+				const ProvinceDefinition::index_t array_index = province_index_1_based - 1;
 				pixels_per_province[array_index]++;
 				pixel_position_sum_per_province[array_index] += static_cast<fvec2_t>(pos);
 			}
@@ -851,8 +851,8 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			const TerrainTypeMapping::index_t terrain = terrain_data[pixel_index];
 			TerrainTypeMapping const* mapping = terrain_type_manager.get_terrain_type_mapping_for(terrain);
 			if (mapping != nullptr) {
-				if (province_index != ProvinceDefinition::NULL_INDEX) {
-					terrain_type_pixels_list[province_index - 1][&mapping->get_type()]++;
+				if (province_index_1_based != ProvinceDefinition::NULL_INDEX) {
+					terrain_type_pixels_list[province_index_1_based - 1][&mapping->get_type()]++;
 				}
 				if (mapping->get_has_texture() && terrain < terrain_type_manager.get_terrain_texture_limit()) {
 					province_shape_image[pixel_index].terrain = terrain + 1;

--- a/src/openvic-simulation/map/MapDefinition.hpp
+++ b/src/openvic-simulation/map/MapDefinition.hpp
@@ -45,7 +45,7 @@ namespace OpenVic {
 #pragma pack(push, 1)
 		/* Used to represent tightly packed 3-byte integer pixel information. */
 		struct shape_pixel_t {
-			ProvinceDefinition::index_t index;
+			ProvinceDefinition::index_t index_1_based;
 			TerrainTypeMapping::index_t terrain;
 		};
 #pragma pack(pop)
@@ -73,7 +73,7 @@ namespace OpenVic {
 		PointMap PROPERTY_REF(path_map_land);
 		PointMap PROPERTY_REF(path_map_sea);
 
-		ProvinceDefinition::index_t get_index_from_colour(colour_t colour) const;
+		ProvinceDefinition::index_t get_index_1_based_from_colour(colour_t colour) const;
 		bool _generate_standard_province_adjacencies();
 
 		inline constexpr int32_t get_pixel_index_from_pos(ivec2_t pos) const {
@@ -106,7 +106,7 @@ namespace OpenVic {
 		size_t get_land_province_count() const;
 		size_t get_water_province_count() const;
 
-		ProvinceDefinition::index_t get_province_index_at(ivec2_t pos) const;
+		ProvinceDefinition::index_t get_province_index_1_based_at(ivec2_t pos) const;
 
 	private:
 		ProvinceDefinition* get_province_definition_at(ivec2_t pos);

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -17,11 +17,11 @@ MapInstance::MapInstance(
 	sea_pathing { *this } {}
 
 ProvinceInstance& MapInstance::get_province_instance_from_definition(ProvinceDefinition const& province) {
-	return province_instances.get_items()[province.get_index() - 1];
+	return province_instances.get_items()[province.get_index()];
 }
 
 ProvinceInstance const& MapInstance::get_province_instance_from_definition(ProvinceDefinition const& province) const {
-	return province_instances.get_items()[province.get_index() - 1];
+	return province_instances.get_items()[province.get_index()];
 }
 
 void MapInstance::enable_canal(canal_index_t canal_index) {

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -85,7 +85,7 @@ bool MapmodeManager::generate_mapmode_colours(
 
 	if (map_instance.province_instances_are_locked()) {
 		for (ProvinceInstance const& province : map_instance.get_province_instances()) {
-			target_stripes[province.get_index()] = mapmode->get_base_stripe_colours(
+			target_stripes[province.get_province_definition().get_index_1_based()] = mapmode->get_base_stripe_colours(
 				map_instance, province, player_country, selected_province
 			);
 		}
@@ -327,7 +327,7 @@ bool MapmodeManager::setup_mapmodes() {
 				CountryInstance const* player_country, ProvinceInstance const* selected_province
 			) -> Mapmode::base_stripe_t {
 				const colour_argb_t::value_type f = colour_argb_t::colour_traits::component_from_fraction(
-					province.get_index(), map_instance.get_map_definition().get_province_definition_count() + 1
+					province.get_province_definition().get_index_1_based(), map_instance.get_map_definition().get_province_definition_count() + 1
 				);
 				return colour_argb_t::fill_as(f).with_alpha(ALPHA_VALUE);
 			}

--- a/src/openvic-simulation/map/ProvinceDefinition.cpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.cpp
@@ -18,7 +18,7 @@ ProvinceDefinition::ProvinceDefinition(
 	HasIndex { new_index } {}
 
 memory::string ProvinceDefinition::to_string() const {
-	return memory::fmt::format("(#{}, {}, 0x{})", get_index(), get_identifier(), get_colour());
+	return memory::fmt::format("(#{}, {}, 0x{})", get_index_1_based(), get_identifier(), get_colour());
 }
 
 bool ProvinceDefinition::load_positions(

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -112,6 +112,10 @@ namespace OpenVic {
 			return region != nullptr;
 		}
 
+		constexpr index_t get_index_1_based() const {
+			return get_index()+1;
+		}
+
 		/* The positions' y coordinates need to be inverted. */
 		bool load_positions(
 			MapDefinition const& map_definition, BuildingTypeManager const& building_type_manager, ast::NodeCPtr root

--- a/src/openvic-simulation/misc/GameAction.cpp
+++ b/src/openvic-simulation/misc/GameAction.cpp
@@ -209,7 +209,7 @@ bool GameActionManager::game_action_callback_expand_province_building(game_actio
 		return false;
 	}
 
-	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index(province_building->first);
+	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index_1_based(province_building->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		Logger::error("GAME_ACTION_EXPAND_PROVINCE_BUILDING called with invalid province index: ", province_building->first);

--- a/src/openvic-simulation/pathfinding/AStarPathing.cpp
+++ b/src/openvic-simulation/pathfinding/AStarPathing.cpp
@@ -115,7 +115,7 @@ bool ArmyAStarPathing::_is_point_enabled(search_const_iterator it) const {
 		return true;
 	}
 
-	ProvinceInstance const* province = map_instance.get_province_instance_by_index(it->first);
+	ProvinceInstance const* province = map_instance.get_province_instance_by_index_1_based(it->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		return true;
@@ -142,7 +142,7 @@ bool NavyAStarPathing::_is_point_enabled(search_const_iterator it) const {
 		return true;
 	}
 
-	ProvinceInstance const* province = map_instance.get_province_instance_by_index(it->first);
+	ProvinceInstance const* province = map_instance.get_province_instance_by_index_1_based(it->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		return true;

--- a/src/openvic-simulation/types/HasIndex.hpp
+++ b/src/openvic-simulation/types/HasIndex.hpp
@@ -10,6 +10,7 @@ namespace OpenVic {
 	public:
 		using index_t = IndexT;
 	private:
+		// always 0-based, this may be used for indexing arrays
 		const index_t PROPERTY(index);
 
 	protected:

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -625,6 +625,12 @@ private:
 #define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(singular, plural, registry, debug_name, index_offset) \
 	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset,)
 
+#define IF_NON_ZERO(value, conditional_part) IF_NON_ZERO_##value(conditional_part)
+#define IF_NON_ZERO_0(conditional_part)
+#define IF_NON_ZERO_1(conditional_part) conditional_part
+#define CONCAT_FORCE_EXPAND(a, b) a##b
+#define CONCAT_TOKENS(a, b) CONCAT_FORCE_EXPAND(a, b)
+
 #define IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset, const_kw) \
 	constexpr decltype(registry)::external_value_type const_kw& get_front_##singular() const_kw { \
 		return registry.front(); \
@@ -639,7 +645,14 @@ private:
 	constexpr T const_kw* get_cast_##singular##_by_identifier(std::string_view identifier) const_kw { \
 		return registry.get_cast_item_by_identifier<T>(identifier); \
 	} \
-	constexpr decltype(registry)::external_value_type const_kw* get_##singular##_by_index(std::size_t index) const_kw { \
+IF_NON_ZERO(index_offset, \
+	constexpr decltype(registry)::external_value_type const_kw* get_##singular##_by_index_0_based(std::size_t index_0_based) const_kw { \
+		return index_0_based >= 0 ? registry.get_item_by_index(index_0_based) : nullptr; \
+	} \
+) \
+	constexpr decltype(registry)::external_value_type const_kw* \
+	CONCAT_TOKENS(get_##singular##_by_index, IF_NON_ZERO(index_offset, _##index_offset##_based)) \
+	(std::size_t index) const_kw { \
 		return index >= index_offset ? registry.get_item_by_index(index - index_offset) : nullptr; \
 	} \
 	constexpr decltype(registry)::storage_type const_kw& get_##plural() const_kw { \


### PR DESCRIPTION
#496 uses the index from HasIndex to directly index arrays. This is great for performance but requires 0-based indexing.
Provinces use 1-based indexing for their 'external id' (data-loading, UI & console).

To remedy this, provinces now use 0-based indices for HasIndex and clearly marked 1-based indices for pathfinding, console, game actions and such.