### PR TITLE
Properties for admin eff tooltip

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1203,13 +1203,16 @@ void CountryInstance::_update_budget() {
 		total_non_colonial_population += state.get_total_population();
 	}
 
+	desired_administrator_percentage = country_defines.get_max_bureaucracy_percentage()
+		+ total_administrative_multiplier * country_defines.get_bureaucracy_percentage_increment();
+
 	if (total_non_colonial_population == 0) {
 		administrative_efficiency_from_administrators = fixed_point_t::_1;
-	} else {
-		const fixed_point_t desired_administrator_percentage = country_defines.get_max_bureaucracy_percentage()
-			+ total_administrative_multiplier * country_defines.get_bureaucracy_percentage_increment();
-		const fixed_point_t desired_administrators = desired_administrator_percentage * total_non_colonial_population;
+		administrator_percentage = fixed_point_t::_0;
+	} else {		
+		administrator_percentage = administrators / total_non_colonial_population;
 
+		const fixed_point_t desired_administrators = desired_administrator_percentage * total_non_colonial_population;
 		administrative_efficiency_from_administrators = std::min(
 			fixed_point_t::mul_div(
 				administrators,

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -152,6 +152,8 @@ namespace OpenVic {
 		constexpr fixed_point_t get_corruption_cost_multiplier() const {
 			return 2 - administrative_efficiency_from_administrators;
 		}
+		fixed_point_t PROPERTY(administrator_percentage);
+		fixed_point_t PROPERTY(desired_administrator_percentage);
 
 		//store per slider per good: desired, bought & cost
 		//store purchase record from last tick and prediction next tick

--- a/src/openvic-simulation/defines/CountryDefines.hpp
+++ b/src/openvic-simulation/defines/CountryDefines.hpp
@@ -28,6 +28,11 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(min_crimefight_percent);
 		fixed_point_t PROPERTY(max_crimefight_percent);
 		fixed_point_t PROPERTY(admin_efficiency_crimefight_percent);
+	public:
+		constexpr fixed_point_t get_admin_spending_crimefight_percent() const {
+			return fixed_point_t::_1 - admin_efficiency_crimefight_percent;
+		}
+	private:
 		fixed_point_t PROPERTY(conservative_increase_after_reform);
 		Timespan PROPERTY(campaign_event_base_duration);
 		Timespan PROPERTY(campaign_event_min_duration); // NOT USED


### PR DESCRIPTION
The tooltip in budget menu needs to display the effect of admin spending on crime as well as administrator percentage and the desired percentage.