### PR TITLE
Refactor index_1_based to province_number

### DIFF
--- a/src/openvic-simulation/console/ConsoleInstance.cpp
+++ b/src/openvic-simulation/console/ConsoleInstance.cpp
@@ -197,21 +197,21 @@ std::optional<bool> ConsoleInstance::validate_boolean(std::string_view value_str
 	return std::nullopt;
 }
 
-ProvinceInstance* ConsoleInstance::validate_province_index(std::string_view value_string) {
-	if (value_string.empty()) {
-		write_error("Please specify province id");
+ProvinceInstance* ConsoleInstance::validate_province_number(std::string_view province_number_string) {
+	if (province_number_string.empty()) {
+		write_error("Please specify province number");
 		return nullptr;
 	}
 
-	std::optional<uint64_t> result = validate_unsigned_integer(value_string);
-	if (!result) {
+	std::optional<uint64_t> province_number = validate_unsigned_integer(province_number_string);
+	if (!province_number) {
 		return nullptr;
 	}
 
-	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index_1_based(*result);
+	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_from_number(*province_number);
 
 	if (province == nullptr) {
-		write_error("Unknown province id");
+		write_error("Unknown province number");
 	}
 	return province;
 }
@@ -359,7 +359,7 @@ bool ConsoleInstance::setup_commands() {
 	bool result = true;
 
 	constexpr auto toggle_province_id = [](Argument& arg) -> bool {
-		// TODO: toggle province id display
+		// TODO: toggle province number display
 		return true;
 	};
 

--- a/src/openvic-simulation/console/ConsoleInstance.hpp
+++ b/src/openvic-simulation/console/ConsoleInstance.hpp
@@ -86,7 +86,7 @@ namespace OpenVic {
 		std::optional<int64_t> validate_integer(std::string_view value_string);
 		std::optional<uint64_t> validate_unsigned_integer(std::string_view value_string);
 		std::optional<bool> validate_boolean(std::string_view value_string);
-		ProvinceInstance* validate_province_index(std::string_view value_string);
+		ProvinceInstance* validate_province_number(std::string_view value_string);
 		CountryInstance* validate_country_tag(std::string_view value_string);
 		Event const* validate_event_id(std::string_view value_string);
 		UnitType const* validate_unit(std::string_view value_string);

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -6,9 +6,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <span>
 #include <system_error>
-#include <stack>
 #include <vector>
 
 #include <range/v3/algorithm/all_of.hpp>
@@ -18,7 +16,6 @@
 #include "openvic-simulation/map/ProvinceDefinition.hpp"
 #include "openvic-simulation/modifier/ModifierManager.hpp"
 #include "openvic-simulation/types/Colour.hpp"
-#include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/Vector.hpp"
 #include "openvic-simulation/utility/BMP.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
@@ -30,6 +27,17 @@ using namespace OpenVic;
 using namespace OpenVic::NodeTools;
 
 MapDefinition::MapDefinition() {}
+
+ProvinceDefinition* MapDefinition::get_province_definition_from_number(
+	decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+) {
+	return province_definitions.get_item_by_index(ProvinceDefinition::get_index_from_province_number(province_number));
+}
+ProvinceDefinition const* MapDefinition::get_province_definition_from_number(
+	decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+) const {
+	return province_definitions.get_item_by_index(ProvinceDefinition::get_index_from_province_number(province_number));
+}
 
 RiverSegment::RiverSegment(uint8_t new_size, memory::vector<ivec2_t>&& new_points)
 	: size { new_size }, points { std::move(new_points) } {}
@@ -46,7 +54,7 @@ bool MapDefinition::add_province_definition(std::string_view identifier, colour_
 		Logger::error("Invalid province identifier - empty!");
 		return false;
 	}
-	// Victoria 2 CTDs on non-numeric province ids
+	// Victoria 2 CTDs on non-numeric province numbers
 	if (!ranges::all_of(identifier, [](char c) -> bool { return std::isdigit(c); })) {
 		Logger::error(
 			"Invalid province identifier: ", identifier, " (can only contain numeric characters)"
@@ -60,15 +68,15 @@ bool MapDefinition::add_province_definition(std::string_view identifier, colour_
 	ProvinceDefinition new_province {
 		identifier, colour, static_cast<ProvinceDefinition::index_t>(province_definitions.size())
 	};
-	const ProvinceDefinition::index_t index_1_based = get_index_1_based_from_colour(colour);
-	if (index_1_based != ProvinceDefinition::NULL_INDEX) {
+	const ProvinceDefinition::index_t province_number = get_province_number_from_colour(colour);
+	if (province_number != ProvinceDefinition::NULL_INDEX) {
 		Logger::error(
-			"Duplicate province colours: ", get_province_definition_by_index_1_based(index_1_based)->to_string(), " and ",
+			"Duplicate province colours: ", get_province_definition_from_number(province_number)->to_string(), " and ",
 			new_province.to_string()
 		);
 		return false;
 	}
-	colour_index_map[new_province.get_colour()] = new_province.get_index_1_based();
+	colour_index_map[new_province.get_colour()] = new_province.get_province_number();
 	return province_definitions.add_item(std::move(new_province));
 }
 
@@ -125,37 +133,37 @@ bool MapDefinition::add_standard_adjacency(ProvinceDefinition& from, ProvinceDef
 		to.coastal = !to.is_water();
 
 		if (from.is_water()) {
-			path_map_sea.try_add_point(to.get_index_1_based(), { to.centre.x, to.centre.y });
+			path_map_sea.try_add_point(to.get_province_number(), { to.centre.x, to.centre.y });
 		} else {
-			path_map_sea.try_add_point(from.get_index_1_based(), { from.centre.x, from.centre.y });
+			path_map_sea.try_add_point(from.get_province_number(), { from.centre.x, from.centre.y });
 		}
 		/* Connect points on pathfinding map */
-		path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
+		path_map_sea.connect_points(from.get_province_number(), to.get_province_number());
 		/* Land units can use transports to path on the sea */
-		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+		path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 		/* Sea points are only valid for land units with a transport */
 		if (from.is_water()) {
-			path_map_land.set_point_disabled(from.get_index_1_based());
+			path_map_land.set_point_disabled(from.get_province_number());
 		} else {
-			path_map_land.set_point_disabled(to.get_index_1_based());
+			path_map_land.set_point_disabled(to.get_province_number());
 		}
 	} else if (from.is_water()) {
 		/* Water-to-water adjacency */
 		type = WATER;
 
 		/* Connect points on pathfinding map */
-		path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
+		path_map_sea.connect_points(from.get_province_number(), to.get_province_number());
 		/* Land units can use transports to path on the sea */
-		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+		path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 		/* Sea points are only valid for land units with a transport */
 		if (from.is_water()) {
-			path_map_land.set_point_disabled(from.get_index_1_based());
+			path_map_land.set_point_disabled(from.get_province_number());
 		} else {
-			path_map_land.set_point_disabled(to.get_index_1_based());
+			path_map_land.set_point_disabled(to.get_province_number());
 		}
 	} else {
 		/* Connect points on pathfinding map */
-		path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+		path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 	}
 
 	if (from_needs_adjacency) {
@@ -283,17 +291,17 @@ bool MapDefinition::add_special_adjacency(
 			}
 			*existing_adjacency = { &to, distance, type, through, data };
 			if (from.is_water() && to.is_water()) {
-				path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_sea.connect_points(from.get_province_number(), to.get_province_number());
 			} else {
-				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 			}
 
 			if (from.is_water() || to.is_water()) {
-				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 				if (from.is_water()) {
-					path_map_land.set_point_disabled(from.get_index_1_based());
+					path_map_land.set_point_disabled(from.get_province_number());
 				} else {
-					path_map_land.set_point_disabled(to.get_index_1_based());
+					path_map_land.set_point_disabled(to.get_province_number());
 				}
 			}
 			return true;
@@ -305,17 +313,17 @@ bool MapDefinition::add_special_adjacency(
 		} else {
 			from.adjacencies.emplace_back(&to, distance, type, through, data);
 			if (from.is_water() && to.is_water()) {
-				path_map_sea.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_sea.connect_points(from.get_province_number(), to.get_province_number());
 			} else {
-				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 			}
 
 			if (from.is_water() || to.is_water()) {
-				path_map_land.connect_points(from.get_index_1_based(), to.get_index_1_based());
+				path_map_land.connect_points(from.get_province_number(), to.get_province_number());
 				if (from.is_water()) {
-					path_map_land.set_point_disabled(from.get_index_1_based());
+					path_map_land.set_point_disabled(from.get_province_number());
 				} else {
-					path_map_land.set_point_disabled(to.get_index_1_based());
+					path_map_land.set_point_disabled(to.get_province_number());
 				}
 			}
 			return true;
@@ -346,7 +354,7 @@ bool MapDefinition::set_water_province(std::string_view identifier) {
 		return false;
 	}
 	province->water = true;
-	path_map_sea.try_add_point(province->get_index_1_based(), path_map_land.get_point_position(province->get_index_1_based()));
+	path_map_sea.try_add_point(province->get_province_number(), path_map_land.get_point_position(province->get_province_number()));
 	return true;
 }
 
@@ -430,7 +438,7 @@ bool MapDefinition::add_region(std::string_view identifier, memory::vector<Provi
 	return ret;
 }
 
-ProvinceDefinition::index_t MapDefinition::get_index_1_based_from_colour(colour_t colour) const {
+ProvinceDefinition::index_t MapDefinition::get_province_number_from_colour(colour_t colour) const {
 	const colour_index_map_t::const_iterator it = colour_index_map.find(colour);
 	if (it != colour_index_map.end()) {
 		return it->second;
@@ -438,19 +446,19 @@ ProvinceDefinition::index_t MapDefinition::get_index_1_based_from_colour(colour_
 	return ProvinceDefinition::NULL_INDEX;
 }
 
-ProvinceDefinition::index_t MapDefinition::get_province_index_1_based_at(ivec2_t pos) const {
+ProvinceDefinition::index_t MapDefinition::get_province_number_at(ivec2_t pos) const {
 	if (pos.nonnegative() && pos.is_within_bound(dims)) {
-		return province_shape_image[get_pixel_index_from_pos(pos)].index_1_based;
+		return province_shape_image[get_pixel_index_from_pos(pos)].province_number;
 	}
 	return ProvinceDefinition::NULL_INDEX;
 }
 
 ProvinceDefinition* MapDefinition::get_province_definition_at(ivec2_t pos) {
-	return get_province_definition_by_index_1_based(get_province_index_1_based_at(pos));
+	return get_province_definition_from_number(get_province_number_at(pos));
 }
 
 ProvinceDefinition const* MapDefinition::get_province_definition_at(ivec2_t pos) const {
-	return get_province_definition_by_index_1_based(get_province_index_1_based_at(pos));
+	return get_province_definition_from_number(get_province_number_at(pos));
 }
 
 bool MapDefinition::set_max_provinces(ProvinceDefinition::index_t new_max_provinces) {
@@ -544,7 +552,7 @@ bool MapDefinition::load_province_definitions(std::span<const LineObject> lines)
 					}
 
 					ProvinceDefinition const& definition = province_definitions.back();
-					ret &= path_map_land.try_add_point(definition.get_index_1_based(), { definition.centre.x, definition.centre.y });
+					ret &= path_map_land.try_add_point(definition.get_province_number(), { definition.centre.x, definition.centre.y });
 					if (!ret) {
 						Logger::error("Province ", identifier, " could not be added to " _OV_STR(path_map_land));
 					}
@@ -810,12 +818,12 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 		for (pos.x = 0; pos.x < get_width(); ++pos.x) {
 			const size_t pixel_index = get_pixel_index_from_pos(pos);
 			const colour_t province_colour = colour_at(province_data, pixel_index);
-			ProvinceDefinition::index_t province_index_1_based = ProvinceDefinition::NULL_INDEX;
+			ProvinceDefinition::index_t province_number = ProvinceDefinition::NULL_INDEX;
 
 			if (pos.x > 0) {
 				const size_t jdx = pixel_index - 1;
 				if (colour_at(province_data, jdx) == province_colour) {
-					province_index_1_based = province_shape_image[jdx].index_1_based;
+					province_number = province_shape_image[jdx].province_number;
 					goto index_found;
 				}
 			}
@@ -823,14 +831,14 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			if (pos.y > 0) {
 				const size_t jdx = pixel_index - get_width();
 				if (colour_at(province_data, jdx) == province_colour) {
-					province_index_1_based = province_shape_image[jdx].index_1_based;
+					province_number = province_shape_image[jdx].province_number;
 					goto index_found;
 				}
 			}
 
-			province_index_1_based = get_index_1_based_from_colour(province_colour);
+			province_number = get_province_number_from_colour(province_colour);
 
-			if (province_index_1_based == ProvinceDefinition::NULL_INDEX && !unrecognised_province_colours.contains(province_colour)) {
+			if (province_number == ProvinceDefinition::NULL_INDEX && !unrecognised_province_colours.contains(province_colour)) {
 				unrecognised_province_colours.insert(province_colour);
 				if (detailed_errors) {
 					Logger::warning(
@@ -840,10 +848,10 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			}
 
 		index_found:
-			province_shape_image[pixel_index].index_1_based = province_index_1_based;
+			province_shape_image[pixel_index].province_number = province_number;
 
-			if (province_index_1_based != ProvinceDefinition::NULL_INDEX) {
-				const ProvinceDefinition::index_t array_index = province_index_1_based - 1;
+			if (province_number != ProvinceDefinition::NULL_INDEX) {
+				const ProvinceDefinition::index_t array_index = province_number - 1;
 				pixels_per_province[array_index]++;
 				pixel_position_sum_per_province[array_index] += static_cast<fvec2_t>(pos);
 			}
@@ -851,8 +859,8 @@ bool MapDefinition::load_map_images(fs::path const& province_path, fs::path cons
 			const TerrainTypeMapping::index_t terrain = terrain_data[pixel_index];
 			TerrainTypeMapping const* mapping = terrain_type_manager.get_terrain_type_mapping_for(terrain);
 			if (mapping != nullptr) {
-				if (province_index_1_based != ProvinceDefinition::NULL_INDEX) {
-					terrain_type_pixels_list[province_index_1_based - 1][&mapping->get_type()]++;
+				if (province_number != ProvinceDefinition::NULL_INDEX) {
+					terrain_type_pixels_list[province_number - 1][&mapping->get_type()]++;
 				}
 				if (mapping->get_has_texture() && terrain < terrain_type_manager.get_terrain_texture_limit()) {
 					province_shape_image[pixel_index].terrain = terrain + 1;

--- a/src/openvic-simulation/map/MapDefinition.hpp
+++ b/src/openvic-simulation/map/MapDefinition.hpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <span>
 #include <string_view>
-#include <vector>
 
 #include <openvic-dataloader/csv/LineObject.hpp>
 
@@ -45,7 +44,7 @@ namespace OpenVic {
 #pragma pack(push, 1)
 		/* Used to represent tightly packed 3-byte integer pixel information. */
 		struct shape_pixel_t {
-			ProvinceDefinition::index_t index_1_based;
+			ProvinceDefinition::index_t province_number;
 			TerrainTypeMapping::index_t terrain;
 		};
 #pragma pack(pop)
@@ -54,7 +53,7 @@ namespace OpenVic {
 		using colour_index_map_t = ordered_map<colour_t, ProvinceDefinition::index_t>;
 		using river_t = memory::vector<RiverSegment>;
 
-		IdentifierRegistry<ProvinceDefinition> IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(province_definition, 1);
+		IdentifierRegistry<ProvinceDefinition> IDENTIFIER_REGISTRY(province_definition);
 		IdentifierRegistry<Region> IDENTIFIER_REGISTRY(region);
 		IdentifierRegistry<Climate> IDENTIFIER_REGISTRY(climate);
 		IdentifierRegistry<Continent> IDENTIFIER_REGISTRY(continent);
@@ -73,17 +72,24 @@ namespace OpenVic {
 		PointMap PROPERTY_REF(path_map_land);
 		PointMap PROPERTY_REF(path_map_sea);
 
-		ProvinceDefinition::index_t get_index_1_based_from_colour(colour_t colour) const;
+		ProvinceDefinition::index_t get_province_number_from_colour(colour_t colour) const;
 		bool _generate_standard_province_adjacencies();
 
 		inline constexpr int32_t get_pixel_index_from_pos(ivec2_t pos) const {
 			return pos.x + pos.y * dims.x;
 		}
 
-		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(province_definition, 1);
+		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(province_definition);
 
 	public:
 		MapDefinition();
+
+		ProvinceDefinition* get_province_definition_from_number(
+			decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+		);
+		ProvinceDefinition const* get_province_definition_from_number(
+			decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+		) const;
 
 		inline constexpr int32_t get_width() const { return dims.x; }
 		inline constexpr int32_t get_height() const { return dims.y; }
@@ -106,7 +112,7 @@ namespace OpenVic {
 		size_t get_land_province_count() const;
 		size_t get_water_province_count() const;
 
-		ProvinceDefinition::index_t get_province_index_1_based_at(ivec2_t pos) const;
+		ProvinceDefinition::index_t get_province_number_at(ivec2_t pos) const;
 
 	private:
 		ProvinceDefinition* get_province_definition_at(ivec2_t pos);

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -1,10 +1,12 @@
 #include "MapInstance.hpp"
+#include <optional>
 
 #include "openvic-simulation/history/ProvinceHistory.hpp"
 #include "openvic-simulation/map/MapDefinition.hpp"
 #include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
 #include "openvic-simulation/utility/ThreadPool.hpp"
+#include "map/ProvinceDefinition.hpp"
 
 using namespace OpenVic;
 
@@ -19,9 +21,19 @@ MapInstance::MapInstance(
 ProvinceInstance& MapInstance::get_province_instance_from_definition(ProvinceDefinition const& province) {
 	return province_instances.get_items()[province.get_index()];
 }
-
 ProvinceInstance const& MapInstance::get_province_instance_from_definition(ProvinceDefinition const& province) const {
 	return province_instances.get_items()[province.get_index()];
+}
+
+ProvinceInstance* MapInstance::get_province_instance_from_number(
+	decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+) {
+	return province_instances.get_item_by_index(ProvinceDefinition::get_index_from_province_number(province_number));
+}
+ProvinceInstance const* MapInstance::get_province_instance_from_number(
+	decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+) const {
+	return province_instances.get_item_by_index(ProvinceDefinition::get_index_from_province_number(province_number));
 }
 
 void MapInstance::enable_canal(canal_index_t canal_index) {

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "openvic-simulation/economy/trading/MarketInstance.hpp"
 #include "openvic-simulation/map/ProvinceDefinition.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/map/State.hpp"
@@ -11,6 +10,7 @@
 
 namespace OpenVic {
 	struct MapDefinition;
+	struct MarketInstance;
 	struct BuildingTypeManager;
 	struct ProvinceHistoryManager;
 	struct IssueManager;
@@ -26,7 +26,7 @@ namespace OpenVic {
 		MapDefinition const& PROPERTY(map_definition);
 		ThreadPool& thread_pool;
 
-		IdentifierRegistry<ProvinceInstance> IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(province_instance, 1);
+		IdentifierRegistry<ProvinceInstance> IDENTIFIER_REGISTRY(province_instance);
 
 		pop_size_t PROPERTY(highest_province_population, 0);
 		pop_size_t PROPERTY(total_map_population, 0);
@@ -48,10 +48,16 @@ namespace OpenVic {
 			return map_definition;
 		}
 
-		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(province_instance, 1);
+		IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS(province_instance);
 
 		ProvinceInstance& get_province_instance_from_definition(ProvinceDefinition const& province);
 		ProvinceInstance const& get_province_instance_from_definition(ProvinceDefinition const& province) const;
+		ProvinceInstance* get_province_instance_from_number(
+			decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+		);
+		ProvinceInstance const* get_province_instance_from_number(
+			decltype(std::declval<ProvinceDefinition>().get_province_number())province_number
+		) const;
 
 		void enable_canal(canal_index_t canal_index);
 		bool is_canal_enabled(canal_index_t canal_index) const;

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -85,7 +85,7 @@ bool MapmodeManager::generate_mapmode_colours(
 
 	if (map_instance.province_instances_are_locked()) {
 		for (ProvinceInstance const& province : map_instance.get_province_instances()) {
-			target_stripes[province.get_province_definition().get_index_1_based()] = mapmode->get_base_stripe_colours(
+			target_stripes[province.get_province_definition().get_province_number()] = mapmode->get_base_stripe_colours(
 				map_instance, province, player_country, selected_province
 			);
 		}
@@ -327,7 +327,7 @@ bool MapmodeManager::setup_mapmodes() {
 				CountryInstance const* player_country, ProvinceInstance const* selected_province
 			) -> Mapmode::base_stripe_t {
 				const colour_argb_t::value_type f = colour_argb_t::colour_traits::component_from_fraction(
-					province.get_province_definition().get_index_1_based(), map_instance.get_map_definition().get_province_definition_count() + 1
+					province.get_province_definition().get_province_number(), map_instance.get_map_definition().get_province_definition_count() + 1
 				);
 				return colour_argb_t::fill_as(f).with_alpha(ALPHA_VALUE);
 			}

--- a/src/openvic-simulation/map/ProvinceDefinition.cpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.cpp
@@ -18,7 +18,7 @@ ProvinceDefinition::ProvinceDefinition(
 	HasIndex { new_index } {}
 
 memory::string ProvinceDefinition::to_string() const {
-	return memory::fmt::format("(#{}, {}, 0x{})", get_index_1_based(), get_identifier(), get_colour());
+	return memory::fmt::format("(#{}, {}, 0x{})", get_province_number(), get_identifier(), get_colour());
 }
 
 bool ProvinceDefinition::load_positions(

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -112,8 +112,11 @@ namespace OpenVic {
 			return region != nullptr;
 		}
 
-		constexpr index_t get_index_1_based() const {
+		constexpr index_t get_province_number() const {
 			return get_index()+1;
+		}
+		static constexpr index_t get_index_from_province_number(const index_t province_number) {
+			return province_number - 1;
 		}
 
 		/* The positions' y coordinates need to be inverted. */

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -101,7 +101,7 @@ namespace OpenVic {
 		memory::vector<ProvinceInstance const*> PROPERTY(adjacent_nonempty_land_provinces);
 		Crime const* PROPERTY_RW(crime, nullptr);
 		ResourceGatheringOperation PROPERTY(rgo);
-		IdentifierRegistry<BuildingInstance> IDENTIFIER_REGISTRY(building, false);
+		IdentifierRegistry<BuildingInstance> IDENTIFIER_REGISTRY(building);
 		memory::vector<ArmyInstance*> SPAN_PROPERTY(armies);
 		memory::vector<NavyInstance*> SPAN_PROPERTY(navies);
 		// The number of land regiments currently in the province, including those being transported by navies

--- a/src/openvic-simulation/misc/GameAction.cpp
+++ b/src/openvic-simulation/misc/GameAction.cpp
@@ -209,7 +209,7 @@ bool GameActionManager::game_action_callback_expand_province_building(game_actio
 		return false;
 	}
 
-	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_by_index_1_based(province_building->first);
+	ProvinceInstance* province = instance_manager.get_map_instance().get_province_instance_from_number(province_building->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		Logger::error("GAME_ACTION_EXPAND_PROVINCE_BUILDING called with invalid province index: ", province_building->first);

--- a/src/openvic-simulation/pathfinding/AStarPathing.cpp
+++ b/src/openvic-simulation/pathfinding/AStarPathing.cpp
@@ -115,7 +115,7 @@ bool ArmyAStarPathing::_is_point_enabled(search_const_iterator it) const {
 		return true;
 	}
 
-	ProvinceInstance const* province = map_instance.get_province_instance_by_index_1_based(it->first);
+	ProvinceInstance const* province = map_instance.get_province_instance_from_number(it->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		return true;
@@ -142,7 +142,7 @@ bool NavyAStarPathing::_is_point_enabled(search_const_iterator it) const {
 		return true;
 	}
 
-	ProvinceInstance const* province = map_instance.get_province_instance_by_index_1_based(it->first);
+	ProvinceInstance const* province = map_instance.get_province_instance_from_number(it->first);
 
 	if (OV_unlikely(province == nullptr)) {
 		return true;

--- a/src/openvic-simulation/types/IdentifierRegistry.hpp
+++ b/src/openvic-simulation/types/IdentifierRegistry.hpp
@@ -559,17 +559,14 @@ namespace OpenVic {
 
 /* Macros to generate declaration and constant accessor methods for a UniqueKeyRegistry member variable. */
 
-#define IDENTIFIER_REGISTRY(name, ...) \
-	IDENTIFIER_REGISTRY_CUSTOM_PLURAL(name, name##s __VA_OPT__(,) __VA_ARGS__)
+#define IDENTIFIER_REGISTRY(name) \
+	IDENTIFIER_REGISTRY_CUSTOM_PLURAL(name, name##s)
 
-#define IDENTIFIER_REGISTRY_CUSTOM_PLURAL(singular, plural, ...) \
-	IDENTIFIER_REGISTRY_FULL_CUSTOM(singular, plural, plural, plural, 0 __VA_OPT__(,) __VA_ARGS__)
+#define IDENTIFIER_REGISTRY_CUSTOM_PLURAL(singular, plural) \
+	IDENTIFIER_REGISTRY_FULL_CUSTOM(singular, plural, plural, plural)
 
-#define IDENTIFIER_REGISTRY_CUSTOM_INDEX_OFFSET(name, index_offset, ...) \
-	IDENTIFIER_REGISTRY_FULL_CUSTOM(name, name##s, name##s, name##s, index_offset __VA_OPT__(,) __VA_ARGS__)
-
-#define IDENTIFIER_REGISTRY_FULL_CUSTOM(singular, plural, registry, debug_name, index_offset, ...) \
-	registry { #debug_name __VA_OPT__(,) __VA_ARGS__ }; \
+#define IDENTIFIER_REGISTRY_FULL_CUSTOM(singular, plural, registry, debug_name) \
+	registry { #debug_name }; \
 public: \
 	constexpr void lock_##plural() { \
 		registry.lock(); \
@@ -608,7 +605,7 @@ public: \
 	) const { \
 		return registry.expect_item_decimal_map(callback, fixed_point_functor); \
 	} \
-	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset, const) \
+	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, const) \
 private:
 
 /* Macros to generate non-constant accessor methods for a UniqueKeyRegistry member variable. */
@@ -617,21 +614,12 @@ private:
 	IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_PLURAL(name, name##s)
 
 #define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_PLURAL(singular, plural) \
-	IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(singular, plural, plural, plural, 0)
+	IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(singular, plural, plural, plural)
 
-#define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_CUSTOM_INDEX_OFFSET(name, index_offset) \
-	IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(name, name##s, name##s, name##s, index_offset)
+#define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(singular, plural, registry, debug_name) \
+	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry,)
 
-#define IDENTIFIER_REGISTRY_NON_CONST_ACCESSORS_FULL_CUSTOM(singular, plural, registry, debug_name, index_offset) \
-	IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset,)
-
-#define IF_NON_ZERO(value, conditional_part) IF_NON_ZERO_##value(conditional_part)
-#define IF_NON_ZERO_0(conditional_part)
-#define IF_NON_ZERO_1(conditional_part) conditional_part
-#define CONCAT_FORCE_EXPAND(a, b) a##b
-#define CONCAT_TOKENS(a, b) CONCAT_FORCE_EXPAND(a, b)
-
-#define IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, index_offset, const_kw) \
+#define IDENTIFIER_REGISTRY_INTERNAL_SHARED(singular, plural, registry, const_kw) \
 	constexpr decltype(registry)::external_value_type const_kw& get_front_##singular() const_kw { \
 		return registry.front(); \
 	} \
@@ -645,15 +633,8 @@ private:
 	constexpr T const_kw* get_cast_##singular##_by_identifier(std::string_view identifier) const_kw { \
 		return registry.get_cast_item_by_identifier<T>(identifier); \
 	} \
-IF_NON_ZERO(index_offset, \
-	constexpr decltype(registry)::external_value_type const_kw* get_##singular##_by_index_0_based(std::size_t index_0_based) const_kw { \
-		return index_0_based >= 0 ? registry.get_item_by_index(index_0_based) : nullptr; \
-	} \
-) \
-	constexpr decltype(registry)::external_value_type const_kw* \
-	CONCAT_TOKENS(get_##singular##_by_index, IF_NON_ZERO(index_offset, _##index_offset##_based)) \
-	(std::size_t index) const_kw { \
-		return index >= index_offset ? registry.get_item_by_index(index - index_offset) : nullptr; \
+	constexpr decltype(registry)::external_value_type const_kw* get_##singular##_by_index(std::size_t index) const_kw { \
+		return index >= 0 ? registry.get_item_by_index(index) : nullptr; \
 	} \
 	constexpr decltype(registry)::storage_type const_kw& get_##plural() const_kw { \
 		return registry.get_items(); \


### PR DESCRIPTION
#504 split 0-based and 1-based indices. Spartan and I agreed that indices should always be 0-based.
So we need a different name for 1-based values (used for provinces).
province_id was rejected as id is typically short for identifier and province identifiers (strings) also exist.
Spartan recommended province_number instead. This PR changes the names.