### PR TITLE
Automatic dependency tracking

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -180,24 +180,24 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 	// TODO - REMOVE TEST CODE
 	Logger::info("===== Ranking system test... =====");
 	if (game_manager.get_instance_manager()) {
-		const auto print_ranking_list = [](std::string_view title, memory::vector<CountryInstance*> const& countries) -> void {
+		const auto print_ranking_list = [](std::string_view title, OpenVic::utility::forwardable_span<CountryInstance* const> countries) -> void {
 			memory::string text;
-			for (CountryInstance const* country : countries) {
+			for (CountryInstance* country : countries) {
 				text += StringUtils::append_string_views(
 					"\n    ", country->get_identifier(),
-					" - Total #", std::to_string(country->get_total_rank()), " (", country->get_total_score().to_string(1),
-					"), Prestige #", std::to_string(country->get_prestige_rank()), " (", country->get_prestige().to_string(1),
-					"), Industry #", std::to_string(country->get_industrial_rank()), " (", country->get_industrial_power().to_string(1),
-					"), Military #", std::to_string(country->get_military_rank()), " (", country->get_military_power().to_string(1), ")"
+					" - Total #", std::to_string(country->get_total_rank()), " (", country->total_score.get().to_string(1),
+					"), Prestige #", std::to_string(country->get_prestige_rank()), " (", country->get_prestige().get_untracked().to_string(1),
+					"), Industry #", std::to_string(country->get_industrial_rank()), " (", country->get_industrial_power().get_untracked().to_string(1),
+					"), Military #", std::to_string(country->get_military_rank()), " (", country->military_power.get().to_string(1), ")"
 				);
 			}
 			Logger::info(title, ":", text);
 		};
 
-		CountryInstanceManager const& country_instance_manager =
+		CountryInstanceManager& country_instance_manager =
 			game_manager.get_instance_manager()->get_country_instance_manager();
 
-		OpenVic::memory::vector<CountryInstance*> const& great_powers = country_instance_manager.get_great_powers();
+		OpenVic::utility::forwardable_span<CountryInstance* const> great_powers = country_instance_manager.get_great_powers();
 		print_ranking_list("Great Powers", great_powers);
 		print_ranking_list("Secondary Powers", country_instance_manager.get_secondary_powers());
 		print_ranking_list("All countries", country_instance_manager.get_total_ranking());

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1239,7 +1239,7 @@ void CountryInstance::_update_budget() {
 
 	const fixed_point_t corruption_cost_multiplier = get_corruption_cost_multiplier();
 	for (auto const& [pop_type, size] : pop_type_distribution) {
-		SharedPopTypeValues const& pop_type_values = shared_country_values.get_shared_pop_type_values()[pop_type];
+		SharedPopTypeValues const& pop_type_values = shared_country_values.get_shared_pop_type_values(pop_type);
 		projected_administration_spending_unscaled_by_slider += size * calculate_administration_salary_base(pop_type_values, corruption_cost_multiplier);
 		projected_education_spending_unscaled_by_slider += size * calculate_education_salary_base(pop_type_values, corruption_cost_multiplier);
 		projected_military_spending_unscaled_by_slider += size * calculate_military_salary_base(pop_type_values, corruption_cost_multiplier);
@@ -2039,7 +2039,7 @@ void CountryInstance::request_salaries_and_welfare_and_import_subsidies(Pop& pop
 	PopType const& pop_type = *pop.get_type();
 	const pop_size_t pop_size = pop.get_size();
 	const fixed_point_t corruption_cost_multiplier = get_corruption_cost_multiplier();
-	SharedPopTypeValues const& pop_type_values = shared_country_values.get_shared_pop_type_values()[pop_type];
+	SharedPopTypeValues const& pop_type_values = shared_country_values.get_shared_pop_type_values(pop_type);
 	ModifierEffectCache const& modifier_effect_cache = shared_country_values.get_modifier_effect_cache();
 
 	if (actual_administration_spending > fixed_point_t::_0) {
@@ -2117,7 +2117,7 @@ fixed_point_t CountryInstance::calculate_minimum_wage_base(PopType const& pop_ty
 
 	return calculate_minimum_wage_base(
 		shared_country_values.get_modifier_effect_cache(),
-		shared_country_values.get_shared_pop_type_values()[pop_type]
+		shared_country_values.get_shared_pop_type_values(pop_type)
 	);
 }
 

--- a/src/openvic-simulation/country/SharedCountryValues.hpp
+++ b/src/openvic-simulation/country/SharedCountryValues.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "openvic-simulation/pop/PopNeedsMacro.hpp"
-#include "openvic-simulation/types/IndexedMap.hpp"
+#include "openvic-simulation/pop/PopType.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 
@@ -10,7 +11,6 @@ namespace OpenVic {
 	struct GoodInstanceManager;
 	struct ModifierEffectCache;
 	struct PopsDefines;
-	struct PopType;
 
 	struct SharedPopTypeValues {
 	private:
@@ -35,7 +35,7 @@ namespace OpenVic {
 		ModifierEffectCache const& PROPERTY(modifier_effect_cache);
 		CountryDefines const& PROPERTY(country_defines);
 		PopsDefines const& pop_defines;
-		IndexedMap<PopType, SharedPopTypeValues> PROPERTY(shared_pop_type_values);
+		IndexedFlatMap<PopType, SharedPopTypeValues> PROPERTY(shared_pop_type_values);
 
 	public:
 		SharedCountryValues(
@@ -46,6 +46,9 @@ namespace OpenVic {
 		);
 		SharedCountryValues(SharedCountryValues&&) = default;
 
+		constexpr SharedPopTypeValues const& get_shared_pop_type_values(PopType const& pop_type) const {
+			return shared_pop_type_values.at(pop_type);
+		}
 		void update_costs(GoodInstanceManager const& good_instance_manager);
 	};
 }

--- a/src/openvic-simulation/dataloader/NodeTools.hpp
+++ b/src/openvic-simulation/dataloader/NodeTools.hpp
@@ -13,6 +13,7 @@
 
 #include "openvic-simulation/types/Colour.hpp"
 #include "openvic-simulation/types/Date.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/TextFormat.hpp"
@@ -687,6 +688,25 @@ using namespace std::string_view_literals;
 				}
 				Logger::warn_or_error(warn, "Duplicate map entry with key: \"", key, "\"");
 				return warn;
+			};
+		}
+
+		template<typename Key, typename Value>
+		Callback<Value> auto map_callback(
+			IndexedFlatMap<Key, Value>& map, Key const* key, bool warn = false
+		) requires std::movable<Value> {
+			return [&map, key, warn](Value value) -> bool {
+				if (key == nullptr) {
+					Logger::error("Null key in map_callback");
+					return false;
+				}
+				bool ret = true;
+				if (map.at(*key) != Value {}) {
+					Logger::warn_or_error(warn, "Duplicate map entry with key: \"", key, "\"");
+					ret = warn;
+				}
+				map.set(*key, std::move(value));
+				return ret;
 			};
 		}
 

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -115,7 +115,7 @@ bool BuildingTypeManager::load_buildings_file(
 	)(root);
 	lock_building_types();
 
-	IndexedMap<BuildingType, ModifierEffectCache::building_type_effects_t>& building_type_effects =
+	IndexedMap<BuildingType, building_type_effects_t>& building_type_effects =
 		modifier_manager.modifier_effect_cache.building_type_effects;
 
 	building_type_effects.set_keys(get_building_types());
@@ -124,7 +124,7 @@ bool BuildingTypeManager::load_buildings_file(
 		using enum ModifierEffect::format_t;
 		using enum ModifierEffect::target_t;
 
-		ModifierEffectCache::building_type_effects_t& this_building_type_effects = building_type_effects[building_type];
+		building_type_effects_t& this_building_type_effects = building_type_effects[building_type];
 
 		static constexpr std::string_view max_prefix = "max_";
 		static constexpr std::string_view min_prefix = "min_build_";

--- a/src/openvic-simulation/economy/GoodDefinition.cpp
+++ b/src/openvic-simulation/economy/GoodDefinition.cpp
@@ -136,7 +136,7 @@ bool GoodDefinitionManager::generate_modifiers(ModifierManager& modifier_manager
 	using enum ModifierEffect::format_t;
 	using enum ModifierEffect::target_t;
 
-	IndexedMap<GoodDefinition, ModifierEffectCache::good_effects_t>& good_effects =
+	IndexedMap<GoodDefinition, good_effects_t>& good_effects =
 		modifier_manager.modifier_effect_cache.good_effects;
 
 	good_effects.set_keys(get_good_definitions());
@@ -156,7 +156,7 @@ bool GoodDefinitionManager::generate_modifiers(ModifierManager& modifier_manager
 
 	for (GoodDefinition const& good : get_good_definitions()) {
 		const std::string_view good_identifier = good.get_identifier();
-		ModifierEffectCache::good_effects_t& this_good_effects = good_effects[good];
+		good_effects_t& this_good_effects = good_effects[good];
 
 		const auto good_modifier = [&modifier_manager, &ret, &good_identifier](
 			ModifierEffect const*& effect_cache, std::string_view name, ModifierEffect::format_t format,

--- a/src/openvic-simulation/economy/production/Employee.cpp
+++ b/src/openvic-simulation/economy/production/Employee.cpp
@@ -9,7 +9,7 @@ Employee::Employee(Pop& new_pop, const pop_size_t new_size)
 	size { new_size }
 	{}
 
-fixed_point_t Employee::update_minimum_wage(CountryInstance const& country_to_report_economy) {
+fixed_point_t Employee::update_minimum_wage(CountryInstance& country_to_report_economy) {
 	const fixed_point_t minimum_wage_base = country_to_report_economy.calculate_minimum_wage_base(*pop.get_type());
 	return minimum_wage_cached = minimum_wage_base * size / Pop::size_denominator;
 }

--- a/src/openvic-simulation/economy/production/Employee.hpp
+++ b/src/openvic-simulation/economy/production/Employee.hpp
@@ -10,6 +10,6 @@ namespace OpenVic {
 		fixed_point_t PROPERTY_RW(minimum_wage_cached);
 	public:
 		Employee(Pop& new_pop, const pop_size_t new_size);
-		fixed_point_t update_minimum_wage(CountryInstance const& country_to_report_economy);
+		fixed_point_t update_minimum_wage(CountryInstance& country_to_report_economy);
 	};
 }

--- a/src/openvic-simulation/history/CountryHistory.cpp
+++ b/src/openvic-simulation/history/CountryHistory.cpp
@@ -290,12 +290,8 @@ bool CountryHistoryManager::is_locked() const {
 	return locked;
 }
 
-CountryHistoryMap const* CountryHistoryManager::get_country_history(CountryDefinition const* country) const {
-	if (country == nullptr) {
-		Logger::error("Attempted to access history of null country");
-		return nullptr;
-	}
-	decltype(country_histories)::const_iterator country_registry = country_histories.find(country);
+CountryHistoryMap const* CountryHistoryManager::get_country_history(CountryDefinition const& country) const {
+	decltype(country_histories)::const_iterator country_registry = country_histories.find(&country);
 	if (country_registry != country_histories.end()) {
 		return &country_registry->second;
 	} else {

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/history/HistoryMap.hpp"
 #include "openvic-simulation/types/Date.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/IndexedMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
@@ -37,7 +38,7 @@ namespace OpenVic {
 		std::optional<Religion const*> PROPERTY(religion);
 		std::optional<CountryParty const*> PROPERTY(ruling_party);
 		std::optional<Date> PROPERTY(last_election);
-		IndexedMap<Ideology, fixed_point_t> PROPERTY(upper_house);
+		IndexedFlatMap<Ideology, fixed_point_t> PROPERTY(upper_house);
 		std::optional<ProvinceDefinition const*> PROPERTY(capital);
 		std::optional<GovernmentType const*> PROPERTY(government_type);
 		std::optional<fixed_point_t> PROPERTY(plurality);
@@ -106,7 +107,7 @@ namespace OpenVic {
 		void lock_country_histories();
 		bool is_locked() const;
 
-		CountryHistoryMap const* get_country_history(CountryDefinition const* country) const;
+		CountryHistoryMap const* get_country_history(CountryDefinition const& country) const;
 
 		bool load_country_history_file(
 			DefinitionManager& definition_manager, Dataloader const& dataloader, CountryDefinition const& country,

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -255,15 +255,15 @@ void ProvinceInstance::_update_pops(DefineManager const& define_manager) {
 	average_consciousness = 0;
 	average_militancy = 0;
 
-	population_by_strata.clear();
-	militancy_by_strata.clear();
-	life_needs_fulfilled_by_strata.clear();
-	everyday_needs_fulfilled_by_strata.clear();
-	luxury_needs_fulfilled_by_strata.clear();
+	population_by_strata.fill(0);
+	militancy_by_strata.fill(fixed_point_t::_0);
+	life_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
+	everyday_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
+	luxury_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
 
-	pop_type_distribution.clear();
-	pop_type_unemployed_count.clear();
-	ideology_distribution.clear();
+	pop_type_distribution.fill(fixed_point_t::_0);
+	pop_type_unemployed_count.fill(fixed_point_t::_0);
+	ideology_distribution.fill(fixed_point_t::_0);
 	issue_distribution.clear();
 	vote_distribution.clear();
 	culture_distribution.clear();
@@ -302,15 +302,15 @@ void ProvinceInstance::_update_pops(DefineManager const& define_manager) {
 		PopType const& pop_type = *pop.get_type();
 		Strata const& strata = pop_type.get_strata();
 
-		population_by_strata[strata] += pop_size_s;
-		militancy_by_strata[strata] += pop.get_militancy() * pop_size_f;
-		life_needs_fulfilled_by_strata[strata] += pop.get_life_needs_fulfilled() * pop_size_f;
-		everyday_needs_fulfilled_by_strata[strata] += pop.get_everyday_needs_fulfilled() * pop_size_f;
-		luxury_needs_fulfilled_by_strata[strata] += pop.get_luxury_needs_fulfilled() * pop_size_f;
+		population_by_strata.at(strata) += pop_size_s;
+		militancy_by_strata.at(strata) += pop.get_militancy() * pop_size_f;
+		life_needs_fulfilled_by_strata.at(strata) += pop.get_life_needs_fulfilled() * pop_size_f;
+		everyday_needs_fulfilled_by_strata.at(strata) += pop.get_everyday_needs_fulfilled() * pop_size_f;
+		luxury_needs_fulfilled_by_strata.at(strata) += pop.get_luxury_needs_fulfilled() * pop_size_f;
 
-		pop_type_distribution[pop_type] += pop_size_s;
-		pop_type_unemployed_count[pop_type] += pop.get_unemployed();
-		pops_cache_by_type[pop_type].push_back(&pop);
+		pop_type_distribution.at(pop_type) += pop_size_s;
+		pop_type_unemployed_count.at(pop_type) += pop.get_unemployed();
+		pops_cache_by_type.at(pop_type).push_back(&pop);
 		// Pop ideology, issue and vote distributions are scaled to pop size so we can add them directly
 		ideology_distribution += pop.get_ideology_distribution();
 		issue_distribution += pop.get_issue_distribution();
@@ -330,10 +330,10 @@ void ProvinceInstance::_update_pops(DefineManager const& define_manager) {
 		average_consciousness /= total_population;
 		average_militancy /= total_population;
 
-		militancy_by_strata /= population_by_strata;
-		life_needs_fulfilled_by_strata /= population_by_strata;
-		everyday_needs_fulfilled_by_strata /= population_by_strata;
-		luxury_needs_fulfilled_by_strata /= population_by_strata;
+		militancy_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &ProvinceInstance::div_by_zero_return_0);
+		life_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &ProvinceInstance::div_by_zero_return_0);
+		everyday_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &ProvinceInstance::div_by_zero_return_0);
+		luxury_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &ProvinceInstance::div_by_zero_return_0);
 	}
 }
 

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -14,6 +14,7 @@
 #include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/types/FlagStrings.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 #include "openvic-simulation/utility/ForwardableSpan.hpp"
@@ -102,11 +103,15 @@ namespace OpenVic {
 		Crime const* PROPERTY_RW(crime, nullptr);
 		ResourceGatheringOperation PROPERTY(rgo);
 		IdentifierRegistry<BuildingInstance> IDENTIFIER_REGISTRY(building, false);
-		memory::vector<ArmyInstance*> PROPERTY(armies);
-		memory::vector<NavyInstance*> PROPERTY(navies);
+		memory::vector<ArmyInstance*> SPAN_PROPERTY(armies);
+		memory::vector<NavyInstance*> SPAN_PROPERTY(navies);
 		// The number of land regiments currently in the province, including those being transported by navies
 		size_t PROPERTY(land_regiment_count, 0);
 		Timespan PROPERTY(occupation_duration);
+
+		constexpr static fixed_point_t& div_by_zero_return_0(fixed_point_t& lhs, pop_size_t const& rhs) {
+			return lhs = fixed_point_t::_0;
+		}
 
 	public:
 		UNIT_BRANCHED_GETTER(get_unit_instance_groups, armies, navies);
@@ -121,16 +126,16 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(average_consciousness);
 		fixed_point_t PROPERTY(average_militancy);
 
-		IndexedMap<Strata, pop_size_t> PROPERTY(population_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(militancy_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(life_needs_fulfilled_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(everyday_needs_fulfilled_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(luxury_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, pop_size_t> PROPERTY(population_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(militancy_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(life_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(everyday_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(luxury_needs_fulfilled_by_strata);
 
-		IndexedMap<PopType, pop_size_t> PROPERTY(pop_type_distribution);
-		IndexedMap<PopType, pop_size_t> PROPERTY(pop_type_unemployed_count);
-		IndexedMap<PopType, memory::vector<Pop*>> PROPERTY(pops_cache_by_type);
-		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
+		IndexedFlatMap<PopType, pop_size_t> PROPERTY(pop_type_distribution);
+		IndexedFlatMap<PopType, pop_size_t> PROPERTY(pop_type_unemployed_count);
+		IndexedFlatMap<PopType, memory::vector<Pop*>> PROPERTY(pops_cache_by_type);
+		IndexedFlatMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Issue const*> PROPERTY(issue_distribution);
 		IndexedMap<CountryParty, fixed_point_t> PROPERTY(vote_distribution);
 		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
@@ -196,32 +201,32 @@ namespace OpenVic {
 		// to get the support as a proportion of 1.0
 
 		constexpr pop_size_t get_pop_type_proportion(PopType const& pop_type) const {
-			return pop_type_distribution[pop_type];
+			return pop_type_distribution.at(pop_type);
 		}
 		constexpr pop_size_t get_pop_type_unemployed(PopType const& pop_type) const {
-			return pop_type_unemployed_count[pop_type];
+			return pop_type_unemployed_count.at(pop_type);
 		}
 		constexpr fixed_point_t get_ideology_support(Ideology const& ideology) const {
-			return ideology_distribution[ideology];
+			return ideology_distribution.at(ideology);
 		}
 		fixed_point_t get_issue_support(Issue const& issue) const;
 		fixed_point_t get_party_support(CountryParty const& party) const;
 		fixed_point_t get_culture_proportion(Culture const& culture) const;
 		fixed_point_t get_religion_proportion(Religion const& religion) const;
 		constexpr pop_size_t get_strata_population(Strata const& strata) const {
-			return population_by_strata[strata];
+			return population_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_militancy(Strata const& strata) const {
-			return militancy_by_strata[strata];
+			return militancy_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_life_needs_fulfilled(Strata const& strata) const {
-			return life_needs_fulfilled_by_strata[strata];
+			return life_needs_fulfilled_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_everyday_needs_fulfilled(Strata const& strata) const {
-			return everyday_needs_fulfilled_by_strata[strata];
+			return everyday_needs_fulfilled_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_luxury_needs_fulfilled(Strata const& strata) const {
-			return luxury_needs_fulfilled_by_strata[strata];
+			return luxury_needs_fulfilled_by_strata.at(strata);
 		}
 
 		bool expand_building(size_t building_index);

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -89,15 +89,15 @@ void State::update_gamestate() {
 	average_consciousness = 0;
 	average_militancy = 0;
 
-	population_by_strata.clear();
-	militancy_by_strata.clear();
-	life_needs_fulfilled_by_strata.clear();
-	everyday_needs_fulfilled_by_strata.clear();
-	luxury_needs_fulfilled_by_strata.clear();
+	population_by_strata.fill(0);
+	militancy_by_strata.fill(fixed_point_t::_0);
+	life_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
+	everyday_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
+	luxury_needs_fulfilled_by_strata.fill(fixed_point_t::_0);
 
-	pop_type_distribution.clear();
-	pop_type_unemployed_count.clear();
-	ideology_distribution.clear();
+	pop_type_distribution.fill(fixed_point_t::_0);
+	pop_type_unemployed_count.fill(fixed_point_t::_0);
+	ideology_distribution.fill(fixed_point_t::_0);
 	issue_distribution.clear();
 	vote_distribution.clear();
 	culture_distribution.clear();
@@ -140,7 +140,7 @@ void State::update_gamestate() {
 		religion_distribution += province->get_religion_distribution();
 
 		for (auto const& [pop_type, province_pops_of_type] : province->get_pops_cache_by_type()) {
-			memory::vector<Pop*>& state_pops_of_type = pops_cache_by_type[pop_type];
+			memory::vector<Pop*>& state_pops_of_type = pops_cache_by_type.at(pop_type);
 			state_pops_of_type.insert(
 				state_pops_of_type.end(),
 				province_pops_of_type.begin(),
@@ -156,10 +156,10 @@ void State::update_gamestate() {
 		average_consciousness /= total_population;
 		average_militancy /= total_population;
 
-		militancy_by_strata /= population_by_strata;
-		life_needs_fulfilled_by_strata /= population_by_strata;
-		everyday_needs_fulfilled_by_strata /= population_by_strata;
-		luxury_needs_fulfilled_by_strata /= population_by_strata;
+		militancy_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &State::div_by_zero_return_0);
+		life_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &State::div_by_zero_return_0);
+		everyday_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &State::div_by_zero_return_0);
+		luxury_needs_fulfilled_by_strata.divide_assign_handle_zero<pop_size_t>(population_by_strata, &State::div_by_zero_return_0);
 	}
 
 	// TODO - use actual values when State has factory data

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include <plf_colony.h>
 
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/pop/PopType.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/PopSize.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 
@@ -23,7 +23,7 @@ namespace OpenVic {
 		StateSet const& PROPERTY(state_set);
 		CountryInstance* PROPERTY_PTR(owner);
 		ProvinceInstance* PROPERTY_PTR(capital);
-		memory::vector<ProvinceInstance*> PROPERTY(provinces);
+		memory::vector<ProvinceInstance*> SPAN_PROPERTY(provinces);
 		ProvinceInstance::colony_status_t PROPERTY(colony_status);
 
 		pop_size_t PROPERTY(total_population, 0);
@@ -32,16 +32,16 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(average_consciousness);
 		fixed_point_t PROPERTY(average_militancy);
 
-		IndexedMap<Strata, pop_size_t> PROPERTY(population_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(militancy_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(life_needs_fulfilled_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(everyday_needs_fulfilled_by_strata);
-		IndexedMap<Strata, fixed_point_t> PROPERTY(luxury_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, pop_size_t> PROPERTY(population_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(militancy_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(life_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(everyday_needs_fulfilled_by_strata);
+		IndexedFlatMap<Strata, fixed_point_t> PROPERTY(luxury_needs_fulfilled_by_strata);
 
-		IndexedMap<PopType, pop_size_t> PROPERTY(pop_type_distribution);
-		IndexedMap<PopType, pop_size_t> PROPERTY(pop_type_unemployed_count);
-		IndexedMap<PopType, memory::vector<Pop*>> PROPERTY(pops_cache_by_type);
-		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
+		IndexedFlatMap<PopType, pop_size_t> PROPERTY(pop_type_distribution);
+		IndexedFlatMap<PopType, pop_size_t> PROPERTY(pop_type_unemployed_count);
+		IndexedFlatMap<PopType, memory::vector<Pop*>> PROPERTY(pops_cache_by_type);
+		IndexedFlatMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Issue const*> PROPERTY(issue_distribution);
 		IndexedMap<CountryParty, fixed_point_t> PROPERTY(vote_distribution);
 		fixed_point_map_t<Culture const*> PROPERTY(culture_distribution);
@@ -62,6 +62,10 @@ namespace OpenVic {
 			decltype(ideology_distribution)::keys_span_type ideology_keys
 		);
 
+		constexpr static fixed_point_t& div_by_zero_return_0(fixed_point_t& lhs, pop_size_t const& rhs) {
+			return lhs = fixed_point_t::_0;
+		}
+
 	public:
 		memory::string get_identifier() const;
 
@@ -72,32 +76,32 @@ namespace OpenVic {
 		// The values returned by these functions are scaled by population size, so they must be divided by population size
 		// to get the support as a proportion of 1.0
 		constexpr pop_size_t get_pop_type_proportion(PopType const& pop_type) const {
-			return pop_type_distribution[pop_type];
+			return pop_type_distribution.at(pop_type);
 		}
 		constexpr pop_size_t get_pop_type_unemployed(PopType const& pop_type) const {
-			return pop_type_unemployed_count[pop_type];
+			return pop_type_unemployed_count.at(pop_type);
 		}
 		constexpr fixed_point_t get_ideology_support(Ideology const& ideology) const {
-			return ideology_distribution[ideology];
+			return ideology_distribution.at(ideology);
 		}
 		fixed_point_t get_issue_support(Issue const& issue) const;
 		fixed_point_t get_party_support(CountryParty const& party) const;
 		fixed_point_t get_culture_proportion(Culture const& culture) const;
 		fixed_point_t get_religion_proportion(Religion const& religion) const;
 		constexpr pop_size_t get_strata_population(Strata const& strata) const {
-			return population_by_strata[strata];
+			return population_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_militancy(Strata const& strata) const {
-			return militancy_by_strata[strata];
+			return militancy_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_life_needs_fulfilled(Strata const& strata) const {
-			return life_needs_fulfilled_by_strata[strata];
+			return life_needs_fulfilled_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_everyday_needs_fulfilled(Strata const& strata) const {
-			return everyday_needs_fulfilled_by_strata[strata];
+			return everyday_needs_fulfilled_by_strata.at(strata);
 		}
 		constexpr fixed_point_t get_strata_luxury_needs_fulfilled(Strata const& strata) const {
-			return luxury_needs_fulfilled_by_strata[strata];
+			return luxury_needs_fulfilled_by_strata.at(strata);
 		}
 
 		void update_gamestate();

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -38,7 +38,7 @@ TerrainTypeMapping::TerrainTypeMapping(
 
 bool TerrainTypeManager::generate_modifiers(ModifierManager& modifier_manager) const {
 	using enum ModifierEffect::format_t;
-	IndexedMap<TerrainType, ModifierEffectCache::unit_terrain_effects_t>& unit_terrain_effects =
+	IndexedMap<TerrainType, unit_terrain_effects_t>& unit_terrain_effects =
 		modifier_manager.modifier_effect_cache.unit_terrain_effects;
 
 	unit_terrain_effects.set_keys(get_terrain_types());
@@ -46,7 +46,7 @@ bool TerrainTypeManager::generate_modifiers(ModifierManager& modifier_manager) c
 	bool ret = true;
 	for (TerrainType const& terrain_type : get_terrain_types()) {
 		const std::string_view identifier = terrain_type.get_identifier();
-		ModifierEffectCache::unit_terrain_effects_t& this_unit_terrain_effects = unit_terrain_effects[terrain_type];
+		unit_terrain_effects_t& this_unit_terrain_effects = unit_terrain_effects[terrain_type];
 		ret &= modifier_manager.register_unit_terrain_modifier_effect(
 			this_unit_terrain_effects.attack, ModifierManager::get_flat_identifier("attack", identifier),
 			FORMAT_x100_1DP_PC_POS, "UA_ATTACK"

--- a/src/openvic-simulation/military/UnitInstanceGroup.hpp
+++ b/src/openvic-simulation/military/UnitInstanceGroup.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <span>
-#include <string>
 #include <string_view>
-#include <vector>
 
 #include <plf_colony.h>
 
@@ -25,7 +23,7 @@ namespace OpenVic {
 		const unique_id_t PROPERTY(unique_id);
 		const UnitType::branch_t PROPERTY(branch);
 		memory::string PROPERTY(name);
-		memory::vector<UnitInstance*> PROPERTY(units);
+		memory::vector<UnitInstance*> SPAN_PROPERTY(units);
 		LeaderInstance* PROPERTY_PTR(leader, nullptr);
 		ProvinceInstance* PROPERTY_PTR(position, nullptr);
 		CountryInstance* PROPERTY_PTR(country, nullptr);
@@ -38,7 +36,7 @@ namespace OpenVic {
 		// Movement attributes
 		// Ordered list of provinces making up the path the unit is trying to move along,
 		// the front province should always be adjacent to the unit's current position.
-		memory::vector<ProvinceInstance*> PROPERTY(path);
+		memory::vector<ProvinceInstance*> SPAN_PROPERTY(path);
 		// Measured in distance travelled, increases each day by unit speed (after modifiers have been applied) until
 		// it reaches the required distance/movement cost to move to the next province in the path.
 		fixed_point_t PROPERTY(movement_progress);
@@ -127,7 +125,7 @@ namespace OpenVic {
 		friend struct UnitInstanceManager;
 
 	private:
-		memory::vector<ArmyInstance*> PROPERTY(carried_armies);
+		memory::vector<ArmyInstance*> SPAN_PROPERTY(carried_armies);
 
 		UnitInstanceGroupBranched(
 			unique_id_t new_unique_id,

--- a/src/openvic-simulation/military/UnitType.cpp
+++ b/src/openvic-simulation/military/UnitType.cpp
@@ -311,7 +311,7 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 	bool ret = true;
 
 	const auto generate_stat_modifiers = [&modifier_manager, &ret](
-		std::derived_from<ModifierEffectCache::unit_type_effects_t> auto unit_type_effects, std::string_view identifier
+		std::derived_from<unit_type_effects_t> auto unit_type_effects, std::string_view identifier
 	) -> void {
 		using enum ModifierEffect::format_t;
 
@@ -330,7 +330,7 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 		// These are ordered following how they appear in the base game, hence the broken up land effects.
 		stat_modifier(unit_type_effects.default_organisation, "default_organisation", FORMAT_x1_1DP_POS, "DEFAULT_ORG");
 		stat_modifier(unit_type_effects.build_time, "build_time", FORMAT_x1_0DP_DAYS_NEG, "BUILD_TIME");
-		if constexpr (std::same_as<decltype(unit_type_effects), ModifierEffectCache::regiment_type_effects_t>) {
+		if constexpr (std::same_as<decltype(unit_type_effects), regiment_type_effects_t>) {
 			stat_modifier(
 				unit_type_effects.reconnaissance, "reconnaissance", FORMAT_x1_2DP_POS, "RECONAISSANCE" // paradox typo
 			);
@@ -338,13 +338,13 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 		}
 		stat_modifier(unit_type_effects.attack, "attack", FORMAT_x1_2DP_POS, "ATTACK");
 		stat_modifier(unit_type_effects.defence, "defence", FORMAT_x1_2DP_POS, "DEFENCE");
-		if constexpr (std::same_as<decltype(unit_type_effects), ModifierEffectCache::regiment_type_effects_t>) {
+		if constexpr (std::same_as<decltype(unit_type_effects), regiment_type_effects_t>) {
 			stat_modifier(unit_type_effects.discipline, "discipline", FORMAT_x100_0DP_PC_POS, "DISCIPLINE");
 			stat_modifier(unit_type_effects.support, "support", FORMAT_x100_0DP_PC_POS, "SUPPORT");
 			stat_modifier(unit_type_effects.maneuver, "maneuver", FORMAT_x1_0DP_POS, "Maneuver");
 		}
 		stat_modifier(unit_type_effects.maximum_speed, "maximum_speed", FORMAT_x1_2DP_SPEED_POS, "MAXIMUM_SPEED");
-		if constexpr(std::same_as<decltype(unit_type_effects), ModifierEffectCache::ship_type_effects_t>) {
+		if constexpr(std::same_as<decltype(unit_type_effects), ship_type_effects_t>) {
 			stat_modifier(unit_type_effects.gun_power, "gun_power", FORMAT_x1_2DP_POS, "GUN_POWER");
 			stat_modifier(unit_type_effects.torpedo_attack, "torpedo_attack", FORMAT_x1_2DP_POS, "TORPEDO_ATTACK");
 			stat_modifier(unit_type_effects.hull, "hull", FORMAT_x1_2DP_POS, "HULL");
@@ -354,7 +354,7 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 		stat_modifier(
 			unit_type_effects.supply_consumption, "supply_consumption", FORMAT_x100_0DP_PC_NEG, "SUPPLY_CONSUMPTION"
 		);
-		if constexpr(std::same_as<decltype(unit_type_effects), ModifierEffectCache::ship_type_effects_t>) {
+		if constexpr(std::same_as<decltype(unit_type_effects), ship_type_effects_t>) {
 			stat_modifier(
 				unit_type_effects.supply_consumption_score, "supply_consumption_score", FORMAT_x1_0DP_NEG, "SUPPLY_LOAD"
 			);
@@ -365,7 +365,7 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 
 	generate_stat_modifiers(modifier_manager.modifier_effect_cache.army_base_effects, "army_base");
 
-	IndexedMap<RegimentType, ModifierEffectCache::regiment_type_effects_t>& regiment_type_effects =
+	IndexedMap<RegimentType, regiment_type_effects_t>& regiment_type_effects =
 		modifier_manager.modifier_effect_cache.regiment_type_effects;
 
 	regiment_type_effects.set_keys(get_regiment_types());
@@ -376,7 +376,7 @@ bool UnitTypeManager::generate_modifiers(ModifierManager& modifier_manager) cons
 
 	generate_stat_modifiers(modifier_manager.modifier_effect_cache.navy_base_effects, "navy_base");
 
-	IndexedMap<ShipType, ModifierEffectCache::ship_type_effects_t>& ship_type_effects =
+	IndexedMap<ShipType, ship_type_effects_t>& ship_type_effects =
 		modifier_manager.modifier_effect_cache.ship_type_effects;
 
 	ship_type_effects.set_keys(get_ship_types());

--- a/src/openvic-simulation/modifier/ModifierEffectCache.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.hpp
@@ -20,6 +20,109 @@ namespace OpenVic {
 	struct TechnologyFolder;
 	struct TerrainTypeManager;
 	struct TerrainType;
+	
+	struct building_type_effects_t {
+		friend struct BuildingTypeManager;
+
+	private:
+		ModifierEffect const* PROPERTY(min_level, nullptr);
+		ModifierEffect const* PROPERTY(max_level, nullptr);
+
+	public:
+		building_type_effects_t() = default;
+	};
+
+	
+	struct good_effects_t {
+		friend struct GoodDefinitionManager;
+
+	private:
+		ModifierEffect const* PROPERTY(artisan_goods_input, nullptr);
+		ModifierEffect const* PROPERTY(artisan_goods_output, nullptr);
+		ModifierEffect const* PROPERTY(artisan_goods_throughput, nullptr);
+		ModifierEffect const* PROPERTY(factory_goods_input, nullptr);
+		ModifierEffect const* PROPERTY(factory_goods_output, nullptr);
+		ModifierEffect const* PROPERTY(factory_goods_throughput, nullptr);
+		ModifierEffect const* PROPERTY(rgo_goods_input, nullptr);
+		ModifierEffect const* PROPERTY(rgo_goods_output, nullptr);
+		ModifierEffect const* PROPERTY(rgo_goods_throughput, nullptr);
+		ModifierEffect const* PROPERTY(rgo_size, nullptr);
+
+	public:
+		good_effects_t() = default;
+	};
+	
+	struct unit_type_effects_t {
+		friend struct UnitTypeManager;
+
+	private:
+		ModifierEffect const* PROPERTY(attack, nullptr);
+		ModifierEffect const* PROPERTY(defence, nullptr);
+		ModifierEffect const* PROPERTY(default_organisation, nullptr);
+		ModifierEffect const* PROPERTY(maximum_speed, nullptr);
+		ModifierEffect const* PROPERTY(build_time, nullptr);
+		ModifierEffect const* PROPERTY(supply_consumption, nullptr);
+
+	protected:
+		unit_type_effects_t() = default;
+	};
+
+	struct regiment_type_effects_t : unit_type_effects_t {
+		friend struct UnitTypeManager;
+
+	private:
+		ModifierEffect const* PROPERTY(reconnaissance, nullptr);
+		ModifierEffect const* PROPERTY(discipline, nullptr);
+		ModifierEffect const* PROPERTY(support, nullptr);
+		ModifierEffect const* PROPERTY(maneuver, nullptr);
+		ModifierEffect const* PROPERTY(siege, nullptr);
+
+	public:
+		regiment_type_effects_t() = default;
+	};
+
+	struct ship_type_effects_t : unit_type_effects_t {
+		friend struct UnitTypeManager;
+
+	private:
+		ModifierEffect const* PROPERTY(colonial_points, nullptr);
+		ModifierEffect const* PROPERTY(supply_consumption_score, nullptr);
+		ModifierEffect const* PROPERTY(hull, nullptr);
+		ModifierEffect const* PROPERTY(gun_power, nullptr);
+		ModifierEffect const* PROPERTY(fire_range, nullptr);
+		ModifierEffect const* PROPERTY(evasion, nullptr);
+		ModifierEffect const* PROPERTY(torpedo_attack, nullptr);
+
+	public:
+		ship_type_effects_t() = default;
+	};
+	
+	struct strata_effects_t {
+		friend struct PopManager;
+
+	private:
+		ModifierEffect const* PROPERTY(income_modifier, nullptr);
+		ModifierEffect const* PROPERTY(vote, nullptr);
+		ModifierEffect const* PROPERTY(life_needs, nullptr);
+		ModifierEffect const* PROPERTY(everyday_needs, nullptr);
+		ModifierEffect const* PROPERTY(luxury_needs, nullptr);
+
+	public:
+		strata_effects_t() = default;
+	};
+
+	struct unit_terrain_effects_t {
+		friend struct TerrainTypeManager;
+
+	private:
+		ModifierEffect const* PROPERTY(attack, nullptr);
+		ModifierEffect const* PROPERTY(defence, nullptr);
+		ModifierEffect const* PROPERTY(attrition, nullptr);
+		ModifierEffect const* PROPERTY(movement, nullptr);
+
+	public:
+		unit_terrain_effects_t() = default;
+	};
 
 	struct ModifierEffectCache {
 		friend struct ModifierManager;
@@ -207,115 +310,14 @@ namespace OpenVic {
 		ModifierEffect const* PROPERTY(reliability, nullptr);
 		ModifierEffect const* PROPERTY(speed, nullptr);
 
-		/* BuildingType Effects */
-	public:
-		struct building_type_effects_t {
-			friend struct BuildingTypeManager;
-
-		private:
-			ModifierEffect const* PROPERTY(min_level, nullptr);
-			ModifierEffect const* PROPERTY(max_level, nullptr);
-
-		public:
-			building_type_effects_t() = default;
-		};
-
-	private:
 		IndexedMap<BuildingType, building_type_effects_t> PROPERTY(building_type_effects);
-
-		/* GoodDefinition Effects */
-	public:
-		struct good_effects_t {
-			friend struct GoodDefinitionManager;
-
-		private:
-			ModifierEffect const* PROPERTY(artisan_goods_input, nullptr);
-			ModifierEffect const* PROPERTY(artisan_goods_output, nullptr);
-			ModifierEffect const* PROPERTY(artisan_goods_throughput, nullptr);
-			ModifierEffect const* PROPERTY(factory_goods_input, nullptr);
-			ModifierEffect const* PROPERTY(factory_goods_output, nullptr);
-			ModifierEffect const* PROPERTY(factory_goods_throughput, nullptr);
-			ModifierEffect const* PROPERTY(rgo_goods_input, nullptr);
-			ModifierEffect const* PROPERTY(rgo_goods_output, nullptr);
-			ModifierEffect const* PROPERTY(rgo_goods_throughput, nullptr);
-			ModifierEffect const* PROPERTY(rgo_size, nullptr);
-
-		public:
-			good_effects_t() = default;
-		};
-
-	private:
 		IndexedMap<GoodDefinition, good_effects_t> PROPERTY(good_effects);
 
 		/* UnitType Effects */
-	public:
-		struct unit_type_effects_t {
-			friend struct UnitTypeManager;
-
-		private:
-			ModifierEffect const* PROPERTY(attack, nullptr);
-			ModifierEffect const* PROPERTY(defence, nullptr);
-			ModifierEffect const* PROPERTY(default_organisation, nullptr);
-			ModifierEffect const* PROPERTY(maximum_speed, nullptr);
-			ModifierEffect const* PROPERTY(build_time, nullptr);
-			ModifierEffect const* PROPERTY(supply_consumption, nullptr);
-
-		protected:
-			unit_type_effects_t() = default;
-		};
-
-		struct regiment_type_effects_t : unit_type_effects_t {
-			friend struct UnitTypeManager;
-
-		private:
-			ModifierEffect const* PROPERTY(reconnaissance, nullptr);
-			ModifierEffect const* PROPERTY(discipline, nullptr);
-			ModifierEffect const* PROPERTY(support, nullptr);
-			ModifierEffect const* PROPERTY(maneuver, nullptr);
-			ModifierEffect const* PROPERTY(siege, nullptr);
-
-		public:
-			regiment_type_effects_t() = default;
-		};
-
-		struct ship_type_effects_t : unit_type_effects_t {
-			friend struct UnitTypeManager;
-
-		private:
-			ModifierEffect const* PROPERTY(colonial_points, nullptr);
-			ModifierEffect const* PROPERTY(supply_consumption_score, nullptr);
-			ModifierEffect const* PROPERTY(hull, nullptr);
-			ModifierEffect const* PROPERTY(gun_power, nullptr);
-			ModifierEffect const* PROPERTY(fire_range, nullptr);
-			ModifierEffect const* PROPERTY(evasion, nullptr);
-			ModifierEffect const* PROPERTY(torpedo_attack, nullptr);
-
-		public:
-			ship_type_effects_t() = default;
-		};
-
-	private:
 		regiment_type_effects_t PROPERTY(army_base_effects);
 		IndexedMap<RegimentType, regiment_type_effects_t> PROPERTY(regiment_type_effects);
 		ship_type_effects_t PROPERTY(navy_base_effects);
 		IndexedMap<ShipType, ship_type_effects_t> PROPERTY(ship_type_effects);
-
-		/* Unit terrain Effects */
-	public:
-		struct unit_terrain_effects_t {
-			friend struct TerrainTypeManager;
-
-		private:
-			ModifierEffect const* PROPERTY(attack, nullptr);
-			ModifierEffect const* PROPERTY(defence, nullptr);
-			ModifierEffect const* PROPERTY(attrition, nullptr);
-			ModifierEffect const* PROPERTY(movement, nullptr);
-
-		public:
-			unit_terrain_effects_t() = default;
-		};
-
-	private:
 		IndexedMap<TerrainType, unit_terrain_effects_t> PROPERTY(unit_terrain_effects);
 
 		/* Rebel Effects */
@@ -323,22 +325,6 @@ namespace OpenVic {
 		IndexedMap<RebelType, ModifierEffect const*> PROPERTY(rebel_org_gain_effects);
 
 		/* Pop Effects */
-	public:
-		struct strata_effects_t {
-			friend struct PopManager;
-
-		private:
-			ModifierEffect const* PROPERTY(income_modifier, nullptr);
-			ModifierEffect const* PROPERTY(vote, nullptr);
-			ModifierEffect const* PROPERTY(life_needs, nullptr);
-			ModifierEffect const* PROPERTY(everyday_needs, nullptr);
-			ModifierEffect const* PROPERTY(luxury_needs, nullptr);
-
-		public:
-			strata_effects_t() = default;
-		};
-
-	private:
 		IndexedMap<Strata, strata_effects_t> PROPERTY(strata_effects);
 
 		/* Technology Effects */

--- a/src/openvic-simulation/pop/Pop.hpp
+++ b/src/openvic-simulation/pop/Pop.hpp
@@ -6,6 +6,7 @@
 #include "openvic-simulation/pop/PopType.hpp"
 #include "openvic-simulation/types/fixed_point/Atomic.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/PopSize.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 #include "openvic-simulation/utility/ForwardableSpan.hpp"
@@ -103,7 +104,7 @@ namespace OpenVic {
 		// All of these should have a total size equal to the pop size, allowing the distributions from different pops to be
 		// added together with automatic weighting based on their relative sizes. Similarly, the province, state and country
 		// equivalents of these distributions will have a total size equal to their total population size.
-		IndexedMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
+		IndexedFlatMap<Ideology, fixed_point_t> PROPERTY(ideology_distribution);
 		fixed_point_map_t<Issue const*> PROPERTY(issue_distribution);
 		IndexedMap<CountryParty, fixed_point_t> PROPERTY(vote_distribution);
 

--- a/src/openvic-simulation/pop/PopType.cpp
+++ b/src/openvic-simulation/pop/PopType.cpp
@@ -574,7 +574,7 @@ bool PopManager::generate_modifiers(ModifierManager& modifier_manager) const {
 
 	static constexpr bool HAS_NO_EFFECT = true;
 
-	IndexedMap<Strata, ModifierEffectCache::strata_effects_t>& strata_effects =
+	IndexedMap<Strata, strata_effects_t>& strata_effects =
 		modifier_manager.modifier_effect_cache.strata_effects;
 
 	strata_effects.set_keys(get_stratas());
@@ -591,7 +591,7 @@ bool PopManager::generate_modifiers(ModifierManager& modifier_manager) const {
 			);
 		};
 
-		ModifierEffectCache::strata_effects_t& this_strata_effects = strata_effects[strata];
+		strata_effects_t& this_strata_effects = strata_effects[strata];
 
 		strata_modifier(this_strata_effects.income_modifier, "_income_modifier", FORMAT_x100_1DP_PC_POS, HAS_NO_EFFECT);
 		strata_modifier(this_strata_effects.vote, "_vote", FORMAT_x100_1DP_PC_POS);

--- a/src/openvic-simulation/pop/PopValuesFromProvince.cpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.cpp
@@ -14,7 +14,7 @@ void PopStrataValuesFromProvince::update_pop_strata_values_from_province(
 	ProvinceInstance const& province
 ) {
 	ModifierEffectCache const& modifier_effect_cache = province.get_modifier_effect_cache();
-	ModifierEffectCache::strata_effects_t const& strata_effects = modifier_effect_cache.get_strata_effects()[strata];
+	strata_effects_t const& strata_effects = modifier_effect_cache.get_strata_effects()[strata];
 	fixed_point_t shared_base_needs_scalar = defines.get_base_goods_demand()
 		* (fixed_point_t::_1 + province.get_modifier_effect_value(*modifier_effect_cache.get_goods_demand()));
 

--- a/src/openvic-simulation/types/IndexedFlatMap.hpp
+++ b/src/openvic-simulation/types/IndexedFlatMap.hpp
@@ -1,0 +1,943 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+#include <utility>
+
+#include <function2/function2.hpp>
+
+#include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/ForwardableSpan.hpp"
+#include "openvic-simulation/utility/MathConcepts.hpp"
+#include "openvic-simulation/utility/Logger.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	concept HasGetIndex = requires(T const& key) {
+		{ key.get_index() } -> std::convertible_to<size_t>;
+	};
+
+	/**
+	* @brief A dictionary-like type that uses std::vector for contiguous storage,
+	* providing O(1) access time by directly using an integer index obtained from the KeyType.
+	* It strictly assumes that keys provided at construction are ordered and continuous
+	* in their index values.
+	* @tparam KeyType The type of keys used to access values. This type must provide a
+	* `size_t getIndex() const` method.
+	* @tparam ValueType The type of values to be stored in the map.
+	*
+	* This class assumes that an integer index can be obtained from the key type
+	* via its `getIndex()` method. The indices used with this map must be within
+	* the specified range [min_index, max_index].
+	*
+	* @warning This class stores a `std::span` of the provided keys. This means the
+	* `IndexedFlatMap` does NOT own the lifetime of the keys. The caller is
+	* responsible for ensuring that the underlying data (the `std::vector` or array)
+	* that the `std::span` refers to remains valid and outlives the `IndexedFlatMap` instance.
+	*/
+	template <typename KeyType, typename ValueType>
+	requires HasGetIndex<KeyType> // Enforce the HasGetIndex concept for KeyType
+	struct IndexedFlatMap {
+		using keys_span_type = OpenVic::utility::forwardable_span<const KeyType>;
+		using values_vector_type = memory::vector<ValueType>;
+
+	private:
+		values_vector_type values;
+		keys_span_type keys; //non-owning!
+		size_t min_index;
+		size_t max_index;
+
+		/**
+		* @brief Converts an external key's index to an internal vector index.
+		* Logs a fatal error if the key's index is out of bounds.
+		* @param key The key whose index is to be converted.
+		* @return The internal index, or 0 if out of bounds (after logging error).
+		*/
+		constexpr size_t get_internal_index_from_key(KeyType const& key) const {
+			// In this project, exceptions are disabled.
+			// Instead of throwing, we log an error and return a potentially invalid index.
+			// The caller must handle the error or ensure valid key access.
+			if (key.get_index() < min_index || key.get_index() > max_index) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> attempted to access key with index ", std::to_string(key.get_index()),
+					" which is outside the map's defined range [",
+					std::to_string(min_index), ", ",
+					std::to_string(max_index), "].\n"
+				);
+				// Return a value that will likely cause a crash or be caught by further checks
+				// if not handled by the caller, consistent with "fatal" error.
+				return 0; // Or some other indicator of invalidity if appropriate
+			}
+			return key.get_index() - min_index;
+		}
+
+		/**
+		* @brief Validates that the provided span of keys is ordered and continuous.
+		* Logs errors if validation fails.
+		* @param new_keys The span of keys to validate.
+		* @return True if keys are valid, false otherwise.
+		*/
+		static bool validate_new_keys(keys_span_type new_keys) {
+			if (new_keys.empty()) {
+				Logger::warning(
+					"DEVELOPER WARNING: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> should not be constructed with empty key span."
+				);
+				return false;
+			}
+
+			const size_t min_index = new_keys.front().get_index();
+			const size_t max_index = new_keys.back().get_index();
+			const size_t expected_capacity = max_index - min_index + 1;
+
+			if (new_keys.size() != expected_capacity) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> must be constructed with a continuous span of keys with incremental indices.\n",
+					"Expected capacity ", std::to_string(expected_capacity),
+					" but got ", std::to_string(new_keys.size()), " keys."
+				);
+				return false;
+			}
+
+			for (size_t i = 0; i < new_keys.size(); ++i) {
+				if (new_keys[i].get_index() != min_index + i) {
+					Logger::error(
+						"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+						utility::type_name<KeyType>(),",",
+						utility::type_name<ValueType>(),
+						"> must be constructed with a continuous span of keys with incremental indices.\n",
+						"Expected index ", std::to_string(min_index + i),
+						" but got ", std::to_string(new_keys[i].get_index()), " at position ", std::to_string(i), "."
+					);
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		//could be rewritten to return iterators for both this and other.
+		//that would overcomplicate it with const & non-const
+		template <typename OtherValueType>
+		keys_span_type get_shared_keys(IndexedFlatMap<KeyType,OtherValueType> const& other) const {
+			if (other.get_min_index() >= min_index && other.get_max_index() <= max_index) {
+				return other.get_keys();
+			}
+
+			const size_t min_shared_index = std::max(other.get_min_index(), min_index);
+			const size_t max_shared_index = std::min(other.get_max_index(), max_index);
+			const size_t shared_count = max_shared_index - min_shared_index;
+			if (shared_count < 1) {
+				return {};
+			}
+			const size_t other_keys_offset = min_shared_index - other.get_min_index();
+			return {other.get_keys().data() + other_keys_offset, shared_count};
+		}
+
+		/**
+		* @brief Checks if the 'other' IndexedFlatMap's key span is a subset of 'this' map's key span,
+		* based purely on index ranges.
+		* Logs a fatal error if not compatible.
+		* @param other The other IndexedFlatMap to compare with.
+		* @return True if compatible as a subset, false otherwise.
+		*/
+		template <typename OtherValueType>
+		bool check_subset_span_match(IndexedFlatMap<KeyType,OtherValueType> const& other) const {
+			// Check if 'other's index range is contained within 'this's index range
+			if (!(other.get_min_index() >= min_index && other.get_max_index() <= max_index)) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> subset operation requires the right-hand map's index range (",
+					std::to_string(other.get_min_index()), "-", std::to_string(other.get_max_index()),
+					") to be a subset of the left-hand map's index range (",
+					std::to_string(min_index), "-", std::to_string(max_index), ")."
+				);
+				return false;
+			}
+
+			// There is no check for keys.data() being identical as KeyType objects are considered functionally equivalent if their get_index() values match.
+			return true;
+		}
+
+	public:
+		/**
+		* @brief Constructs an IndexedFlatMap based on a provided span of ordered and continuous keys
+		* and a key-based generator.
+		* The map's range [min_idx, max_idx] is determined by the first and last key in the span.
+		* All elements are initialized using the `value_generator`.
+		* @param new_keys A `std::span<const KeyType>` of KeyType objects. These keys MUST be
+		* ordered by their index and continuous (i.e., `new_keys[i+1].getIndex() == new_keys[i].getIndex() + 1`).
+		* The `IndexedFlatMap` stores a reference to this span; the caller is responsible
+		* for ensuring the underlying data outlives this map instance.
+		* @param value_generator A callable that takes a `KeyType const&` and returns a `ValueType`.
+		* This is used to generate values for each key in the provided span.
+		*/
+		IndexedFlatMap(
+			keys_span_type new_keys,
+			fu2::function<ValueType(KeyType const&)> value_generator
+		) : keys(new_keys)
+		{
+			if (!validate_new_keys(new_keys)) {
+				keys = {};
+				return;
+			}
+			min_index = keys.front().get_index();
+			max_index = keys.back().get_index();
+			size_t expected_capacity = max_index - min_index + 1;
+			values.reserve(expected_capacity);
+			for (KeyType const& key : keys) {
+				values.emplace_back(value_generator(key));
+			}
+		}
+
+		/**
+		* @brief Constructs an IndexedFlatMap based on a provided span of ordered and continuous keys.
+		* All elements are default-constructed upon creation.
+		* @param new_keys A `std::span<const KeyType>` of KeyType objects. These keys MUST be
+		* ordered by their index and continuous (i.e., `new_keys[i+1].getIndex() == new_keys[i].getIndex() + 1`).
+		* The `IndexedFlatMap` stores a reference to this span; the caller is responsible
+		* for ensuring the underlying data outlives this map instance.
+		*
+		* @note This constructor requires `ValueType` to be `std::default_initializable`.
+		*/
+		IndexedFlatMap(keys_span_type new_keys)
+			requires std::default_initializable<ValueType>
+			: keys(new_keys)
+		{
+			if (!validate_new_keys(new_keys)) {
+				keys = {};
+				return;
+			}
+			min_index = keys.front().get_index();
+			max_index = keys.back().get_index();
+			size_t expected_capacity = max_index - min_index + 1;
+			// Resize and default-construct elements
+			values.resize(expected_capacity);
+		}
+
+		/**
+			* @brief Default constructor, creates an empty map.
+			* Useful for returning an invalid state on error in other operations.
+			*/
+		IndexedFlatMap() : values(), keys(), min_index(0), max_index(0) {}
+
+		/**
+		* @brief Sets the value associated with a key using copy assignment.
+		*/
+		void set(KeyType const& key, ValueType const& value)
+			requires std::assignable_from<ValueType&, ValueType const&>
+		{
+			values[get_internal_index_from_key(key)] = value;
+		}
+
+		/**
+		* @brief Sets the value associated with a key using move assignment (via std::swap).
+		*/
+		void set(KeyType const& key, ValueType&& value)
+			requires std::movable<ValueType>
+		{
+			std::swap(
+				values[get_internal_index_from_key(key)],
+				value
+			);
+		}
+
+		constexpr ValueType& at(KeyType const& key) {
+			return values[get_internal_index_from_key(key)];
+		}
+
+		constexpr ValueType const& at(KeyType const& key) const {
+			return values[get_internal_index_from_key(key)];
+		}
+
+		constexpr bool contains(KeyType const& key) const {
+			size_t external_index = key.get_index();
+			return external_index >= min_index && external_index <= max_index;
+		}
+
+		constexpr keys_span_type const& get_keys() const {
+			return keys;
+		}
+		
+		constexpr OpenVic::utility::forwardable_span<ValueType> get_values() {
+			return values;
+		}
+
+		constexpr OpenVic::utility::forwardable_span<const ValueType> get_values() const {
+			return values;
+		}
+
+		constexpr size_t get_count() const {
+			return keys.size();
+		}
+
+		constexpr size_t get_min_index() const {
+			return min_index;
+		}
+
+		constexpr size_t get_max_index() const {
+			return max_index;
+		}
+
+		/**
+		* @brief Fills all elements in the map with a specified value.
+		* The capacity and index range remain unchanged.
+		* @param value The value to fill all elements with.
+		*
+		* @note This method requires `ValueType` to be copy-constructible and copy-assignable.
+		*/
+		void fill(ValueType const& value)
+			requires std::copy_constructible<ValueType> && std::assignable_from<ValueType&, ValueType const&>
+		{
+			values.assign(values.size(), value);
+		}
+
+		constexpr void copy_values_from(IndexedFlatMap const& other)
+			requires std::assignable_from<ValueType&, ValueType const&> {
+			for (KeyType const& key : get_shared_keys(other)) {
+				set(key, other.at(key));
+			}
+		}
+
+		/**
+		* @brief Reinitializes all elements in the map using a provided value generator function.
+		* This overload is chosen for types that are copyable (have a copy constructor and copy assignment).
+		* The capacity and index range remain unchanged.
+		* @param value_generator A callable that takes a `KeyType const&` and
+		* returns a `ValueType`. This is used to generate a new value for each slot.
+		*
+		* @note This method requires `ValueType` to be copy-assignable.
+		*/
+		void reinitialize_with_generator(fu2::function<ValueType(KeyType const&)> value_generator)
+			requires std::copyable<ValueType>
+		{
+			for (size_t i = 0; i < values.size(); ++i) {
+				values[i] = value_generator(keys[i]); // Copy/Move assignment
+			}
+		}
+
+		/**
+		* @brief Reinitializes all elements in the map using a provided value generator function.
+		* This overload is chosen for types that are movable but NOT copyable.
+		* The capacity and index range remain unchanged.
+		* @param value_generator A callable that takes a `KeyType const&` and
+		* returns a `ValueType`. This is used to generate a new value for each slot.
+		*
+		* @note This method destroys existing elements and constructs new ones in place,
+		* which is often more efficient for move-only types.
+		*/
+		void reinitialize_with_generator(fu2::function<ValueType(KeyType const&)> value_generator)
+			requires std::movable<ValueType> && (!std::copyable<ValueType>)
+		{
+			values.clear();
+			for (KeyType const& key : keys) {
+				// Emplace directly, using move construction if generator returns rvalue
+				values.emplace_back(value_generator(key));
+			}
+		}
+
+		// --- Mathematical Operators (Valarray-like functionality) ---
+
+		// Unary plus operator
+		IndexedFlatMap<KeyType, ValueType> operator+() const
+		{
+			// Unary plus typically returns a copy of itself
+			return *this;
+		}
+
+		// Unary minus operator
+		IndexedFlatMap<KeyType, ValueType> operator-() const
+			requires UnaryNegatable<ValueType>
+		{
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				return -this->at(key);
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap<KeyType, ValueType> operator+(IndexedFlatMap<KeyType,OtherValueType> const& other) const
+			requires Addable<ValueType,OtherValueType,ValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return IndexedFlatMap();
+			}
+
+			// Create a new map with the same keys as 'this'
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				if (other.contains(key)) {
+					// If the key exists in 'other' (i.e., within its min_index/max_index),
+					// perform the operation.
+					return this->at(key) + other.at(key);
+				} else {
+					// If the key does not exist in 'other' (i.e., outside its min_index/max_index),
+					// retain the value from 'this'.
+					return this->at(key);
+				}
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap<KeyType, ValueType> operator-(IndexedFlatMap<KeyType,OtherValueType> const& other) const
+			requires Subtractable<ValueType,OtherValueType,KeyType>
+		{
+			if (!check_subset_span_match(other)) {
+				return IndexedFlatMap();
+			}
+
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				if (other.contains(key)) {
+					return this->at(key) - other.at(key);
+				} else {
+					return this->at(key);
+				}
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap<KeyType, ValueType> operator*(IndexedFlatMap<KeyType,OtherValueType> const& other) const
+			requires Multipliable<ValueType,OtherValueType,ValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return IndexedFlatMap();
+			}
+
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				if (other.contains(key)) {
+					return this->at(key) * other.at(key);
+				} else {
+					return this->at(key);
+				}
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap<KeyType, ValueType> operator/(IndexedFlatMap<KeyType,OtherValueType> const& other) const
+			requires Divisible<ValueType,OtherValueType,ValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return IndexedFlatMap();
+			}
+
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				// Add a basic division by zero check for each element
+				if (other.contains(key)) {
+					if (other.at(key) == static_cast<ValueType>(0)) {
+						Logger::error(
+							"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+							utility::type_name<KeyType>(),",",
+							utility::type_name<ValueType>(),
+							"> division by zero detected at key index ", std::to_string(key.get_index()), "."
+						);
+						//continue and let it throw
+					}
+					return this->at(key) / other.at(key);
+				} else {
+					return this->at(key); // Retain original value if key not in 'other'
+				}
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap<KeyType, ValueType> divide_handle_zero(
+			IndexedFlatMap<KeyType,OtherValueType> const& other,
+			fu2::function<ValueType(ValueType const&, OtherValueType const&)> handle_div_by_zero
+		) const
+			requires Divisible<ValueType,OtherValueType,ValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return IndexedFlatMap();
+			}
+
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				if (other.contains(key)) {
+					if (other.at(key) == static_cast<ValueType>(0)) {
+						return handle_div_by_zero(
+							this->at(key),
+							other.at(key)
+						);
+					}
+					return this->at(key) / other.at(key);
+				} else {
+					return this->at(key); // Retain original value if key not in 'other'
+				}
+			});
+		}
+
+		// Binary addition operator (Map + Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap<KeyType, ValueType> operator+(ScalarType const& scalar) const
+			requires Addable<ValueType,ScalarType,ValueType>
+		{
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				return this->at(key) + scalar;
+			});
+		}
+
+		// Binary subtraction operator (Map - Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap<KeyType, ValueType> operator-(ScalarType const& scalar) const
+			requires Subtractable<ValueType,ScalarType,ValueType>
+		{
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				return this->at(key) - scalar;
+			});
+		}
+
+		// Binary multiplication operator (Map * Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap<KeyType, ValueType> operator*(ScalarType const& scalar) const
+			requires Multipliable<ValueType,ScalarType,ValueType>
+		{
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				return this->at(key) * scalar;
+			});
+		}
+
+		// Binary division operator (Map / Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap<KeyType, ValueType> operator/(ScalarType const& scalar) const
+			requires Divisible<ValueType,ScalarType,ValueType>
+		{
+			if (scalar == static_cast<ValueType>(0)) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> division by zero for scalar operation."
+				);
+				//continue and let it throw
+			}
+			return IndexedFlatMap(keys, [&](KeyType const& key) {
+				return this->at(key) / scalar;
+			});
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap& operator+=(IndexedFlatMap<KeyType,OtherValueType> const& other)
+			requires AddAssignable<ValueType,OtherValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return *this; // Return current state on error
+			}
+
+			// Iterate only over the keys that are present in 'other'
+			for (KeyType const& key : other.get_keys()) {
+				this->at(key) += other.at(key);
+			}
+			return *this;
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap& operator-=(IndexedFlatMap<KeyType,OtherValueType> const& other)
+			requires SubtractAssignable<ValueType,OtherValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return *this;
+			}
+
+			for (KeyType const& key : other.get_keys()) {
+				this->at(key) -= other.at(key);
+			}
+			return *this;
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap& operator*=(IndexedFlatMap<KeyType,OtherValueType> const& other)
+			requires MultiplyAssignable<ValueType,OtherValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return *this;
+			}
+
+			for (KeyType const& key : other.get_keys()) {
+				this->at(key) *= other.at(key);
+			}
+			return *this;
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap& operator/=(IndexedFlatMap<KeyType,OtherValueType> const& other)
+			requires DivideAssignable<ValueType,OtherValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return *this;
+			}
+
+			for (KeyType const& key : other.get_keys()) {
+				if (other.at(key) == static_cast<ValueType>(0)) {
+					Logger::error(
+						"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+						utility::type_name<KeyType>(),",",
+						utility::type_name<ValueType>(),
+						"> compound division by zero detected at key index ", std::to_string(key.get_index()), "."
+					);
+					//continue and let it throw
+				}
+				this->at(key) /= other.at(key);
+			}
+			return *this;
+		}
+
+		template <typename OtherValueType>
+		IndexedFlatMap& divide_assign_handle_zero(
+			IndexedFlatMap<KeyType,OtherValueType> const& other,
+			fu2::function<ValueType&(ValueType&, OtherValueType const&)> handle_div_by_zero
+		)
+			requires DivideAssignable<ValueType,OtherValueType>
+		{
+			if (!check_subset_span_match(other)) {
+				return *this;
+			}
+
+			for (KeyType const& key : other.get_keys()) {
+				if (other.at(key) == static_cast<ValueType>(0)) {
+					handle_div_by_zero(
+						this->at(key),
+						other.at(key)
+					);
+				} else {
+					this->at(key) /= other.at(key);
+				}
+			}
+			return *this;
+		}
+
+		// Compound assignment addition operator (Map += Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap& operator+=(ScalarType const& scalar)
+			requires AddAssignable<ValueType,ScalarType>
+		{
+			for (ValueType& val : values) {
+				val += scalar;
+			}
+			return *this;
+		}
+
+		// Compound assignment subtraction operator (Map -= Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap& operator-=(ScalarType const& scalar)
+			requires SubtractAssignable<ValueType,ScalarType>
+		{
+			for (ValueType& val : values) {
+				val -= scalar;
+			}
+			return *this;
+		}
+
+		// Compound assignment multiplication operator (Map *= Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap& operator*=(ScalarType const& scalar)
+			requires MultiplyAssignable<ValueType,ScalarType>
+		{
+			for (ValueType& val : values) {
+				val *= scalar;
+			}
+			return *this;
+		}
+
+		// Compound assignment division operator (Map /= Scalar)
+		template <typename ScalarType>
+		IndexedFlatMap& operator/=(ScalarType const& scalar)
+			requires DivideAssignable<ValueType,ScalarType>
+		{
+			if (scalar == static_cast<ValueType>(0)) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> compound division by zero for scalar operation."
+				);
+				//continue and let it throw
+			}
+			for (ValueType& val : values) {
+				val /= scalar;
+			}
+			return *this;
+		}
+
+		template <typename OtherValueType,typename ScalarType>
+		constexpr IndexedFlatMap& mul_add(IndexedFlatMap<KeyType,OtherValueType> const& other, ScalarType const& factor)
+			requires (
+				AddAssignable<ValueType,OtherValueType>
+				&& Multipliable<OtherValueType,ScalarType,OtherValueType>
+			) || (
+				AddAssignable<ValueType,ScalarType>
+				&& Multipliable<OtherValueType,ScalarType,ScalarType>
+			)
+		{
+			for (KeyType const& key : get_shared_keys(other)) {
+				at(key) += other.at(key) * factor;
+			}
+
+			return *this;
+		}
+
+		template <typename ValueTypeA,typename ValueTypeB>
+		constexpr IndexedFlatMap& mul_add(
+			IndexedFlatMap<KeyType,ValueTypeA> const& a,
+			IndexedFlatMap<KeyType,ValueTypeB> const& b
+		) requires (
+				AddAssignable<ValueType,ValueTypeA>
+				&& Multipliable<ValueTypeA,ValueTypeB,ValueTypeA>
+			) || (
+				AddAssignable<ValueType,ValueTypeB>
+				&& Multipliable<ValueTypeA,ValueTypeB,ValueTypeB>
+			)
+		{
+			if (a.get_min_index() != b.get_min_index() || a.get_max_index() != b.get_max_index()) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> attempted mul_add where a and b don't have the same keys. This is not implemented."
+				);
+			}
+
+			for (KeyType const& key : get_shared_keys(a)) {
+				at(key) += a.at(key) * b.at(key);
+			}
+
+			return *this;
+		}
+
+		template <typename ScalarType>
+		constexpr IndexedFlatMap& rescale(ScalarType const& new_total)
+			requires std::default_initializable<ValueType>
+			&& AddAssignable<ValueType>
+			&& MultiplyAssignable<ValueType,ScalarType>
+			&& DivideAssignable<ValueType>
+		{
+			bool has_any_non_zero_value = false;
+			const ValueType zero = static_cast<ValueType>(0);
+			ValueType old_total {};
+			for (ValueType const& value : values) {
+				old_total += value;
+				has_any_non_zero_value |= value != zero;
+			}
+			IndexedFlatMap& this_ref = *this;
+			if (has_any_non_zero_value) {
+				this_ref *= new_total;
+				this_ref /= old_total;
+			}
+			return this_ref;
+		}
+
+		// --- Iterators for Key-Value Pairs ---
+		template <bool IsConst>
+		class BasicIterator {
+		public:
+			using value_type = std::pair<KeyType const&, std::conditional_t<IsConst, ValueType const&, ValueType&>>;
+			using difference_type = std::ptrdiff_t;
+			using reference = value_type;
+			using iterator_category = std::random_access_iterator_tag;
+
+		private:
+			std::conditional_t<IsConst, typename values_vector_type::const_iterator, typename values_vector_type::iterator> value_it;
+			typename keys_span_type::iterator key_it;
+
+		public:
+			// Constructor
+			BasicIterator(
+				std::conditional_t<IsConst, typename values_vector_type::const_iterator, typename values_vector_type::iterator> val_it,
+				typename keys_span_type::iterator k_it
+			) : value_it(val_it), key_it(k_it) {}
+
+			// Dereference operator
+			reference operator*() const {
+				return {*key_it, *value_it};
+			}
+
+			// Arrow operator (for member access)
+			// Note: This returns a proxy object, as std::pair is not a class type.
+			// For direct member access, it's often better to dereference and use dot operator: (*it).first
+			// However, for compatibility with some algorithms, a proxy is provided.
+			struct Proxy {
+				KeyType const& first;
+				std::conditional_t<IsConst, ValueType const&, ValueType&> second;
+				// Add operator-> for nested access if needed, e.g., Proxy->first.some_member()
+				// For now, direct access to first/second is assumed.
+			};
+			Proxy operator->() const {
+				return {*key_it, *value_it};
+			}
+
+			// Pre-increment
+			BasicIterator& operator++() {
+				++value_it;
+				++key_it;
+				return *this;
+			}
+
+			// Post-increment
+			BasicIterator operator++(int) {
+				BasicIterator temp = *this;
+				++(*this);
+				return temp;
+			}
+
+			// Pre-decrement
+			BasicIterator& operator--() {
+				--value_it;
+				--key_it;
+				return *this;
+			}
+
+			// Post-decrement
+			BasicIterator operator--(int) {
+				BasicIterator temp = *this;
+				--(*this);
+				return temp;
+			}
+
+			// Random access operators
+			BasicIterator& operator+=(difference_type n) {
+				value_it += n;
+				key_it += n;
+				return *this;
+			}
+
+			BasicIterator operator+(difference_type n) const {
+				BasicIterator temp = *this;
+				temp += n;
+				return temp;
+			}
+
+			BasicIterator& operator-=(difference_type n) {
+				value_it -= n;
+				key_it -= n;
+				return *this;
+			}
+
+			BasicIterator operator-(difference_type n) const {
+				BasicIterator temp = *this;
+				temp -= n;
+				return temp;
+			}
+
+			difference_type operator-(BasicIterator const& other) const {
+				return value_it - other.value_it;
+			}
+
+			// Comparison operators
+			bool operator==(BasicIterator const& other) const {
+				return value_it == other.value_it;
+			}
+
+			bool operator!=(BasicIterator const& other) const {
+				return !(*this == other);
+			}
+
+			bool operator<(BasicIterator const& other) const {
+				return value_it < other.value_it;
+			}
+
+			bool operator>(BasicIterator const& other) const {
+				return value_it > other.value_it;
+			}
+
+			bool operator<=(BasicIterator const& other) const {
+				return value_it <= other.value_it;
+			}
+
+			bool operator>=(BasicIterator const& other) const {
+				return value_it >= other.value_it;
+			}
+
+			// Conversion to const_iterator
+			operator BasicIterator<true>() const {
+				return BasicIterator<true>(value_it, key_it);
+			}
+		};
+
+		using iterator = BasicIterator<false>;
+		using const_iterator = BasicIterator<true>;
+
+		// Begin and End methods
+		// note cbegin & cend for std::span<T> requires c++23 so begin & end are used instead
+		iterator begin() {
+			return iterator(values.begin(), keys.begin());
+		}
+
+		const_iterator begin() const {
+			return const_iterator(values.cbegin(), keys.begin());
+		}
+
+		const_iterator cbegin() const {
+			return const_iterator(values.cbegin(), keys.begin());
+		}
+
+		iterator end() {
+			return iterator(values.end(), keys.end());
+		}
+
+		const_iterator end() const {
+			return const_iterator(values.cend(), keys.end());
+		}
+
+		const_iterator cend() const {
+			return const_iterator(values.cend(), keys.end());
+		}
+	};
+
+	// Non-member binary operators for (Scalar op Map)
+	template <typename ScalarType, typename KeyType, typename ValueType>
+	IndexedFlatMap<KeyType, ValueType> operator+(
+		ScalarType const& scalar,
+		IndexedFlatMap<KeyType, ValueType> const& map
+	) requires Addable<ValueType,ScalarType,ValueType>
+	{
+		return map + scalar; // Delegate to the member operator
+	}
+
+	template <typename ScalarType, typename KeyType, typename ValueType>
+	IndexedFlatMap<KeyType, ValueType> operator-(
+		ValueType const& scalar,
+		IndexedFlatMap<KeyType, ValueType> const& map
+	) requires Subtractable<ScalarType,ValueType,ValueType>
+	{
+		// Scalar - Map is not simply map - scalar, so we implement it directly
+		return IndexedFlatMap<KeyType, ValueType>(map.get_keys(), [&](KeyType const& key) {
+			return scalar - map.at(key);
+		});
+	}
+
+	template <typename ScalarType, typename KeyType, typename ValueType>
+	IndexedFlatMap<KeyType, ValueType> operator*(
+		ScalarType const& scalar,
+		IndexedFlatMap<KeyType, ValueType> const& map
+	) requires Multipliable<ValueType,ScalarType,ValueType>
+	{
+		return map * scalar; // Delegate to the member operator
+	}
+
+	template <typename ScalarType, typename KeyType, typename ValueType>
+	IndexedFlatMap<KeyType, ValueType> operator/(
+		ScalarType const& scalar,
+		IndexedFlatMap<KeyType, ValueType> const& map
+	) requires Divisible<ScalarType, ValueType, ValueType>
+	{
+		return IndexedFlatMap<KeyType, ValueType>(map.get_keys(), [&](KeyType const& key) {
+			if (map.at(key) == static_cast<ValueType>(0)) {
+				Logger::error(
+					"DEVELOPER FATAL: OpenVic::IndexedFlatMap<",
+					utility::type_name<KeyType>(),",",
+					utility::type_name<ValueType>(),
+					"> scalar division by zero detected at key index ", std::to_string(key.get_index()), "."
+				);
+				//continue and let it throw
+			}
+			return scalar / map.at(key);
+		});
+	}
+}

--- a/src/openvic-simulation/types/Signal.hpp
+++ b/src/openvic-simulation/types/Signal.hpp
@@ -506,9 +506,17 @@ namespace OpenVic::_detail::signal {
 
 	template<typename Lockable>
 	struct basic_observer : private observer_type {
+		basic_observer() = default;
+		basic_observer(basic_observer&& other) noexcept
+			: observer_type(),
+			connections { std::move(other.connections) } { }
 		virtual ~basic_observer() = default;
 
 	protected:
+		constexpr bool has_no_connections() const {
+			return connections.empty();
+		}
+
 		/**
 		 * Disconnect all signals connected to this object.
 		 *
@@ -530,7 +538,7 @@ namespace OpenVic::_detail::signal {
 			connections.emplace_back(std::move(conn));
 		}
 
-		Lockable mutex;
+		Lockable mutex{};
 		memory::vector<scoped_connection> connections;
 	};
 
@@ -1301,7 +1309,7 @@ namespace OpenVic::_detail::signal {
 		}
 
 	private:
-		mutable Lockable mutex;
+		mutable Lockable mutex{};
 		cow_type<Lockable> slots;
 		std::atomic_bool is_blocked;
 	};

--- a/src/openvic-simulation/types/SliderValue.hpp
+++ b/src/openvic-simulation/types/SliderValue.hpp
@@ -4,6 +4,7 @@
 
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/reactive/MutableState.hpp"
 
 namespace OpenVic {
 
@@ -11,30 +12,34 @@ namespace OpenVic {
 	private:
 		fixed_point_t PROPERTY(min);
 		fixed_point_t PROPERTY(max);
-		fixed_point_t PROPERTY(value);
+		MutableState<fixed_point_t> STATE_PROPERTY(current);
 
 	public:
 		constexpr SliderValue() = default;
+		SliderValue(SliderValue&&) = default;
+		SliderValue(SliderValue const&) = delete;
+		SliderValue& operator=(SliderValue&&) = default;
+		SliderValue& operator=(SliderValue const&) = delete;
 
-		constexpr void set_value(fixed_point_t new_value) {
+		void set_value(fixed_point_t new_value) {
 			if (min <= max) {
-				value = std::clamp(new_value, min, max);
+				current.set(std::clamp(new_value, min, max));
 			} else {
 				// You *can* actually have min > max in Victoria 2
 				// Such a situation will result in only being able to be move between the max and min value.
 				// This logic replicates this "feature"
 				if (new_value > max) {
-					value = min;
+					current.set(min);
 				} else {
-					value = max;
+					current.set(max);
 				}
 			}
 		}
 
-		constexpr void set_bounds(fixed_point_t new_min, fixed_point_t new_max) {
+		void set_bounds(fixed_point_t new_min, fixed_point_t new_max) {
 			min = new_min;
 			max = new_max;
-			set_value(value);
+			set_value(current.get());
 		}
 	};
 }

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -106,7 +106,7 @@ namespace OpenVic {
 		}
 
 		template<std::integral T>
-		constexpr fixed_point_t operator/=(T const& obj) {
+		constexpr fixed_point_t& operator/=(T const& obj) {
 			value /= obj;
 			return *this;
 		}
@@ -117,7 +117,7 @@ namespace OpenVic {
 		}
 
 		template<std::integral T>
-		constexpr fixed_point_t operator*=(T const& obj) {
+		constexpr fixed_point_t& operator*=(T const& obj) {
 			value *= obj;
 			return *this;
 		}
@@ -519,13 +519,13 @@ namespace OpenVic {
 			return parse_raw((static_cast<value_type>(lhs) << PRECISION) + rhs.value);
 		}
 
-		constexpr fixed_point_t operator+=(fixed_point_t const& obj) {
+		constexpr fixed_point_t& operator+=(fixed_point_t const& obj) {
 			value += obj.value;
 			return *this;
 		}
 
 		template<std::integral T>
-		constexpr fixed_point_t operator+=(T const& obj) {
+		constexpr fixed_point_t& operator+=(T const& obj) {
 			value += (static_cast<value_type>(obj) << PRECISION);
 			return *this;
 		}
@@ -544,13 +544,13 @@ namespace OpenVic {
 			return parse_raw((static_cast<value_type>(lhs) << PRECISION) - rhs.value);
 		}
 
-		constexpr fixed_point_t operator-=(fixed_point_t const& obj) {
+		constexpr fixed_point_t& operator-=(fixed_point_t const& obj) {
 			value -= obj.value;
 			return *this;
 		}
 
 		template<std::integral T>
-		constexpr fixed_point_t operator-=(T const& obj) {
+		constexpr fixed_point_t& operator-=(T const& obj) {
 			value -= (static_cast<value_type>(obj) << PRECISION);
 			return *this;
 		}
@@ -596,7 +596,7 @@ namespace OpenVic {
 			return parse_raw(lhs * rhs.value);
 		}
 
-		constexpr fixed_point_t operator*=(fixed_point_t const& obj) {
+		constexpr fixed_point_t& operator*=(fixed_point_t const& obj) {
 			value *= obj.value;
 			value >>= PRECISION;
 			return *this;
@@ -606,7 +606,7 @@ namespace OpenVic {
 			return parse_raw((lhs.value << PRECISION) / rhs.value);
 		}
 
-		constexpr fixed_point_t operator/=(fixed_point_t const& obj) {
+		constexpr fixed_point_t& operator/=(fixed_point_t const& obj) {
 			value = (value << PRECISION) / obj.value;
 			return *this;
 		}
@@ -630,13 +630,13 @@ namespace OpenVic {
 			return parse_raw((static_cast<value_type>(lhs) << PRECISION) % rhs.value);
 		}
 
-		constexpr fixed_point_t operator%=(fixed_point_t const& obj) {
+		constexpr fixed_point_t& operator%=(fixed_point_t const& obj) {
 			value %= obj.value;
 			return *this;
 		}
 
 		template<std::integral T>
-		constexpr fixed_point_t operator%=(T const& obj) {
+		constexpr fixed_point_t& operator%=(T const& obj) {
 			value %= (static_cast<value_type>(obj) << PRECISION);
 			return *this;
 		}

--- a/src/openvic-simulation/utility/Getters.hpp
+++ b/src/openvic-simulation/utility/Getters.hpp
@@ -255,3 +255,13 @@ public: \
 		return NAME; \
 	} \
 ACCESS:
+
+#define SPAN_PROPERTY(NAME) SPAN_PROPERTY_ACCESS(NAME, private)
+#define SPAN_PROPERTY_ACCESS(NAME, ACCESS) \
+	NAME; \
+\
+public: \
+	[[nodiscard]] constexpr auto get_##NAME() const -> OpenVic::utility::forwardable_span<decltype(NAME)::value_type const> { \
+		return NAME; \
+	} \
+	ACCESS:

--- a/src/openvic-simulation/utility/MathConcepts.hpp
+++ b/src/openvic-simulation/utility/MathConcepts.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <concepts>
+
+namespace OpenVic {
+	// Concept: UnaryNegatable
+	// Describes types that support the unary minus operator (-)
+	// The result type of -a must be the same as T.
+	template <typename T>
+	concept UnaryNegatable = requires(T a) {
+		{ -a } -> std::same_as<T>;
+	};
+
+	// Concept: Addable
+	// Describes types Lhs and Rhs that support the binary addition operator (+)
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs + rhs must be convertible to Result.
+	// By default, Result is std::common_type_t<Lhs, Rhs>.
+	template <typename Lhs, typename Rhs = Lhs, typename Result = std::common_type_t<Lhs, Rhs>>
+	concept Addable = requires(Lhs lhs, Rhs rhs) {
+		{ lhs + rhs } -> std::convertible_to<Result>;
+	};
+
+	// Concept: Subtractable
+	// Describes types Lhs and Rhs that support the binary subtraction operator (-)
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs - rhs must be convertible to Result.
+	// By default, Result is std::common_type_t<Lhs, Rhs>.
+	template <typename Lhs, typename Rhs = Lhs, typename Result = std::common_type_t<Lhs, Rhs>>
+	concept Subtractable = requires(Lhs lhs, Rhs rhs) {
+		{ lhs - rhs } -> std::convertible_to<Result>;
+	};
+
+	// Concept: Multipliable
+	// Describes types Lhs and Rhs that support the binary multiplication operator (*)
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs * rhs must be convertible to Result.
+	// By default, Result is std::common_type_t<Lhs, Rhs>.
+	template <typename Lhs, typename Rhs = Lhs, typename Result = std::common_type_t<Lhs, Rhs>>
+	concept Multipliable = requires(Lhs lhs, Rhs rhs) {
+		{ lhs * rhs } -> std::convertible_to<Result>;
+	};
+
+	// Concept: Divisible
+	// Describes types Lhs and Rhs that support the binary division operator (/)
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs / rhs must be convertible to Result.
+	// By default, Result is std::common_type_t<Lhs, Rhs>.
+	// Note: This concept only checks for syntactic validity. Division by zero
+	// is a runtime error and cannot be checked at compile time with concepts alone.
+	template <typename Lhs, typename Rhs = Lhs, typename Result = std::common_type_t<Lhs, Rhs>>
+	concept Divisible = requires(Lhs lhs, Rhs rhs) {
+		{ lhs / rhs } -> std::convertible_to<Result>;
+	};
+
+	// Concept: AddAssignable
+	// Describes types Lhs and Rhs where Lhs can be assigned the result of Lhs += Rhs.
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs += rhs must be a reference to Lhs (Lhs&).
+	template <typename Lhs, typename Rhs = Lhs>
+	concept AddAssignable = requires(Lhs& lhs, Rhs rhs) {
+		{ lhs += rhs } -> std::same_as<Lhs&>;
+	};
+
+	// Concept: SubtractAssignable
+	// Describes types Lhs and Rhs where Lhs can be assigned the result of Lhs -= Rhs.
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs -= rhs must be a reference to Lhs (Lhs&).
+	template <typename Lhs, typename Rhs = Lhs>
+	concept SubtractAssignable = requires(Lhs& lhs, Rhs rhs) {
+		{ lhs -= rhs } -> std::same_as<Lhs&>;
+	};
+
+	// Concept: MultiplyAssignable
+	// Describes types Lhs and Rhs where Lhs can be assigned the result of Lhs *= Rhs.
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs *= rhs must be a reference to Lhs (Lhs&).
+	template <typename Lhs, typename Rhs = Lhs>
+	concept MultiplyAssignable = requires(Lhs& lhs, Rhs rhs) {
+		{ lhs *= rhs } -> std::same_as<Lhs&>;
+	};
+
+	// Concept: DivideAssignable
+	// Describes types Lhs and Rhs where Lhs can be assigned the result of Lhs /= Rhs.
+	// If only Lhs is provided, Rhs defaults to Lhs.
+	// The result type of lhs /= rhs must be a reference to Lhs (Lhs&).
+	// Note: Similar to Divisible, this only checks for syntactic validity.
+	template <typename Lhs, typename Rhs = Lhs>
+	concept DivideAssignable = requires(Lhs& lhs, Rhs rhs) {
+		{ lhs /= rhs } -> std::same_as<Lhs&>;
+	};
+}

--- a/src/openvic-simulation/utility/reactive/DependencyTracker.cpp
+++ b/src/openvic-simulation/utility/reactive/DependencyTracker.cpp
@@ -1,0 +1,26 @@
+#include "DependencyTracker.hpp"
+
+#include <mutex>
+
+namespace OpenVic::DependencyTracker {
+	static thread_local std::mutex _mutex;
+	static thread_local memory::vector<std::function<void(signal<>&)>> _connect_methods;
+
+	void start_tracking(std::function<void(signal<>&)>&& connect) {
+		const std::lock_guard<std::mutex> lock_guard { _mutex };
+		_connect_methods.push_back(std::move(connect));
+	}
+
+	void track(signal<>& changed) {
+		const std::lock_guard<std::mutex> lock_guard { _mutex };
+		if (_connect_methods.empty()) {
+			return;
+		}
+		_connect_methods.back()(changed);
+	}
+
+	void end_tracking() {
+		const std::lock_guard<std::mutex> lock_guard { _mutex };
+		_connect_methods.pop_back();
+	}
+}

--- a/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
+++ b/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "openvic-simulation/types/Signal.hpp"
+
+namespace OpenVic::DependencyTracker {
+	void start_tracking(std::function<void(signal<>&)>&& connect);
+	void track(signal<>& changed);
+	void end_tracking();
+}

--- a/src/openvic-simulation/utility/reactive/DerivedState.hpp
+++ b/src/openvic-simulation/utility/reactive/DerivedState.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "openvic-simulation/types/Signal.hpp"
+#include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/Logger.hpp"
+#include "openvic-simulation/utility/reactive/DependencyTracker.hpp"
+#include "openvic-simulation/utility/reactive/TrackableState.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	struct DerivedState : public TrackableState<T>, public observer {
+	private:
+		memory::unique_ptr<std::mutex> recalculate_lock;
+		std::function<const T()> calculate;
+		bool is_dirty = true;
+
+		void mark_dirty() {
+			is_dirty = true;
+		}
+
+	public:
+		DerivedState()
+			requires std::is_default_constructible_v<T>
+			: DerivedState([]()->T{ return T{}; }) {}
+
+		explicit DerivedState(std::function<T()> const& new_calculate)
+			requires std::is_default_constructible_v<T>
+			: calculate { new_calculate },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>() {}
+
+		explicit DerivedState(std::function<T()> const& new_calculate, T const& empty_initial_value)
+			: calculate { new_calculate },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>(empty_initial_value) {}
+
+		explicit DerivedState(std::function<T()> const& new_calculate, T&& empty_initial_value)
+			: calculate { new_calculate },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>(std::move(empty_initial_value)) {}
+
+		explicit DerivedState(std::function<T()>&& new_calculate)
+			requires std::is_default_constructible_v<T>
+			: calculate { std::move(new_calculate) },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>() {}
+
+		explicit DerivedState(std::function<T()>&& new_calculate, T const& empty_initial_value)
+			: calculate { std::move(new_calculate) },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>(empty_initial_value) {}
+
+		explicit DerivedState(std::function<T()>&& new_calculate, T&& empty_initial_value)
+			: calculate { std::move(new_calculate) },
+			recalculate_lock { memory::make_unique<std::mutex>() },
+			TrackableState<T>(std::move(empty_initial_value)) {}
+
+		DerivedState(DerivedState&&) = default;
+		DerivedState(DerivedState const&) = delete;
+		DerivedState& operator=(DerivedState&&) = delete;
+		DerivedState& operator=(DerivedState const&) = delete;
+			
+		[[nodiscard]] T const& get() {
+			if (is_dirty) {
+				const std::lock_guard<std::mutex> lock_guard { *recalculate_lock };
+				if (is_dirty) {
+					observer::disconnect_all();
+					DependencyTracker::start_tracking([this](signal<>& dependency_changed) mutable->void {
+						dependency_changed.connect_scoped(&DerivedState<T>::mark_dirty, this);
+					});
+					T value = calculate();
+					DependencyTracker::end_tracking();
+
+					if (observer::has_no_connections()) {
+						Logger::warning(
+							"DEVELOPER WARNING: OpenVic::DerivedState<",
+							OpenVic::utility::type_name<T>(),
+							"> has no reactive dependencies. Its value will never change again.",
+							"If it should be reactive, ensure 'calculate' accesses its dependencies. ",
+							"Alternatively use a plain variable or MutableState<T>."
+						);
+					}
+
+					TrackableState<T>::set_cached_value(std::move(value));
+					is_dirty = false;
+				}
+			}
+
+			return TrackableState<T>::get_cached_value_tracked();
+		}
+	};
+}

--- a/src/openvic-simulation/utility/reactive/MutableState.hpp
+++ b/src/openvic-simulation/utility/reactive/MutableState.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "openvic-simulation/utility/reactive/TrackableState.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	struct MutableState : public TrackableState<T> {
+	public:
+		constexpr MutableState()
+			requires std::is_default_constructible_v<T>
+			: TrackableState<T>() {}
+		constexpr explicit MutableState(T const& new_value) : TrackableState<T>(new_value) {}
+		constexpr explicit MutableState(T&& new_value) : TrackableState<T>(std::move(new_value)) {}
+		MutableState(MutableState&&) = default;
+		MutableState(MutableState const&) = delete;
+		MutableState& operator=(MutableState&&) = default;
+		MutableState& operator=(MutableState const&) = delete;
+
+		[[nodiscard]] T const& get() {
+			return TrackableState<T>::get_cached_value_tracked();
+		}
+		[[nodiscard]] constexpr T const& get_untracked() const {
+			return TrackableState<T>::get_cached_value_untracked();
+		}
+
+		void set(T&& new_value) {
+			TrackableState<T>::set_cached_value(std::move(new_value));
+		}
+
+		void set(T const& new_value) {
+			TrackableState<T>::set_cached_value(new_value);
+		}
+
+		MutableState<T>& operator+=(auto const& rhs) {
+			set(get() + rhs);
+			return *this;
+		}
+		MutableState<T>& operator-=(auto const& rhs) {
+			set(get() - rhs);
+			return *this;
+		}
+		MutableState<T>& operator*=(auto const& rhs) {
+			set(get() * rhs);
+			return *this;
+		}
+		MutableState<T>& operator/=(auto const& rhs) {
+			set(get() / rhs);
+			return *this;
+		}
+	};
+}

--- a/src/openvic-simulation/utility/reactive/TrackableState.hpp
+++ b/src/openvic-simulation/utility/reactive/TrackableState.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "openvic-simulation/types/Signal.hpp"
+#include "openvic-simulation/utility/reactive/DependencyTracker.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	struct TrackableState {
+	private:
+		T cached_value;
+		signal<> changed;
+
+	protected:
+		constexpr TrackableState()
+			requires std::is_default_constructible_v<T> {}
+		constexpr explicit TrackableState(T const& new_cached_value) : cached_value { new_cached_value } {}
+		constexpr explicit TrackableState(T&& new_cached_value) : cached_value { std::move(new_cached_value) } {}
+		TrackableState(TrackableState&&) = default;
+		TrackableState(TrackableState const&) = delete;
+		TrackableState& operator=(TrackableState&&) = default;
+		TrackableState& operator=(TrackableState const&) = delete;
+
+		[[nodiscard]] T const& get_cached_value_tracked() {
+			DependencyTracker::track(changed);
+			return cached_value;
+		}
+
+		[[nodiscard]] constexpr T const& get_cached_value_untracked() const {
+			return cached_value;
+		}
+
+		void set_cached_value(T&& new_cached_value) {
+			if (cached_value != new_cached_value) {
+				cached_value = std::move(new_cached_value);
+				changed();
+			}
+		}
+
+		void set_cached_value(T const& new_cached_value) {
+			if (cached_value != new_cached_value) {
+				cached_value = new_cached_value;
+				changed();
+			}
+		}
+
+	public:
+		//special case where connection may be discarded as the observer handles it
+		template<typename Pmf, OpenVic::_detail::signal::Observer Ptr>
+		requires OpenVic::_detail::signal::Callable<Pmf, Ptr>
+		connection connect_using_observer(Pmf&& pmf, Ptr&& ptr, OpenVic::_detail::signal::group_id gid = 0) {
+			return changed.connect(pmf, ptr, gid);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect(Ts&&... args) const {
+			return changed.connect(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect_extended(Ts&&... args) const {
+			return changed.connect_extended(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] scoped_connection connect_scoped(Ts&&... args) const {
+			return changed.connect_scoped(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		void disconnect(Ts&&... args) const {
+			return changed.disconnect(std::forward<Ts>(args)...);
+		}
+	};
+#define STATE_PROPERTY(NAME) STATE_PROPERTY_ACCESS(NAME, private)
+#define STATE_PROPERTY_ACCESS(NAME, ACCESS) \
+	NAME; \
+\
+public: \
+	[[nodiscard]] constexpr auto get_##NAME() const -> decltype(OpenVic::_get_property<decltype(NAME)>(NAME)) { \
+		return OpenVic::_get_property<decltype(NAME)>(NAME); \
+	} \
+	[[nodiscard]] auto get_##NAME##_value() { \
+		return NAME.get(); \
+	} \
+	ACCESS:
+}


### PR DESCRIPTION
Replaced by #523 

Depends on:
- #509 
- #511 

Context from Discord:
General WVPM — 25/07/2025 16:33
_When it comes to reactivity in the UI I'd love to use a reactive pull based model.
Where the reactive part is event-driven marking data as dirty.
The pull part would be the UI updating all elements marked dirty.
This would be kinda like Svelte, but Svelte does it compile-time._

_Sadly according to Gemini and my own research neither godot nor C++ have something like this.
We're stuck with signals and manually invalidating or directly updating UI elements.
Also we have to ensure that signals can't flood the UI with updates._

_This is a error-prone approach.
I'd love to hear your thoughts on the subject. (I'll read them pull based.)_

General WVPM — 09:57
_I thought about it some more and came up with the following high-level idea:
Split state up into:_
- constant state
- mutable state (properties with events)
- derived state (tracks dependencies is marked dirty when they update. recalculates if dirty when requested)
- manually tracked derived state


_We can use signal for the events.
signal_property would have to be replaced with mutable state that exposes a get() method and changed signal.
Manually tracked derived state would be pop distributions and other aggregates that we know when to update in the sim.
You don't want to track every pop his size in the province + the list of all pops. You could just manually update that like we do now.
Mutable, derived & manually tracked derived state all implement the same interface of a get() method and changed signal.
The derived state (mainly for UI purposes) should automatically handle tracking._