### PR TITLE
Expose vector properties via span

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -180,7 +180,7 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 	// TODO - REMOVE TEST CODE
 	Logger::info("===== Ranking system test... =====");
 	if (game_manager.get_instance_manager()) {
-		const auto print_ranking_list = [](std::string_view title, memory::vector<CountryInstance*> const& countries) -> void {
+		const auto print_ranking_list = [](std::string_view title, OpenVic::utility::forwardable_span<CountryInstance* const> countries) -> void {
 			memory::string text;
 			for (CountryInstance const* country : countries) {
 				text += StringUtils::append_string_views(
@@ -197,7 +197,7 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 		CountryInstanceManager const& country_instance_manager =
 			game_manager.get_instance_manager()->get_country_instance_manager();
 
-		OpenVic::memory::vector<CountryInstance*> const& great_powers = country_instance_manager.get_great_powers();
+		OpenVic::utility::forwardable_span<CountryInstance* const> great_powers = country_instance_manager.get_great_powers();
 		print_ranking_list("Great Powers", great_powers);
 		print_ranking_list("Secondary Powers", country_instance_manager.get_secondary_powers());
 		print_ranking_list("All countries", country_instance_manager.get_total_ranking());

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -302,10 +302,10 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(military_power_from_sea);
 		fixed_point_t PROPERTY(military_power_from_leaders);
 		size_t PROPERTY(military_rank, 0);
-		memory::vector<LeaderInstance*> PROPERTY(generals);
-		memory::vector<LeaderInstance*> PROPERTY(admirals);
-		memory::vector<ArmyInstance*> PROPERTY(armies);
-		memory::vector<NavyInstance*> PROPERTY(navies);
+		memory::vector<LeaderInstance*> SPAN_PROPERTY(generals);
+		memory::vector<LeaderInstance*> SPAN_PROPERTY(admirals);
+		memory::vector<ArmyInstance*> SPAN_PROPERTY(armies);
+		memory::vector<NavyInstance*> SPAN_PROPERTY(navies);
 		size_t PROPERTY(regiment_count, 0);
 		size_t PROPERTY(max_supported_regiment_count, 0);
 		size_t PROPERTY(mobilisation_potential_regiment_count, 0);
@@ -715,13 +715,13 @@ namespace OpenVic {
 
 		IndexedMap<CountryDefinition, CountryInstance*> PROPERTY(country_definition_to_instance_map);
 
-		memory::vector<CountryInstance*> PROPERTY(great_powers);
-		memory::vector<CountryInstance*> PROPERTY(secondary_powers);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(great_powers);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(secondary_powers);
 
-		memory::vector<CountryInstance*> PROPERTY(total_ranking);
-		memory::vector<CountryInstance*> PROPERTY(prestige_ranking);
-		memory::vector<CountryInstance*> PROPERTY(industrial_power_ranking);
-		memory::vector<CountryInstance*> PROPERTY(military_power_ranking);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(total_ranking);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(prestige_ranking);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(industrial_power_ranking);
+		memory::vector<CountryInstance*> SPAN_PROPERTY(military_power_ranking);
 
 		void update_rankings(Date today, DefineManager const& define_manager);
 

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -102,8 +102,8 @@ namespace OpenVic {
 		Crime const* PROPERTY_RW(crime, nullptr);
 		ResourceGatheringOperation PROPERTY(rgo);
 		IdentifierRegistry<BuildingInstance> IDENTIFIER_REGISTRY(building, false);
-		memory::vector<ArmyInstance*> PROPERTY(armies);
-		memory::vector<NavyInstance*> PROPERTY(navies);
+		memory::vector<ArmyInstance*> SPAN_PROPERTY(armies);
+		memory::vector<NavyInstance*> SPAN_PROPERTY(navies);
 		// The number of land regiments currently in the province, including those being transported by navies
 		size_t PROPERTY(land_regiment_count, 0);
 		Timespan PROPERTY(occupation_duration);

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -23,7 +23,7 @@ namespace OpenVic {
 		StateSet const& PROPERTY(state_set);
 		CountryInstance* PROPERTY_PTR(owner);
 		ProvinceInstance* PROPERTY_PTR(capital);
-		memory::vector<ProvinceInstance*> PROPERTY(provinces);
+		memory::vector<ProvinceInstance*> SPAN_PROPERTY(provinces);
 		ProvinceInstance::colony_status_t PROPERTY(colony_status);
 
 		pop_size_t PROPERTY(total_population, 0);

--- a/src/openvic-simulation/military/UnitInstanceGroup.hpp
+++ b/src/openvic-simulation/military/UnitInstanceGroup.hpp
@@ -25,7 +25,7 @@ namespace OpenVic {
 		const unique_id_t PROPERTY(unique_id);
 		const UnitType::branch_t PROPERTY(branch);
 		memory::string PROPERTY(name);
-		memory::vector<UnitInstance*> PROPERTY(units);
+		memory::vector<UnitInstance*> SPAN_PROPERTY(units);
 		LeaderInstance* PROPERTY_PTR(leader, nullptr);
 		ProvinceInstance* PROPERTY_PTR(position, nullptr);
 		CountryInstance* PROPERTY_PTR(country, nullptr);
@@ -38,7 +38,7 @@ namespace OpenVic {
 		// Movement attributes
 		// Ordered list of provinces making up the path the unit is trying to move along,
 		// the front province should always be adjacent to the unit's current position.
-		memory::vector<ProvinceInstance*> PROPERTY(path);
+		memory::vector<ProvinceInstance*> SPAN_PROPERTY(path);
 		// Measured in distance travelled, increases each day by unit speed (after modifiers have been applied) until
 		// it reaches the required distance/movement cost to move to the next province in the path.
 		fixed_point_t PROPERTY(movement_progress);
@@ -127,7 +127,7 @@ namespace OpenVic {
 		friend struct UnitInstanceManager;
 
 	private:
-		memory::vector<ArmyInstance*> PROPERTY(carried_armies);
+		memory::vector<ArmyInstance*> SPAN_PROPERTY(carried_armies);
 
 		UnitInstanceGroupBranched(
 			unique_id_t new_unique_id,

--- a/src/openvic-simulation/utility/Getters.hpp
+++ b/src/openvic-simulation/utility/Getters.hpp
@@ -255,3 +255,13 @@ public: \
 		return NAME; \
 	} \
 ACCESS:
+
+#define SPAN_PROPERTY(NAME) SPAN_PROPERTY_ACCESS(NAME, private)
+#define SPAN_PROPERTY_ACCESS(NAME, ACCESS) \
+	NAME; \
+\
+public: \
+	[[nodiscard]] constexpr auto get_##NAME() const -> OpenVic::utility::forwardable_span<const decltype(NAME)::value_type> { \
+		return NAME; \
+	} \
+	ACCESS:


### PR DESCRIPTION
Instead `get_##NAME()` returning a `vector<T> const&` it now returns a `forwardable_span<const T>`.
This ensures the collection is const, but if T is a pointer to a non-const type, the instance it points to is non-const.
This is required for #508 as it requires non-const instances to get data that may update a cache.
If desired, the forwardable_span return could be exposed as non-const with the `vector<T> const&` remaining as const variant.
That would result in different return types between const and non-const `get_##NAME()`.