### PR TITLE
Construct via emplace

### DIFF
--- a/src/openvic-simulation/country/CountryDefinition.cpp
+++ b/src/openvic-simulation/country/CountryDefinition.cpp
@@ -76,12 +76,13 @@ bool CountryDefinitionManager::add_country(
 
 	static constexpr colour_t default_colour = colour_t::fill_as(colour_t::max_value);
 
-	return country_definitions.add_item({
+	return country_definitions.emplace_item(
+		identifier,
 		identifier, colour, get_country_definition_count(), *graphical_culture, std::move(parties), std::move(unit_names),
 		dynamic_tag, std::move(alternative_colours),
 		/* Default to country colour for the chest and grey for the others. Update later if necessary. */
 		colour, default_colour, default_colour
-	});
+	);
 }
 
 bool CountryDefinitionManager::load_countries(
@@ -199,8 +200,10 @@ node_callback_t CountryDefinitionManager::load_country_party(
 			Logger::warning("Country party ", party_name, " has no ideology, defaulting to nullptr / no ideology");
 		}
 
-		ret &= country_parties.add_item(
-			{ party_name, start_date, end_date, ideology, std::move(policies) }, duplicate_warning_callback
+		ret &= country_parties.emplace_item(
+			party_name,
+			duplicate_warning_callback,
+			party_name, start_date, end_date, ideology, std::move(policies)
 		);
 
 		return ret;

--- a/src/openvic-simulation/country/CountryDefinition.hpp
+++ b/src/openvic-simulation/country/CountryDefinition.hpp
@@ -22,8 +22,6 @@ namespace OpenVic {
 	struct CountryDefinitionManager;
 
 	struct CountryParty : HasIdentifierAndColour {
-		friend struct CountryDefinitionManager;
-
 		using policy_map_t = IndexedMap<IssueGroup, Issue const*>;
 
 	private:
@@ -32,19 +30,18 @@ namespace OpenVic {
 		Ideology const* PROPERTY(ideology); // Can be nullptr, shows up as "No Ideology" in game
 		policy_map_t PROPERTY(policies);
 
+	public:
 		CountryParty(
 			std::string_view new_identifier, Date new_start_date, Date new_end_date, Ideology const* new_ideology,
 			policy_map_t&& new_policies
 		);
-
-	public:
 		CountryParty(CountryParty&&) = default;
 	};
 
 	/* Generic information about a TAG */
 	struct CountryDefinition : HasIdentifierAndColour, HasIndex<CountryDefinition> {
 		friend struct CountryDefinitionManager;
-
+		
 		using unit_names_map_t = ordered_map<UnitType const*, name_list_t>;
 		using government_colour_map_t = ordered_map<GovernmentType const*, colour_t>;
 
@@ -61,14 +58,14 @@ namespace OpenVic {
 		colour_t PROPERTY(tertiary_unit_colour);
 		// Unit colours not const due to being added after construction
 
+
+	public:
 		CountryDefinition(
 			std::string_view new_identifier, colour_t new_colour, index_t new_index,
 			GraphicalCultureType const& new_graphical_culture, IdentifierRegistry<CountryParty>&& new_parties,
 			unit_names_map_t&& new_unit_names, bool new_dynamic_tag, government_colour_map_t&& new_alternative_colours,
 			colour_t new_primary_unit_colour, colour_t new_secondary_unit_colour, colour_t new_tertiary_unit_colour
 		);
-
-	public:
 		CountryDefinition(CountryDefinition&&) = default;
 
 		// TODO - get_colour including alternative colours

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -2323,7 +2323,8 @@ bool CountryInstanceManager::generate_country_instances(
 	bool ret = true;
 
 	for (CountryDefinition const& country_definition : country_definition_manager.get_country_definitions()) {
-		if (country_instances.add_item({
+		if (country_instances.emplace_item(
+			country_definition.get_identifier(),
 			&country_definition,
 			get_country_instance_count(),
 			building_type_keys,
@@ -2344,7 +2345,7 @@ bool CountryInstanceManager::generate_country_instances(
 			good_instance_manager,
 			country_defines,
 			economy_defines
-		})) {
+		)) {
 			// We need to update the country's ModifierSum's source here as the country's address is finally stable
 			// after changing between its constructor call and now due to being std::move'd into the registry.
 			CountryInstance& country_instance = get_back_country_instance();

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -345,6 +345,7 @@ namespace OpenVic {
 		unlock_level_t PROPERTY(gas_defence_unlock_level, 0);
 		memory::vector<unlock_level_t> PROPERTY(unit_variant_unlock_levels);
 
+	public:
 		CountryInstance(
 			CountryDefinition const* new_country_definition,
 			index_t new_index,
@@ -368,7 +369,6 @@ namespace OpenVic {
 			EconomyDefines const& new_economy_defines
 		);
 
-	public:
 		UNIT_BRANCHED_GETTER(get_unit_instance_groups, armies, navies);
 		UNIT_BRANCHED_GETTER(get_unit_type_unlock_levels, regiment_type_unlock_levels, ship_type_unlock_levels);
 		UNIT_BRANCHED_GETTER(get_leaders, generals, admirals);

--- a/src/openvic-simulation/dataloader/ModManager.cpp
+++ b/src/openvic-simulation/dataloader/ModManager.cpp
@@ -38,8 +38,8 @@ bool ModManager::load_mod_file(ast::NodeCPtr root) {
 	}
 
 	if (ret) {
-		ret &= mods.add_item(
-			{ identifier, path, user_dir, std::move(replace_paths), std::move(dependencies) }
+		ret &= mods.emplace_item(
+			identifier, identifier, path, user_dir, std::move(replace_paths), std::move(dependencies)
 		);
 	}
 

--- a/src/openvic-simulation/dataloader/ModManager.hpp
+++ b/src/openvic-simulation/dataloader/ModManager.hpp
@@ -1,26 +1,21 @@
 #pragma once
 
 #include <string_view>
-#include <vector>
 
 #include "openvic-simulation/types/HasIdentifier.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 
 namespace OpenVic {
-
 	struct Mod : HasIdentifier {
-		friend struct ModManager;
-
 	private:
 		const memory::string PROPERTY(dataloader_root_path);
 		const std::optional<memory::string> PROPERTY(user_dir);
 		const memory::vector<memory::string> PROPERTY(replace_paths);
 		const memory::vector<memory::string> PROPERTY(dependencies);
 
-		Mod(std::string_view new_identifier, std::string_view new_path, std::optional<std::string_view> new_user_dir, memory::vector<memory::string> new_replace_paths, memory::vector<memory::string> new_dependencies);
-
 	public:
+		Mod(std::string_view new_identifier, std::string_view new_path, std::optional<std::string_view> new_user_dir, memory::vector<memory::string> new_replace_paths, memory::vector<memory::string> new_dependencies);
 		Mod(Mod&&) = default;
 	};
 
@@ -34,4 +29,4 @@ namespace OpenVic {
 
 		bool load_mod_file(ast::NodeCPtr root);
 	};
-} // namespace OpenVic
+}

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.cpp
@@ -26,7 +26,7 @@ bool DiplomaticActionManager::add_diplomatic_action(
 		Logger::error("Invalid diplomatic action identifier - empty!");
 		return false;
 	}
-	return diplomatic_action_types.add_item({ identifier, DiplomaticActionType { std::move(initializer) } });
+	return diplomatic_action_types.emplace_item( identifier, identifier, DiplomaticActionType { std::move(initializer) } );
 }
 
 bool DiplomaticActionManager::add_cancelable_diplomatic_action(
@@ -36,7 +36,7 @@ bool DiplomaticActionManager::add_cancelable_diplomatic_action(
 		Logger::error("Invalid cancelable diplomatic action identifier - empty!");
 		return false;
 	}
-	return diplomatic_action_types.add_item({ identifier, CancelableDiplomaticActionType { std::move(initializer) } });
+	return diplomatic_action_types.emplace_item( identifier, identifier, CancelableDiplomaticActionType { std::move(initializer) } );
 }
 
 DiplomaticActionTickCache DiplomaticActionManager::create_diplomatic_action_tick(

--- a/src/openvic-simulation/economy/BuildingInstance.hpp
+++ b/src/openvic-simulation/economy/BuildingInstance.hpp
@@ -4,7 +4,6 @@
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 
 namespace OpenVic {
-
 	struct BuildingInstance : HasIdentifier { // used in the actual game
 		using level_t = BuildingType::level_t;
 

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -44,7 +44,7 @@ bool BuildingTypeManager::add_building_type(
 		return false;
 	}
 
-	const bool ret = building_types.add_item({ identifier, building_type_args });
+	const bool ret = building_types.emplace_item( identifier, identifier, building_type_args );
 
 	if (ret) {
 		building_type_types.emplace(building_type_args.type);

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -9,17 +9,12 @@
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-
-	struct BuildingTypeManager;
-
 	/* REQUIREMENTS:
 	 * MAP-11, MAP-72, MAP-73
 	 * MAP-12, MAP-75, MAP-76
 	 * MAP-13, MAP-78, MAP-79
 	 */
 	struct BuildingType : Modifier {
-		friend struct BuildingTypeManager;
-
 		using level_t = int16_t;
 		using naval_capacity_t = uint64_t;
 
@@ -73,9 +68,8 @@ namespace OpenVic {
 		bool PROPERTY(capital); // only in naval base
 		bool PROPERTY_CUSTOM_PREFIX(port, is); // only in naval base
 
-		BuildingType(std::string_view identifier, building_type_args_t& building_type_args);
-
 	public:
+		BuildingType(std::string_view identifier, building_type_args_t& building_type_args);
 		BuildingType(BuildingType&&) = default;
 	};
 

--- a/src/openvic-simulation/economy/GoodDefinition.cpp
+++ b/src/openvic-simulation/economy/GoodDefinition.cpp
@@ -33,7 +33,7 @@ bool GoodDefinitionManager::add_good_category(std::string_view identifier, size_
 		return false;
 	}
 
-	if (good_categories.add_item({ identifier })) {
+	if (good_categories.emplace_item(identifier, identifier)) {
 		good_categories.back().good_definitions.reserve(expected_goods_in_category);
 		return true;
 	} else {
@@ -62,10 +62,11 @@ bool GoodDefinitionManager::add_good_definition(
 		);
 	}
 
-	if (good_definitions.add_item({
+	if (good_definitions.emplace_item(
+		identifier,
 		identifier, colour, get_good_definition_count(), category, base_price, is_available_from_start,
 		is_tradeable, is_money, has_overseas_penalty
-	})) {
+	)) {
 		category.good_definitions.push_back(&get_back_good_definition());
 		return true;
 	} else {

--- a/src/openvic-simulation/economy/GoodDefinition.hpp
+++ b/src/openvic-simulation/economy/GoodDefinition.hpp
@@ -12,10 +12,8 @@ namespace OpenVic {
 
 	private:
 		memory::vector<GoodDefinition const*> PROPERTY(good_definitions);
-
-		GoodCategory(std::string_view new_identifier);
-
 	public:
+		GoodCategory(std::string_view new_identifier);
 		GoodCategory(GoodCategory&&) = default;
 	};
 
@@ -32,8 +30,6 @@ namespace OpenVic {
 	 * ECON-250, ECON-251, ECON-252, ECON-253, ECON-254, ECON-255, ECON-256, ECON-257, ECON-258, ECON-259, ECON-260, ECON-261
 	 */
 	struct GoodDefinition : HasIdentifierAndColour, HasIndex<GoodDefinition> {
-		friend struct GoodDefinitionManager;
-
 		using good_definition_map_t = fixed_point_map_t<GoodDefinition const*>;
 
 	private:
@@ -44,13 +40,12 @@ namespace OpenVic {
 		const bool PROPERTY(is_money);
 		const bool PROPERTY(counters_overseas_penalty);
 
+	public:
 		GoodDefinition(
 			std::string_view new_identifier, colour_t new_colour, index_t new_index, GoodCategory const& new_category,
 			fixed_point_t new_base_price, bool new_is_available_from_start, bool new_is_tradeable, bool new_is_money,
 			bool new_counters_overseas_penalty
 		);
-
-	public:
 		GoodDefinition(GoodDefinition&&) = default;
 	};
 

--- a/src/openvic-simulation/economy/GoodInstance.cpp
+++ b/src/openvic-simulation/economy/GoodInstance.cpp
@@ -21,7 +21,7 @@ bool GoodInstanceManager::setup_goods(GameRulesManager const& game_rules_manager
 	bool ret = true;
 
 	for (GoodDefinition const& good : good_definition_manager.get_good_definitions()) {
-		ret &= good_instances.add_item({ good, game_rules_manager });
+		ret &= good_instances.emplace_item(good.get_identifier(), good, game_rules_manager);
 	}
 
 	lock_good_instances();

--- a/src/openvic-simulation/economy/GoodInstance.hpp
+++ b/src/openvic-simulation/economy/GoodInstance.hpp
@@ -11,10 +11,8 @@ namespace OpenVic {
 	struct GoodInstance : HasIdentifierAndColour, GoodMarket {
 		friend struct GoodInstanceManager;
 
-	private:
-		GoodInstance(GoodDefinition const& new_good_definition, GameRulesManager const& new_game_rules_manager);
-
 	public:
+		GoodInstance(GoodDefinition const& new_good_definition, GameRulesManager const& new_game_rules_manager);
 		GoodInstance(GoodInstance&&) = default;
 
 		// Is the good available for trading? (e.g. should be shown in trade menu)

--- a/src/openvic-simulation/economy/production/ProductionType.cpp
+++ b/src/openvic-simulation/economy/production/ProductionType.cpp
@@ -173,11 +173,11 @@ bool ProductionTypeManager::add_production_type(
 		}
 	}
 
-	const bool ret = production_types.add_item({
-		game_rules_manager,
-		identifier, owner, std::move(jobs), template_type, base_workforce_size, std::move(input_goods), *output_good,
+	const bool ret = production_types.emplace_item(
+		identifier,
+		game_rules_manager, identifier, owner, std::move(jobs), template_type, base_workforce_size, std::move(input_goods), *output_good,
 		base_output_quantity, std::move(bonuses), std::move(maintenance_requirements), is_coastal, is_farm, is_mine
-	});
+	);
 
 	if (ret && (template_type == RGO)) {
 		ProductionType const*& current_rgo_pt = good_to_rgo_production_type[*output_good];

--- a/src/openvic-simulation/economy/production/ProductionType.hpp
+++ b/src/openvic-simulation/economy/production/ProductionType.hpp
@@ -57,7 +57,9 @@ namespace OpenVic {
 		GoodDefinition::good_definition_map_t PROPERTY(maintenance_requirements);
 		const bool PROPERTY_CUSTOM_PREFIX(coastal, is);
 		const bool _is_farm, _is_mine;
+		bool parse_scripts(DefinitionManager const& definition_manager);
 
+	public:
 		ProductionType(
 			GameRulesManager const& new_game_rules_manager,
 			const std::string_view new_identifier,
@@ -75,9 +77,6 @@ namespace OpenVic {
 			const bool new_is_mine
 		);
 
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		constexpr bool get_is_farm_for_tech() const {
 			if (game_rules_manager.get_use_simple_farm_mine_logic()) {
 				return _is_farm;

--- a/src/openvic-simulation/history/Bookmark.cpp
+++ b/src/openvic-simulation/history/Bookmark.cpp
@@ -26,7 +26,10 @@ Bookmark::Bookmark(
 bool BookmarkManager::add_bookmark(
 	std::string_view name, std::string_view description, Date date, fvec2_t initial_camera_position
 ) {
-	return bookmarks.add_item({ bookmarks.size(), name, description, date, initial_camera_position });
+	return bookmarks.emplace_item(
+		name,
+		bookmarks.size(), name, description, date, initial_camera_position
+	);
 }
 
 bool BookmarkManager::load_bookmark_file(fixed_point_t map_height, ast::NodeCPtr root) {

--- a/src/openvic-simulation/history/Bookmark.hpp
+++ b/src/openvic-simulation/history/Bookmark.hpp
@@ -1,16 +1,11 @@
 #pragma once
 
-#include <cstdint>
-
 #include <openvic-dataloader/v2script/AbstractSyntaxTree.hpp>
 
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
-	struct BookmarkManager;
-
 	struct Bookmark : HasIdentifier, HasIndex<Bookmark> {
-		friend struct BookmarkManager;
 
 	private:
 		memory::string PROPERTY(name);
@@ -18,6 +13,7 @@ namespace OpenVic {
 		const Date PROPERTY(date);
 		const fvec2_t PROPERTY(initial_camera_position);
 
+	public:
 		Bookmark(
 			index_t new_index,
 			std::string_view new_name,
@@ -25,8 +21,6 @@ namespace OpenVic {
 			Date new_date,
 			fvec2_t new_initial_camera_position
 		);
-
-	public:
 		Bookmark(Bookmark&&) = default;
 	};
 

--- a/src/openvic-simulation/interface/GFXSprite.hpp
+++ b/src/openvic-simulation/interface/GFXSprite.hpp
@@ -2,15 +2,9 @@
 
 #include "openvic-simulation/interface/LoadBase.hpp"
 
-namespace OpenVic {
-	class UIManager;
-}
-
 namespace OpenVic::GFX {
 
 	struct Font : HasIdentifierAndAlphaColour {
-		friend class OpenVic::UIManager;
-
 		using colour_codes_t = ordered_map<char, colour_t>;
 
 	private:
@@ -21,12 +15,11 @@ namespace OpenVic::GFX {
 
 		// TODO - effect
 
+	public:
 		Font(
 			std::string_view new_identifier, colour_argb_t new_colour, std::string_view new_fontname,
 			std::string_view new_charset, uint32_t new_height, colour_codes_t&& new_colour_codes
 		);
-
-	public:
 		Font(Font&&) = default;
 	};
 

--- a/src/openvic-simulation/interface/GUI.cpp
+++ b/src/openvic-simulation/interface/GUI.cpp
@@ -63,11 +63,11 @@ bool Element::_fill_elements_key_map(
 
 bool Scene::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_elements_key_map(key_map, [this](memory::unique_base_ptr<Element>&& element) -> bool {
-		return scene_elements.add_item(std::move(element));
+		return scene_elements.emplace_via_move(std::move(element));
 	}, ui_manager);
 	ret &= add_key_map_entry(key_map,
 		"positionType", ZERO_OR_MORE, Position::_expect_value<Position>([this](Position&& position) -> bool {
-			return scene_positions.add_item(std::move(position));
+			return scene_positions.emplace_via_move(std::move(position));
 		})
 	);
 	return ret;
@@ -86,7 +86,7 @@ Window::Window() {}
 
 bool Window::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_elements_key_map(key_map, [this](memory::unique_base_ptr<Element>&& element) -> bool {
-		return window_elements.add_item(std::move(element), duplicate_warning_callback);
+		return window_elements.emplace_via_move(std::move(element), duplicate_warning_callback);
 	}, ui_manager);
 	ret &= Element::_fill_key_map(key_map, ui_manager);
 	ret &= add_key_map_entries(key_map,
@@ -243,7 +243,7 @@ Scrollbar::Scrollbar() {
 bool Scrollbar::_fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) {
 	bool ret = Element::_fill_key_map(key_map, ui_manager);
 	const auto add_element = [this](memory::unique_base_ptr<Element>&& element) -> bool {
-		return scrollbar_elements.add_item(std::move(element));
+		return scrollbar_elements.emplace_via_move(std::move(element));
 	};
 	ret &= add_key_map_entries(key_map,
 		"slider", ONE_EXACTLY, expect_string(assign_variable_callback_string(slider_button_name)),

--- a/src/openvic-simulation/map/Crime.cpp
+++ b/src/openvic-simulation/map/Crime.cpp
@@ -21,8 +21,10 @@ bool CrimeManager::add_crime_modifier(
 		return false;
 	}
 
-	return crime_modifiers.add_item(
-		{ identifier, std::move(values), icon, std::move(trigger), default_active }, duplicate_warning_callback
+	return crime_modifiers.emplace_item(
+		identifier,
+		duplicate_warning_callback,
+		identifier, std::move(values), icon, std::move(trigger), default_active
 	);
 }
 

--- a/src/openvic-simulation/map/Crime.hpp
+++ b/src/openvic-simulation/map/Crime.hpp
@@ -3,18 +3,19 @@
 #include "openvic-simulation/modifier/Modifier.hpp"
 
 namespace OpenVic {
+	struct CrimeManager;
+
 	struct Crime final : TriggeredModifier {
 		friend struct CrimeManager;
 
 	private:
 		const bool PROPERTY_CUSTOM_PREFIX(default_active, is);
 
+	public:
 		Crime(
 			std::string_view new_identifier, ModifierValue&& new_values, icon_t new_icon, ConditionScript&& new_trigger,
 			bool new_default_active
 		);
-
-	public:
 		Crime(Crime&&) = default;
 	};
 

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -66,23 +66,19 @@ bool MapInstance::setup(
 	} else {
 		province_instances.reserve(map_definition.get_province_definition_count());
 
-		for (ProvinceDefinition const& province : map_definition.get_province_definitions()) {
-			if (province_instances.add_item({
-				market_instance,
-				game_rules_manager,
-				modifier_effect_cache,
-				province,
-				strata_keys,
-				pop_type_keys,
-				ideology_keys
-			})) {
-				// We need to update the province's ModifierSum's source here as the province's address is finally stable
-				// after changing between its constructor call and now due to being std::move'd into the registry.
-				ProvinceInstance& province_instance = get_back_province_instance();
-				province_instance.modifier_sum.set_this_source(&province_instance);
-			} else {
+		for (ProvinceDefinition const& province_definition : map_definition.get_province_definitions()) {
+			if (!province_instances.emplace_item(
+				province_definition.get_identifier(),
+				market_instance, game_rules_manager, modifier_effect_cache, province_definition, strata_keys, pop_type_keys, ideology_keys
+			)) {
 				ret = false;
+				continue;
 			}
+
+			// We need to update the province's ModifierSum's source here as the province's address is finally stable
+			// after changing between its constructor call and now due to being std::move'd into the registry.
+			ProvinceInstance& province_instance = get_back_province_instance();
+			province_instance.modifier_sum.set_this_source(&province_instance);
 		}
 	}
 

--- a/src/openvic-simulation/map/Mapmode.cpp
+++ b/src/openvic-simulation/map/Mapmode.cpp
@@ -51,13 +51,10 @@ bool MapmodeManager::add_mapmode(
 		Logger::error("Mapmode colour function is null for identifier: ", identifier);
 		return false;
 	}
-	return mapmodes.add_item({
+	return mapmodes.emplace_item(
 		identifier,
-		static_cast<Mapmode::index_t>(mapmodes.size()),
-		colour_func,
-		localisation_key,
-		parchment_mapmode_allowed
-	});
+		identifier, static_cast<Mapmode::index_t>(mapmodes.size()), colour_func, localisation_key, parchment_mapmode_allowed
+	);
 }
 
 bool MapmodeManager::generate_mapmode_colours(

--- a/src/openvic-simulation/map/Mapmode.hpp
+++ b/src/openvic-simulation/map/Mapmode.hpp
@@ -13,8 +13,6 @@ namespace OpenVic {
 	struct CountryInstance;
 
 	struct Mapmode : HasIdentifier, HasIndex<Mapmode, int32_t> {
-		friend struct MapmodeManager;
-
 		/* Bottom 32 bits are the base colour, top 32 are the stripe colour, both in ARGB format with the alpha channels
 		 * controlling interpolation with the terrain colour (0 = all terrain, 255 = all corresponding RGB) */
 		struct base_stripe_t {
@@ -34,6 +32,9 @@ namespace OpenVic {
 		memory::string PROPERTY(localisation_key);
 		const bool PROPERTY_CUSTOM_PREFIX(parchment_mapmode_allowed, is);
 
+	public:
+		static const Mapmode ERROR_MAPMODE;
+
 		Mapmode(
 			std::string_view new_identifier,
 			index_t new_index,
@@ -41,10 +42,6 @@ namespace OpenVic {
 			std::string_view new_localisation_key = {},
 			bool new_parchment_mapmode_allowed = true
 		);
-
-	public:
-		static const Mapmode ERROR_MAPMODE;
-
 		Mapmode(Mapmode&&) = default;
 
 		base_stripe_t get_base_stripe_colours(

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -101,9 +101,8 @@ namespace OpenVic {
 		fvec2_t PROPERTY(centre);
 		province_positions_t positions {};
 
-		ProvinceDefinition(std::string_view new_identifier, colour_t new_colour, index_t new_index);
-
 	public:
+		ProvinceDefinition(std::string_view new_identifier, colour_t new_colour, index_t new_index);
 		ProvinceDefinition(ProvinceDefinition&&) = default;
 
 		memory::string to_string() const;

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/defines/Define.hpp"
 #include "openvic-simulation/DefinitionManager.hpp"
+#include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/economy/production/ProductionType.hpp"
 #include "openvic-simulation/economy/production/ResourceGatheringOperation.hpp"
 #include "openvic-simulation/history/ProvinceHistory.hpp"
@@ -556,8 +557,9 @@ bool ProvinceInstance::setup(BuildingTypeManager const& building_type_manager) {
 		if (building_type_manager.building_types_are_locked()) {
 			buildings.reserve(building_type_manager.get_province_building_types().size());
 
-			for (BuildingType const* building_type : building_type_manager.get_province_building_types()) {
-				ret &= buildings.add_item({ *building_type });
+			for (BuildingType const* building_type_ptr : building_type_manager.get_province_building_types()) {
+				BuildingType const& building_type = *building_type_ptr;
+				ret &= buildings.emplace_item(building_type.get_identifier(), building_type);
 			}
 		} else {
 			Logger::error("Cannot generate buildings until building types are locked!");

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -137,6 +137,12 @@ namespace OpenVic {
 		fixed_point_map_t<Religion const*> PROPERTY(religion_distribution);
 		size_t PROPERTY(max_supported_regiments, 0);
 
+		void _add_pop(Pop&& pop);
+		void _update_pops(DefineManager const& define_manager);
+		bool convert_rgo_worker_pops_to_equivalent(ProductionType const& production_type);
+		void initialise_rgo();
+
+	public:
 		ProvinceInstance(
 			MarketInstance& new_market_instance,
 			GameRulesManager const& new_game_rules_manager,
@@ -146,13 +152,6 @@ namespace OpenVic {
 			decltype(pop_type_distribution)::keys_span_type pop_type_keys,
 			decltype(ideology_distribution)::keys_span_type ideology_keys
 		);
-
-		void _add_pop(Pop&& pop);
-		void _update_pops(DefineManager const& define_manager);
-		bool convert_rgo_worker_pops_to_equivalent(ProductionType const& production_type);
-		void initialise_rgo();
-
-	public:
 		ProvinceInstance(ProvinceInstance&&) = default;
 
 		inline explicit constexpr operator ProvinceDefinition const&() const {

--- a/src/openvic-simulation/map/Region.hpp
+++ b/src/openvic-simulation/map/Region.hpp
@@ -2,13 +2,11 @@
 
 #include <ranges>
 #include <string_view>
-#include <vector>
 
 #include "openvic-simulation/modifier/Modifier.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-
 	struct ProvinceDefinition;
 
 	struct ProvinceSet {
@@ -48,10 +46,8 @@ namespace OpenVic {
 	};
 
 	struct ProvinceSetModifier : Modifier, ProvinceSet {
-		friend struct MapDefinition;
-	private:
-		ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type);
 	public:
+		ProvinceSetModifier(std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type);
 		ProvinceSetModifier(ProvinceSetModifier&&) = default;
 	};
 
@@ -59,17 +55,14 @@ namespace OpenVic {
 	 * MAP-6, MAP-44, MAP-48
 	 */
 	struct Region : HasIdentifierAndColour, ProvinceSet {
-		friend struct MapDefinition;
-
 	private:
 		/* A meta region cannot be the template for a state.
 		 * Any region without provinces or containing water provinces is considered a meta region.
 		 */
 		const bool PROPERTY(is_meta);
 
-		Region(std::string_view new_identifier, colour_t new_colour, bool new_is_meta);
-
 	public:
+		Region(std::string_view new_identifier, colour_t new_colour, bool new_is_meta);
 		Region(Region&&) = default;
 	};
 }

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -88,9 +88,10 @@ bool TerrainTypeManager::add_terrain_type(
 		return false;
 	}
 
-	return terrain_types.add_item({
+	return terrain_types.emplace_item(
+		identifier,
 		identifier, colour, std::move(values), movement_cost, defence_bonus, combat_width_percentage_change, is_water
-	});
+	);
 }
 
 bool TerrainTypeManager::add_terrain_type_mapping(
@@ -131,7 +132,10 @@ bool TerrainTypeManager::add_terrain_type_mapping(
 		}
 	}
 
-	ret &= terrain_type_mappings.add_item({ identifier, *type, std::move(terrain_indices), priority, has_texture });
+	ret &= terrain_type_mappings.emplace_item(
+		identifier,
+		identifier, *type, std::move(terrain_indices), priority, has_texture
+	);
 
 	return ret;
 }

--- a/src/openvic-simulation/map/TerrainType.hpp
+++ b/src/openvic-simulation/map/TerrainType.hpp
@@ -5,13 +5,9 @@
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-	struct TerrainTypeManager;
-
 	// Using HasColour rather than HasIdentifierAndColour to avoid needing virtual inheritance
 	// (extending Modifier is more useful than extending HasIdentifierAndColour).
 	struct TerrainType : Modifier, HasColour {
-		friend struct TerrainTypeManager;
-
 	private:
 		ModifierValue PROPERTY(modifier);
 		fixed_point_t PROPERTY(movement_cost);
@@ -19,6 +15,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(combat_width_percentage_change);
 		const bool PROPERTY(is_water);
 
+	public:
 		TerrainType(
 			std::string_view new_identifier,
 			colour_t new_colour,
@@ -28,14 +25,10 @@ namespace OpenVic {
 			fixed_point_t new_combat_width_percentage_change,
 			bool new_is_water
 		);
-
-	public:
 		TerrainType(TerrainType&&) = default;
 	};
 
 	struct TerrainTypeMapping : HasIdentifier {
-		friend struct TerrainTypeManager;
-
 		using index_t = uint8_t;
 
 	private:
@@ -44,6 +37,7 @@ namespace OpenVic {
 		const index_t PROPERTY(priority);
 		const bool PROPERTY(has_texture);
 
+	public:
 		TerrainTypeMapping(
 			std::string_view new_identifier,
 			TerrainType const& new_type,
@@ -51,8 +45,6 @@ namespace OpenVic {
 			index_t new_priority,
 			bool new_has_texture
 		);
-
-	public:
 		TerrainTypeMapping(TerrainTypeMapping&&) = default;
 	};
 

--- a/src/openvic-simulation/military/Deployment.cpp
+++ b/src/openvic-simulation/military/Deployment.cpp
@@ -35,7 +35,10 @@ bool DeploymentManager::add_deployment(
 		return false;
 	}
 
-	return deployments.add_item({ path, std::move(armies), std::move(navies), std::move(leaders) });
+	return deployments.emplace_item(
+		path,
+		path, std::move(armies), std::move(navies), std::move(leaders)
+	);
 }
 
 bool DeploymentManager::load_oob_file(

--- a/src/openvic-simulation/military/Deployment.hpp
+++ b/src/openvic-simulation/military/Deployment.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <string>
 #include <string_view>
-#include <vector>
 
 #include "openvic-simulation/military/Leader.hpp"
 #include "openvic-simulation/military/UnitType.hpp"
@@ -71,19 +69,16 @@ namespace OpenVic {
 	using NavyDeployment = UnitDeploymentGroup<UnitType::branch_t::NAVAL>;
 
 	struct Deployment : HasIdentifier {
-		friend struct DeploymentManager;
-
 	private:
 		memory::vector<ArmyDeployment> PROPERTY(armies);
 		memory::vector<NavyDeployment> PROPERTY(navies);
 		memory::vector<LeaderBase> PROPERTY(leaders);
 
+	public:
 		Deployment(
 			std::string_view new_path, memory::vector<ArmyDeployment>&& new_armies, memory::vector<NavyDeployment>&& new_navies,
 			memory::vector<LeaderBase>&& new_leaders
 		);
-
-	public:
 		Deployment(Deployment&&) = default;
 
 		UNIT_BRANCHED_GETTER_CONST(get_unit_deployment_groups, armies, navies);

--- a/src/openvic-simulation/military/LeaderTrait.cpp
+++ b/src/openvic-simulation/military/LeaderTrait.cpp
@@ -65,22 +65,25 @@ bool LeaderTraitManager::add_leader_trait(
 		return false;
 	}
 
-	if (leader_traits.add_item({ identifier, type, std::move(modifiers) })) {
-		using enum LeaderTrait::trait_type_t;
-
-		switch (type) {
-		case PERSONALITY:
-			personality_traits.push_back(&leader_traits.back());
-			break;
-		case BACKGROUND:
-			background_traits.push_back(&leader_traits.back());
-			break;
-		}
-
-		return true;
-	} else {
+	if (!leader_traits.emplace_item(
+		identifier,
+		identifier, type, std::move(modifiers)
+	)) {
 		return false;
 	}
+
+	using enum LeaderTrait::trait_type_t;
+
+	switch (type) {
+	case PERSONALITY:
+		personality_traits.push_back(&leader_traits.back());
+		break;
+	case BACKGROUND:
+		background_traits.push_back(&leader_traits.back());
+		break;
+	}
+
+	return true;
 }
 
 bool LeaderTraitManager::load_leader_traits_file(ModifierManager const& modifier_manager, ast::NodeCPtr root) {

--- a/src/openvic-simulation/military/LeaderTrait.hpp
+++ b/src/openvic-simulation/military/LeaderTrait.hpp
@@ -8,10 +8,7 @@
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-	struct LeaderTraitManager;
-
 	struct LeaderTrait : Modifier {
-		friend struct LeaderTraitManager;
 
 		enum class trait_type_t { PERSONALITY, BACKGROUND };
 
@@ -31,9 +28,8 @@ namespace OpenVic {
 		 * reliability - decimal, mil gain or loss for associated POPs
 		 */
 
-		LeaderTrait(std::string_view new_identifier, trait_type_t new_type, ModifierValue&& new_modifiers);
-
 	public:
+		LeaderTrait(std::string_view new_identifier, trait_type_t new_type, ModifierValue&& new_modifiers);
 		LeaderTrait(LeaderTrait&&) = default;
 
 		bool is_personality_trait() const;

--- a/src/openvic-simulation/military/UnitType.cpp
+++ b/src/openvic-simulation/military/UnitType.cpp
@@ -122,10 +122,13 @@ bool UnitTypeManager::add_regiment_type(
 		return false;
 	}
 
-	bool ret = regiment_types.add_item({ identifier, unit_args, std::move(regiment_type_args) });
+	bool ret = regiment_types.emplace_item(
+		identifier,
+		identifier, unit_args, std::move(regiment_type_args)
+	);
 	if (ret) {
 		// Cannot use get_back_regiment_type() as we need non-const but don't want to generate all non-const functions.
-		ret &= unit_types.add_item(&regiment_types.back());
+		ret &= unit_types.emplace_via_copy(&regiment_types.back());
 	}
 	return ret;
 }
@@ -151,10 +154,13 @@ bool UnitTypeManager::add_ship_type(
 		return false;
 	}
 
-	bool ret = ship_types.add_item({ identifier, unit_args, ship_type_args });
+	bool ret = ship_types.emplace_item(
+		identifier,
+		identifier, unit_args, ship_type_args
+	);
 	if (ret) {
 		// Cannot use get_back_ship_type() as we need non-const but don't want to generate all non-const functions.
-		ret &= unit_types.add_item(&ship_types.back());
+		ret &= unit_types.emplace_via_copy(&ship_types.back());
 	}
 	return ret;
 }

--- a/src/openvic-simulation/military/UnitType.hpp
+++ b/src/openvic-simulation/military/UnitType.hpp
@@ -146,8 +146,6 @@ namespace OpenVic {
 
 	template<>
 	struct UnitTypeBranched<UnitType::branch_t::LAND> : UnitType {
-		friend struct UnitTypeManager;
-
 		// Each value is a subset of its predecessor, so smaller values contain larger values
 		// The exact values here must be preserved to allow easy comparison against Pop::culture_status_t
 		enum struct allowed_cultures_t : uint8_t { ALL_CULTURES, ACCEPTED_CULTURES, PRIMARY_CULTURE, NO_CULTURES };
@@ -183,11 +181,10 @@ namespace OpenVic {
 		const fixed_point_t PROPERTY(maneuver);
 		const fixed_point_t PROPERTY(siege);
 
+	public:
 		UnitTypeBranched(
 			std::string_view new_identifier, unit_type_args_t& unit_args, regiment_type_args_t const& regiment_type_args
 		);
-
-	public:
 		UnitTypeBranched(UnitTypeBranched&&) = default;
 	};
 
@@ -195,8 +192,6 @@ namespace OpenVic {
 
 	template<>
 	struct UnitTypeBranched<UnitType::branch_t::NAVAL> : UnitType {
-		friend struct UnitTypeManager;
-
 		struct ship_type_args_t {
 			icon_t naval_icon = 0;
 			bool sail = false, transport = false, capital = false, build_overseas = false;
@@ -226,9 +221,8 @@ namespace OpenVic {
 		const fixed_point_t PROPERTY(evasion);
 		const fixed_point_t PROPERTY(torpedo_attack);
 
-		UnitTypeBranched(std::string_view new_identifier, unit_type_args_t& unit_args, ship_type_args_t const& ship_type_args);
-
 	public:
+		UnitTypeBranched(std::string_view new_identifier, unit_type_args_t& unit_args, ship_type_args_t const& ship_type_args);
 		UnitTypeBranched(UnitTypeBranched&&) = default;
 	};
 

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -62,12 +62,13 @@ bool WargoalTypeManager::add_wargoal_type(
 		Logger::warning("Invalid sprite for wargoal ", identifier, " - 0");
 	}
 
-	return wargoal_types.add_item({
+	return wargoal_types.emplace_item(
+		identifier,
 		identifier, war_name, available_length, truce_length, sprite_index, triggered_only, civil_war, constructing, crisis,
 		great_war_obligatory, mutual, all_allowed_states, always, std::move(modifiers), peace_options, std::move(can_use),
 		std::move(is_valid), std::move(allowed_states), std::move(allowed_substate_regions),
 		std::move(allowed_states_in_crisis), std::move(allowed_countries), std::move(on_add), std::move(on_po_accepted)
-	});
+	);
 }
 
 bool WargoalTypeManager::load_wargoal_file(ovdl::v2script::Parser const& parser) {

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -80,6 +80,9 @@ namespace OpenVic {
 		EffectScript PROPERTY(on_add);
 		EffectScript PROPERTY(on_po_accepted);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		WargoalType(
 			std::string_view new_identifier, std::string_view new_war_name, Timespan new_available_length,
 			Timespan new_truce_length, sprite_t new_sprite_index, bool new_triggered_only, bool new_civil_war,
@@ -89,10 +92,6 @@ namespace OpenVic {
 			ConditionScript&& new_allowed_substate_regions, ConditionScript&& new_allowed_states_in_crisis,
 			ConditionScript&& new_allowed_countries, EffectScript&& new_on_add, EffectScript&& new_on_po_accepted
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		WargoalType(WargoalType&&) = default;
 	};
 

--- a/src/openvic-simulation/misc/Decision.cpp
+++ b/src/openvic-simulation/misc/Decision.cpp
@@ -44,10 +44,12 @@ bool DecisionManager::add_decision(
 		}
 	}
 
-	return decisions.add_item({
+	return decisions.emplace_item(
+		identifier,
+		duplicate_warning_callback,
 		identifier, alert, news, news_title, news_desc_long, news_desc_medium, news_desc_short, picture, std::move(potential),
 		std::move(allow), std::move(ai_will_do), std::move(effect)
-	}, duplicate_warning_callback);
+	);
 }
 
 bool DecisionManager::load_decision_file(ast::NodeCPtr root) {

--- a/src/openvic-simulation/misc/Decision.hpp
+++ b/src/openvic-simulation/misc/Decision.hpp
@@ -23,16 +23,15 @@ namespace OpenVic {
 		ConditionalWeightFactorMul PROPERTY(ai_will_do);
 		EffectScript PROPERTY(effect);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Decision(
 			std::string_view new_identifier, bool new_alert, bool new_news, std::string_view new_news_title,
 			std::string_view new_news_desc_long, std::string_view new_news_desc_medium, std::string_view new_news_desc_short,
 			std::string_view new_picture, ConditionScript&& new_potential, ConditionScript&& new_allow,
 			ConditionalWeightFactorMul&& new_ai_will_do, EffectScript&& new_effect
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Decision(Decision&&) = default;
 	};
 

--- a/src/openvic-simulation/misc/Event.cpp
+++ b/src/openvic-simulation/misc/Event.cpp
@@ -108,11 +108,13 @@ bool EventManager::register_event(
 
 	// TODO - error if is_triggered_only with triggers or MTTH defined
 
-	return events.add_item({
+	return events.emplace_item(
+		identifier,
+		duplicate_warning_callback,
 		identifier, title, description, image, type, triggered_only, major, fire_only_once, allows_multiple_instances, news,
 		news_title, news_desc_long, news_desc_medium, news_desc_short, election, election_issue_group, std::move(trigger),
 		std::move(mean_time_to_happen), std::move(immediate), std::move(options)
-	}, duplicate_warning_callback);
+	);
 }
 
 bool EventManager::add_on_action(std::string_view identifier, OnAction::weight_map_t&& weighted_events) {
@@ -121,7 +123,10 @@ bool EventManager::add_on_action(std::string_view identifier, OnAction::weight_m
 		return false;
 	}
 
-	return on_actions.add_item({ identifier, std::move(weighted_events) });
+	return on_actions.emplace_item(
+		identifier,
+		identifier, std::move(weighted_events)
+	);
 }
 
 bool EventManager::load_event_file(IssueManager const& issue_manager, ast::NodeCPtr root) {

--- a/src/openvic-simulation/misc/Event.hpp
+++ b/src/openvic-simulation/misc/Event.hpp
@@ -60,6 +60,9 @@ namespace OpenVic {
 
 		memory::vector<EventOption> PROPERTY(options);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Event(
 			std::string_view new_identifier, std::string_view new_title, std::string_view new_description,
 			std::string_view new_image, event_type_t new_type, bool new_triggered_only, bool new_major,
@@ -69,24 +72,17 @@ namespace OpenVic {
 			ConditionalWeightTime&& new_mean_time_to_happen, EffectScript&& new_immediate,
 			memory::vector<EventOption>&& new_options
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Event(Event&&) = default;
 	};
 
 	struct OnAction : HasIdentifier {
-		friend struct EventManager;
-
 		using weight_map_t = ordered_map<Event const*, uint64_t>;
 
 	private:
 		weight_map_t PROPERTY(weighted_events);
 
-		OnAction(std::string_view new_identifier, weight_map_t&& new_weighted_events);
-
 	public:
+		OnAction(std::string_view new_identifier, weight_map_t&& new_weighted_events);
 		OnAction(OnAction&&) = default;
 	};
 

--- a/src/openvic-simulation/misc/SongChance.cpp
+++ b/src/openvic-simulation/misc/SongChance.cpp
@@ -31,7 +31,10 @@ bool SongChanceManager::load_songs_file(ast::NodeCPtr root) {
 				"chance", ONE_EXACTLY, chance.expect_conditional_weight()
 			)(value);
 
-			ret &= song_chances.add_item({ song_chances.size(), name, std::move(chance) });
+			ret &= song_chances.emplace_item(
+				name,
+				song_chances.size(), name, std::move(chance)
+			);
 			return ret;
 		}
 	)(root);

--- a/src/openvic-simulation/misc/SongChance.hpp
+++ b/src/openvic-simulation/misc/SongChance.hpp
@@ -14,11 +14,10 @@ namespace OpenVic {
 		memory::string PROPERTY(file_name);
 		ConditionalWeightFactorMul PROPERTY(chance);
 
-		SongChance(size_t new_index, std::string_view new_filename, ConditionalWeightFactorMul&& new_chance);
-
 		bool parse_scripts(DefinitionManager const& definition_manager);
 
 	public:
+		SongChance(size_t new_index, std::string_view new_filename, ConditionalWeightFactorMul&& new_chance);
 		SongChance(SongChance&&) = default;
 	};
 

--- a/src/openvic-simulation/misc/SoundEffect.cpp
+++ b/src/openvic-simulation/misc/SoundEffect.cpp
@@ -35,7 +35,10 @@ bool SoundEffectManager::_load_sound_define(Dataloader const& dataloader, std::s
 		Logger::warning("Sound filename ", sfx_identifier, " was empty!");
 	}
 
-	ret &= sound_effects.add_item({ sfx_identifier, std::move(file), volume });
+	ret &= sound_effects.emplace_item(
+		sfx_identifier,
+		sfx_identifier, std::move(file), volume
+	);
 	return ret;
 }
 

--- a/src/openvic-simulation/misc/SoundEffect.hpp
+++ b/src/openvic-simulation/misc/SoundEffect.hpp
@@ -8,19 +8,13 @@
 namespace OpenVic {
 	class Dataloader;
 
-	/*For interface/Sound.sfx */
-	class SoundEffectManager;
-
 	struct SoundEffect : HasIdentifier {
-		friend class SoundEffectManager;
-
 	private:
 		std::filesystem::path PROPERTY(file);
 		fixed_point_t PROPERTY(volume);
 
-		SoundEffect(std::string_view new_identifier, std::filesystem::path&& new_file, fixed_point_t new_volume);
-
 	public:
+		SoundEffect(std::string_view new_identifier, std::filesystem::path&& new_file, fixed_point_t new_volume);
 		SoundEffect(SoundEffect&&) = default;
 	};
 

--- a/src/openvic-simulation/modifier/Modifier.hpp
+++ b/src/openvic-simulation/modifier/Modifier.hpp
@@ -35,18 +35,14 @@ namespace OpenVic {
 	};
 
 	struct IconModifier : Modifier {
-		friend struct ModifierManager;
-
 		using icon_t = uint8_t;
 
 	private:
 		/* A modifier can have no icon (zero). */
 		const icon_t PROPERTY(icon);
 
-	protected:
-		IconModifier(std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type, icon_t new_icon);
-
 	public:
+		IconModifier(std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type, icon_t new_icon);
 		IconModifier(IconModifier&&) = default;
 	};
 
@@ -57,14 +53,13 @@ namespace OpenVic {
 		ConditionScript trigger;
 
 	protected:
+		bool parse_scripts(DefinitionManager const& definition_manager, bool can_be_null = false);
+
+	public:
 		TriggeredModifier(
 			std::string_view new_identifier, ModifierValue&& new_values, modifier_type_t new_type, icon_t new_icon,
 			ConditionScript&& new_trigger
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager, bool can_be_null = false);
-
-	public:
 		TriggeredModifier(TriggeredModifier&&) = default;
 	};
 

--- a/src/openvic-simulation/modifier/ModifierEffect.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffect.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include <string_view>
 
 #include "openvic-simulation/types/EnumBitfield.hpp"
@@ -10,8 +9,6 @@ namespace OpenVic {
 	struct ModifierManager;
 
 	struct ModifierEffect : HasIdentifier {
-		friend struct ModifierManager;
-
 		static constexpr size_t FORMAT_MULTIPLIER_BIT_COUNT = 2;
 		static constexpr size_t FORMAT_DECIMAL_PLACES_BIT_COUNT = 2;
 		static constexpr size_t FORMAT_SUFFIX_BIT_COUNT = 2;
@@ -106,12 +103,11 @@ namespace OpenVic {
 
 		// TODO - format/precision, e.g. 80% vs 0.8 vs 0.800, 2 vs 2.0 vs 200%
 
+	public:
 		ModifierEffect(
 			std::string_view new_identifier, format_t new_format, target_t new_targets,
 			std::string_view new_localisation_key, bool new_has_no_effect
 		);
-
-	public:
 		ModifierEffect(ModifierEffect&&) = default;
 
 		// TODO - check if this is an accurate and consistent method of classifying global and local effects

--- a/src/openvic-simulation/modifier/ModifierManager.cpp
+++ b/src/openvic-simulation/modifier/ModifierManager.cpp
@@ -57,9 +57,10 @@ bool ModifierManager::_register_modifier_effect(
 		return false;
 	}
 
-	const bool ret = registry.add_item({
-		std::move(identifier), format, targets, localisation_key, has_no_effect
-	});
+	const bool ret = registry.emplace_item(
+		identifier,
+		identifier, format, targets, localisation_key, has_no_effect
+	);
 
 	if (ret) {
 		effect_cache = &registry.back();
@@ -670,8 +671,10 @@ bool ModifierManager::add_event_modifier(
 		return false;
 	}
 
-	return event_modifiers.add_item(
-		{ identifier, std::move(values), type, icon }, duplicate_warning_callback
+	return event_modifiers.emplace_item(
+		identifier,
+		duplicate_warning_callback,
+		identifier, std::move(values), type, icon 
 	);
 }
 
@@ -713,9 +716,10 @@ bool ModifierManager::add_triggered_modifier(
 		return false;
 	}
 
-	return triggered_modifiers.add_item(
-		{ identifier, std::move(values), TRIGGERED, icon, std::move(trigger) },
-		duplicate_warning_callback
+	return triggered_modifiers.emplace_item(
+		identifier,
+		duplicate_warning_callback,
+		identifier, std::move(values), TRIGGERED, icon, std::move(trigger)
 	);
 }
 

--- a/src/openvic-simulation/politics/Government.cpp
+++ b/src/openvic-simulation/politics/Government.cpp
@@ -36,9 +36,10 @@ bool GovernmentTypeManager::add_government_type(
 		return false;
 	}
 
-	const bool ret = government_types.add_item({
+	const bool ret = government_types.emplace_item(
+		identifier,
 		identifier, std::move(ideologies), elections, appoint_ruling_party, term_duration, flag_type
-	});
+	);
 
 	/* flag_type can be empty here for default/non-ideological flag */
 	if (ret) {

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -4,11 +4,7 @@
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-	struct GovernmentTypeManager;
-
 	struct GovernmentType : HasIdentifier {
-		friend struct GovernmentTypeManager;
-
 	private:
 		memory::vector<Ideology const*> PROPERTY(ideologies);
 		const bool PROPERTY_CUSTOM_PREFIX(elections, holds);
@@ -16,12 +12,11 @@ namespace OpenVic {
 		const Timespan PROPERTY(term_duration);
 		memory::string PROPERTY_CUSTOM_NAME(flag_type_identifier, get_flag_type);
 
+	public:
 		GovernmentType(
 			std::string_view new_identifier, memory::vector<Ideology const*>&& new_ideologies, bool new_elections,
 			bool new_appoint_ruling_party, Timespan new_term_duration, std::string_view new_flag_type_identifier
 		);
-
-	public:
 		GovernmentType(GovernmentType&&) = default;
 
 		bool is_ideology_compatible(Ideology const* ideology) const;

--- a/src/openvic-simulation/politics/Ideology.cpp
+++ b/src/openvic-simulation/politics/Ideology.cpp
@@ -55,7 +55,7 @@ bool IdeologyManager::add_ideology_group(std::string_view identifier) {
 		return false;
 	}
 
-	return ideology_groups.add_item({ identifier });
+	return ideology_groups.emplace_item(identifier, identifier);
 }
 
 bool IdeologyManager::add_ideology(
@@ -85,7 +85,8 @@ bool IdeologyManager::add_ideology(
 	}
 
 	const Ideology::index_t new_index = ideologies.size();
-	return ideologies.add_item({
+	return ideologies.emplace_item(
+		identifier,
 		identifier,
 		new_index,
 		colour,
@@ -100,7 +101,7 @@ bool IdeologyManager::add_ideology(
 		std::move(remove_social_reform),
 		std::move(add_military_reform),
 		std::move(add_economic_reform)
-	});
+	);
 }
 
 /* REQUIREMENTS:

--- a/src/openvic-simulation/politics/Ideology.hpp
+++ b/src/openvic-simulation/politics/Ideology.hpp
@@ -7,12 +7,8 @@ namespace OpenVic {
 	struct IdeologyManager;
 
 	struct IdeologyGroup : HasIdentifier {
-		friend struct IdeologyManager;
-
-	private:
-		IdeologyGroup(std::string_view new_identifier);
-
 	public:
+		IdeologyGroup(std::string_view new_identifier);
 		IdeologyGroup(IdeologyGroup&&) = default;
 	};
 
@@ -36,6 +32,9 @@ namespace OpenVic {
 
 		// TODO - willingness to repeal/pass reforms (and its modifiers)
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Ideology(
 			std::string_view new_identifier,
 			index_t new_index,
@@ -52,10 +51,6 @@ namespace OpenVic {
 			ConditionalWeightBase&& new_add_military_reform,
 			ConditionalWeightBase&& new_add_economic_reform
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Ideology(Ideology&&) = default;
 	};
 

--- a/src/openvic-simulation/politics/Issue.cpp
+++ b/src/openvic-simulation/politics/Issue.cpp
@@ -52,7 +52,10 @@ bool IssueManager::add_issue_group(std::string_view identifier) {
 		return false;
 	}
 
-	return issue_groups.add_item({ identifier, get_issue_group_count() });
+	return issue_groups.emplace_item(
+		identifier,
+		identifier, get_issue_group_count()
+	);
 }
 
 bool IssueManager::add_issue(
@@ -64,12 +67,15 @@ bool IssueManager::add_issue(
 		return false;
 	}
 
-	if (issues.add_item({ identifier, new_colour, std::move(values), issue_group, std::move(rules), jingoism })) {
-		issue_group.issues.push_back(&get_back_issue());
-		return true;
-	} else {
+	if (!issues.emplace_item(
+		identifier,
+		identifier, new_colour, std::move(values), issue_group, std::move(rules), jingoism
+	)) {
 		return false;
 	}
+
+	issue_group.issues.push_back(&get_back_issue());
+	return true;
 }
 
 bool IssueManager::add_reform_type(std::string_view identifier, bool uncivilised) {
@@ -78,7 +84,10 @@ bool IssueManager::add_reform_type(std::string_view identifier, bool uncivilised
 		return false;
 	}
 
-	return reform_types.add_item({ identifier, uncivilised });
+	return reform_types.emplace_item(
+		identifier,
+		identifier, uncivilised
+	);
 }
 
 bool IssueManager::add_reform_group(
@@ -89,14 +98,15 @@ bool IssueManager::add_reform_group(
 		return false;
 	}
 
-	if (reform_groups.add_item({
+	if (!reform_groups.emplace_item(
+		identifier,
 		identifier, get_reform_group_count(), reform_type, ordered, administrative
-	})) {
-		reform_type.reform_groups.push_back(&get_back_reform_group());
-		return true;
-	} else {
+	)) {
 		return false;
 	}
+
+	reform_type.reform_groups.push_back(&get_back_reform_group());
+	return true;
 }
 
 bool IssueManager::add_reform(
@@ -135,15 +145,16 @@ bool IssueManager::add_reform(
 		);
 	}
 
-	if (reforms.add_item({
+	if (!reforms.emplace_item(
+		identifier,
 		identifier, new_colour, std::move(values), reform_group, ordinal, administrative_multiplier, std::move(rules),
 		technology_cost, std::move(allow), std::move(on_execute_trigger), std::move(on_execute_effect)
-	})) {
-		reform_group.issues.push_back(&get_back_reform());
-		return true;
-	} else {
+	)) {
 		return false;
 	}
+
+	reform_group.issues.push_back(&get_back_reform());
+	return true;
 }
 
 bool IssueManager::_load_issue_group(size_t& expected_issues, std::string_view identifier, ast::NodeCPtr node) {

--- a/src/openvic-simulation/politics/Issue.hpp
+++ b/src/openvic-simulation/politics/Issue.hpp
@@ -18,10 +18,8 @@ namespace OpenVic {
 	private:
 		memory::vector<Issue const*> PROPERTY(issues);
 
-	protected:
-		IssueGroup(std::string_view identifier, index_t new_index);
-
 	public:
+		IssueGroup(std::string_view identifier, index_t new_index);
 		IssueGroup(IssueGroup&&) = default;
 
 		constexpr size_t get_issue_count() const {
@@ -31,21 +29,17 @@ namespace OpenVic {
 
 	// Issue (i.e. protectionism)
 	struct Issue : Modifier, HasColour {
-		friend struct IssueManager;
-
 	private:
 		IssueGroup const& PROPERTY(issue_group);
 		RuleSet PROPERTY(rules);
 		const bool PROPERTY_CUSTOM_PREFIX(jingoism, is);
 
-	protected:
+	public:
 		Issue(
 			std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values,
 			IssueGroup const& new_issue_group, RuleSet&& new_rules, bool new_jingoism,
 			modifier_type_t new_type = modifier_type_t::ISSUE
 		);
-
-	public:
 		Issue(Issue&&) = default;
 	};
 
@@ -60,9 +54,8 @@ namespace OpenVic {
 		// in vanilla education, military and economic reforms are hardcoded to true and the rest to false
 		memory::vector<ReformGroup const*> PROPERTY(reform_groups);
 
-		ReformType(std::string_view new_identifier, bool new_uncivilised);
-
 	public:
+		ReformType(std::string_view new_identifier, bool new_uncivilised);
 		ReformType(ReformType&&) = default;
 	};
 
@@ -70,19 +63,17 @@ namespace OpenVic {
 
 	// Reform group (i.e. slavery)
 	struct ReformGroup : IssueGroup {
-		friend struct IssueManager;
 
 	private:
 		ReformType const& PROPERTY(reform_type);
 		const bool PROPERTY_CUSTOM_PREFIX(ordered, is); // next_step_only
 		const bool PROPERTY_CUSTOM_PREFIX(administrative, is);
 
+	public:
 		ReformGroup(
 			std::string_view new_identifier, index_t new_index, ReformType const& new_reform_type, bool new_ordered,
 			bool new_administrative
 		);
-
-	public:
 		ReformGroup(ReformGroup&&) = default;
 
 		constexpr size_t get_reform_count() const {
@@ -111,16 +102,15 @@ namespace OpenVic {
 		ConditionScript PROPERTY(on_execute_trigger);
 		EffectScript PROPERTY(on_execute_effect);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Reform(
 			std::string_view new_identifier, colour_t new_colour, ModifierValue&& new_values,
 			ReformGroup const& new_reform_group, size_t new_ordinal, fixed_point_t new_administrative_multiplier,
 			RuleSet&& new_rules, tech_cost_t new_technology_cost, ConditionScript&& new_allow,
 			ConditionScript&& new_on_execute_trigger, EffectScript&& new_on_execute_effect
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Reform(Reform&&) = default;
 
 		constexpr ReformGroup const& get_reform_group() const {

--- a/src/openvic-simulation/politics/NationalFocus.cpp
+++ b/src/openvic-simulation/politics/NationalFocus.cpp
@@ -51,7 +51,7 @@ inline bool NationalFocusManager::add_national_focus_group(std::string_view iden
 		return false;
 	}
 
-	return national_focus_groups.add_item({ identifier });
+	return national_focus_groups.emplace_item(identifier, identifier);
 }
 
 inline bool NationalFocusManager::add_national_focus(
@@ -88,11 +88,12 @@ inline bool NationalFocusManager::add_national_focus(
 		);
 	}
 
-	return national_foci.add_item({
+	return national_foci.emplace_item(
+		identifier,
 		identifier, group, icon, has_flashpoint, flashpoint_tension, own_provinces, outliner_show_as_percent,
 		std::move(modifiers), loyalty_ideology, loyalty_value, encourage_railroads, std::move(encourage_goods),
 		std::move(encourage_pop_types), std::move(limit)
-	});
+	);
 }
 
 bool NationalFocusManager::load_national_foci_file(

--- a/src/openvic-simulation/politics/NationalFocus.hpp
+++ b/src/openvic-simulation/politics/NationalFocus.hpp
@@ -9,9 +9,7 @@ namespace OpenVic {
 	struct NationalFocusManager;
 
 	struct NationalFocusGroup : HasIdentifier {
-		friend struct NationalFocusManager;
-
-	private:
+	public:
 		NationalFocusGroup(std::string_view new_identifier);
 	};
 
@@ -36,6 +34,9 @@ namespace OpenVic {
 		fixed_point_map_t<PopType const*> PROPERTY(encourage_pop_types);
 		ConditionScript PROPERTY(limit);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		NationalFocus(
 			std::string_view new_identifier,
 			NationalFocusGroup const& new_group,
@@ -52,10 +53,6 @@ namespace OpenVic {
 			fixed_point_map_t<PopType const*>&& new_encourage_pop_types,
 			ConditionScript&& new_limit
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		NationalFocus(NationalFocus&&) = default;
 	};
 

--- a/src/openvic-simulation/politics/NationalValue.cpp
+++ b/src/openvic-simulation/politics/NationalValue.cpp
@@ -15,7 +15,10 @@ bool NationalValueManager::add_national_value(std::string_view identifier, Modif
 		return false;
 	}
 
-	return national_values.add_item({ identifier, std::move(modifiers) });
+	return national_values.emplace_item(
+		identifier,
+		identifier, std::move(modifiers)
+	);
 }
 
 bool NationalValueManager::load_national_values_file(ModifierManager const& modifier_manager, ast::NodeCPtr root) {

--- a/src/openvic-simulation/politics/NationalValue.hpp
+++ b/src/openvic-simulation/politics/NationalValue.hpp
@@ -7,12 +7,8 @@ namespace OpenVic {
 	struct NationalValueManager;
 
 	struct NationalValue : Modifier {
-		friend struct NationalValueManager;
-
-	private:
-		NationalValue(std::string_view new_identifier, ModifierValue&& new_modifiers);
-
 	public:
+		NationalValue(std::string_view new_identifier, ModifierValue&& new_modifiers);
 		NationalValue(NationalValue&&) = default;
 	};
 

--- a/src/openvic-simulation/politics/Rebel.cpp
+++ b/src/openvic-simulation/politics/Rebel.cpp
@@ -56,13 +56,14 @@ bool RebelManager::add_rebel_type(
 		return false;
 	}
 
-	return rebel_types.add_item({
+	return rebel_types.emplace_item(
+		new_identifier,
 		new_identifier, icon, area, break_alliance_on_win, std::move(desired_governments), defection, independence,
 		defect_delay, ideology, allow_all_cultures, allow_all_culture_groups, allow_all_religions, allow_all_ideologies,
 		resilient, reinforcing, general, smart, unit_transfer, occupation_mult, std::move(will_rise), std::move(spawn_chance),
 		std::move(movement_evaluation), std::move(siege_won_trigger), std::move(siege_won_effect),
 		std::move(demands_enforced_trigger), std::move(demands_enforced_effect)
-	});
+	);
 }
 
 bool RebelManager::load_rebels_file(

--- a/src/openvic-simulation/politics/Rebel.hpp
+++ b/src/openvic-simulation/politics/Rebel.hpp
@@ -60,6 +60,9 @@ namespace OpenVic {
 		ConditionScript PROPERTY(demands_enforced_trigger);
 		EffectScript PROPERTY(demands_enforced_effect);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		RebelType(
 			std::string_view new_identifier, RebelType::icon_t icon, RebelType::area_t area, bool break_alliance_on_win,
 			RebelType::government_map_t&& desired_governments, RebelType::defection_t defection,
@@ -71,10 +74,6 @@ namespace OpenVic {
 			EffectScript&& new_siege_won_effect, ConditionScript&& new_demands_enforced_trigger,
 			EffectScript&& new_demands_enforced_effect
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		RebelType(RebelType&&) = default;
 	};
 

--- a/src/openvic-simulation/politics/Rule.cpp
+++ b/src/openvic-simulation/politics/Rule.cpp
@@ -142,7 +142,10 @@ bool RuleManager::add_rule(std::string_view identifier, Rule::rule_group_t group
 		Logger::error("Invalid rule identifier - empty!");
 		return false;
 	}
-	return rules.add_item({ identifier, group, rule_group_sizes[group]++, localisation_key });
+	return rules.emplace_item(
+		identifier,
+		identifier, group, rule_group_sizes[group]++, localisation_key
+	);
 }
 
 bool RuleManager::setup_rules(BuildingTypeManager const& building_type_manager) {

--- a/src/openvic-simulation/politics/Rule.hpp
+++ b/src/openvic-simulation/politics/Rule.hpp
@@ -9,8 +9,6 @@ namespace OpenVic {
 
 	/* The index of the Rule within its group, used to determine precedence in mutually exclusive rule groups. */
 	struct Rule : HasIdentifier, HasIndex<Rule> {
-		friend struct RuleManager;
-
 		enum class rule_group_t : uint8_t {
 			ECONOMY, CITIZENSHIP, SLAVERY, UPPER_HOUSE, VOTING
 		};
@@ -30,11 +28,10 @@ namespace OpenVic {
 		const rule_group_t PROPERTY(group);
 		memory::string PROPERTY(localisation_key);
 
+	public:
 		Rule(
 			std::string_view new_identifier, rule_group_t new_group, index_t new_index, std::string_view new_localisation_key
 		);
-
-	public:
 		Rule(Rule&&) = default;
 	};
 

--- a/src/openvic-simulation/pop/Culture.cpp
+++ b/src/openvic-simulation/pop/Culture.cpp
@@ -32,7 +32,10 @@ bool CultureManager::add_graphical_culture_type(std::string_view identifier) {
 		Logger::error("Invalid culture group identifier - empty!");
 		return false;
 	}
-	return graphical_culture_types.add_item({ identifier });
+	return graphical_culture_types.emplace_item(
+		identifier,
+		identifier
+	);
 }
 
 bool CultureManager::add_culture_group(
@@ -62,12 +65,15 @@ bool CultureManager::add_culture_group(
 		leader = default_leader;
 		Logger::warning("In culture \"", identifier, "\" - group leader is undefined, set to default of: \"", default_leader, "\".");
 	}
-	if (culture_groups.add_item({ identifier, leader, *graphical_culture_type, is_overseas, union_country })) {
-		leader_picture_counts.emplace(leader, general_admiral_picture_count_t { 0, 0 });
-		return true;
-	} else {
+	if (!culture_groups.emplace_item(
+		identifier,
+		identifier, leader, *graphical_culture_type, is_overseas, union_country
+	)) {
 		return false;
 	}
+	
+	leader_picture_counts.emplace(leader, general_admiral_picture_count_t { 0, 0 });
+	return true;
 }
 
 bool CultureManager::add_culture(
@@ -85,9 +91,10 @@ bool CultureManager::add_culture(
 
 	// TODO - check radicalism range
 
-	return cultures.add_item({
+	return cultures.emplace_item(
+		identifier,
 		identifier, colour, group, std::move(first_names), std::move(last_names), radicalism, primary_country
-	});
+	);
 }
 
 bool CultureManager::load_graphical_culture_type_file(ast::NodeCPtr root) {

--- a/src/openvic-simulation/pop/Culture.hpp
+++ b/src/openvic-simulation/pop/Culture.hpp
@@ -4,7 +4,6 @@
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
-
 	struct CultureManager;
 	struct CountryDefinition;
 	struct CountryDefinitionManager;
@@ -13,10 +12,8 @@ namespace OpenVic {
 	struct GraphicalCultureType : HasIdentifier {
 		friend struct CultureManager;
 
-	private:
-		GraphicalCultureType(std::string_view new_identifier);
-
 	public:
+		GraphicalCultureType(std::string_view new_identifier);
 		GraphicalCultureType(GraphicalCultureType&&) = default;
 	};
 
@@ -29,13 +26,12 @@ namespace OpenVic {
 		bool PROPERTY(is_overseas);
 		CountryDefinition const* PROPERTY(union_country);
 
+	public:
 		CultureGroup(
 			std::string_view new_identifier, std::string_view new_leader,
 			GraphicalCultureType const& new_unit_graphical_culture_type, bool new_is_overseas,
 			CountryDefinition const* new_union_country
 		);
-
-	public:
 		CultureGroup(CultureGroup&&) = default;
 
 		constexpr bool has_union_country() const {
@@ -44,8 +40,6 @@ namespace OpenVic {
 	};
 
 	struct Culture : HasIdentifierAndColour {
-		friend struct CultureManager;
-
 	private:
 		CultureGroup const& PROPERTY(group);
 		name_list_t PROPERTY(first_names);
@@ -53,12 +47,11 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(radicalism);
 		CountryDefinition const* PROPERTY(primary_country);
 
+	public:
 		Culture(
 			std::string_view new_identifier, colour_t new_colour, CultureGroup const& new_group, name_list_t&& new_first_names,
 			name_list_t&& new_last_names, fixed_point_t new_radicalism, CountryDefinition const* new_primary_country
 		);
-
-	public:
 		Culture(Culture&&) = default;
 
 		constexpr bool has_union_country() const {

--- a/src/openvic-simulation/pop/PopType.cpp
+++ b/src/openvic-simulation/pop/PopType.cpp
@@ -159,7 +159,10 @@ bool PopManager::add_strata(std::string_view identifier) {
 		Logger::error("Invalid strata identifier - empty!");
 		return false;
 	}
-	return stratas.add_item({ identifier, get_strata_count() });
+	return stratas.emplace_item(
+		identifier,
+		identifier, get_strata_count()
+	);
 }
 
 bool PopManager::add_pop_type(
@@ -236,7 +239,8 @@ bool PopManager::add_pop_type(
 		return false;
 	}
 
-	if (OV_unlikely(!pop_types.add_item({
+	if (OV_unlikely(!pop_types.emplace_item(
+		identifier,
 		identifier,
 		colour,
 		get_pop_type_count(),
@@ -248,7 +252,7 @@ bool PopManager::add_pop_type(
 		life_needs_income_types,
 		everyday_needs_income_types,
 		luxury_needs_income_types,
-		{},
+		PopType::rebel_units_t{},
 		max_size,
 		merge_max_size,
 		state_capital_only,
@@ -267,13 +271,13 @@ bool PopManager::add_pop_type(
 		leadership_points,
 		research_leadership_optimum,
 		state_administration_multiplier,
-		nullptr,
+		static_cast<PopType const*>(nullptr),
 		std::move(country_migration_target),
 		std::move(migration_target),
-		{},
+		PopType::poptype_weight_map_t{},
 		std::move(ideologies),
-		{}
-	}))) {
+		PopType::issue_weight_map_t{}
+	))) {
 		return false;
 	}
 

--- a/src/openvic-simulation/pop/PopType.hpp
+++ b/src/openvic-simulation/pop/PopType.hpp
@@ -26,9 +26,8 @@ namespace OpenVic {
 	private:
 		memory::vector<PopType const*> PROPERTY(pop_types);
 
-		Strata(std::string_view new_identifier, index_t new_index);
-
 	public:
+		Strata(std::string_view new_identifier, index_t new_index);
 		Strata(Strata&&) = default;
 	};
 
@@ -88,6 +87,9 @@ namespace OpenVic {
 		ideology_weight_map_t PROPERTY(ideologies); /* Scope - pop */
 		issue_weight_map_t PROPERTY(issues); /* Scope - province, THIS - country (?) */
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		PopType(
 			std::string_view new_identifier,
 			colour_t new_colour,
@@ -126,10 +128,6 @@ namespace OpenVic {
 			ideology_weight_map_t&& new_ideologies,
 			issue_weight_map_t&& new_issues
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		PopType(PopType&&) = default;
 
 		constexpr bool has_income_type(income_type_t income_type) const;

--- a/src/openvic-simulation/pop/Religion.cpp
+++ b/src/openvic-simulation/pop/Religion.cpp
@@ -23,7 +23,7 @@ bool ReligionManager::add_religion_group(std::string_view identifier) {
 		Logger::error("Invalid religion group identifier - empty!");
 		return false;
 	}
-	return religion_groups.add_item({ identifier });
+	return religion_groups.emplace_item(identifier, identifier);
 }
 
 bool ReligionManager::add_religion(
@@ -41,7 +41,10 @@ bool ReligionManager::add_religion(
 		Logger::error("Invalid religion icon for ", identifier, ": ", icon);
 		return false;
 	}
-	return religions.add_item({ identifier, colour, group, icon, pagan });
+	return religions.emplace_item(
+		identifier,
+		identifier, colour, group, icon, pagan
+	);
 }
 
 /* REQUIREMENTS:

--- a/src/openvic-simulation/pop/Religion.hpp
+++ b/src/openvic-simulation/pop/Religion.hpp
@@ -4,22 +4,13 @@
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
 
 namespace OpenVic {
-
-	struct ReligionManager;
-
 	struct ReligionGroup : HasIdentifier {
-		friend struct ReligionManager;
-
-	private:
-		ReligionGroup(std::string_view new_identifier);
-
 	public:
+		ReligionGroup(std::string_view new_identifier);
 		ReligionGroup(ReligionGroup&&) = default;
 	};
 
 	struct Religion : HasIdentifierAndColour {
-		friend struct ReligionManager;
-
 		using icon_t = uint8_t;
 
 	private:
@@ -27,12 +18,11 @@ namespace OpenVic {
 		const icon_t PROPERTY(icon);
 		const bool PROPERTY(pagan);
 
+	public:
 		Religion(
 			std::string_view new_identifier, colour_t new_colour, ReligionGroup const& new_group, icon_t new_icon,
 			bool new_pagan
 		);
-
-	public:
 		Religion(Religion&&) = default;
 	};
 

--- a/src/openvic-simulation/research/Invention.cpp
+++ b/src/openvic-simulation/research/Invention.cpp
@@ -48,10 +48,11 @@ bool InventionManager::add_invention(
 		return false;
 	}
 
-	return inventions.add_item({
+	return inventions.emplace_item(
+		identifier,
 		identifier, std::move(values), news, std::move(activated_units), std::move(activated_buildings),
 		std::move(enabled_crimes), unlock_gas_attack, unlock_gas_defence, std::move(limit), std::move(chance)
-	});
+	);
 }
 
 bool InventionManager::load_inventions_file(

--- a/src/openvic-simulation/research/Invention.hpp
+++ b/src/openvic-simulation/research/Invention.hpp
@@ -6,16 +6,18 @@
 #include "openvic-simulation/types/OrderedContainers.hpp"
 
 namespace OpenVic {
-	struct UnitType;
-	struct BuildingType;
-	struct Crime;
 
-	struct UnitTypeManager;
+	struct BuildingType;
 	struct BuildingTypeManager;
+	struct Crime;
 	struct CrimeManager;
+	struct InventionManager;
+	struct UnitType;
+	struct UnitTypeManager;
 
 	struct Invention : Modifier {
 		friend struct InventionManager;
+
 		//TODO implement limit and chance
 		using unit_set_t = ordered_set<UnitType const*>;
 		using building_set_t = ordered_set<BuildingType const*>;
@@ -31,6 +33,9 @@ namespace OpenVic {
 		ConditionScript PROPERTY(limit);
 		ConditionalWeightBase PROPERTY(chance);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Invention(
 			std::string_view new_identifier,
 			ModifierValue&& new_values,
@@ -43,10 +48,6 @@ namespace OpenVic {
 			ConditionScript&& new_limit,
 			ConditionalWeightBase&& new_chance
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Invention(Invention&&) = default;
 	};
 

--- a/src/openvic-simulation/research/Technology.cpp
+++ b/src/openvic-simulation/research/Technology.cpp
@@ -49,7 +49,10 @@ bool TechnologyManager::add_technology_folder(std::string_view identifier) {
 		return false;
 	}
 
-	return technology_folders.add_item({ identifier, get_technology_folder_count() });
+	return technology_folders.emplace_item(
+		identifier,
+		identifier, get_technology_folder_count()
+	);
 }
 
 bool TechnologyManager::add_technology_area(std::string_view identifier, TechnologyFolder const& folder) {
@@ -58,7 +61,10 @@ bool TechnologyManager::add_technology_area(std::string_view identifier, Technol
 		return false;
 	}
 
-	return technology_areas.add_item({ identifier, folder });
+	return technology_areas.emplace_item(
+		identifier,
+		identifier, folder
+	);
 }
 
 bool TechnologyManager::add_technology(
@@ -88,7 +94,8 @@ bool TechnologyManager::add_technology(
 		return false;
 	}
 
-	if (technologies.add_item({
+	if (!technologies.emplace_item(
+		identifier,
 		identifier,
 		get_technology_count(),
 		*area,
@@ -101,12 +108,12 @@ bool TechnologyManager::add_technology(
 		std::move(activated_buildings),
 		std::move(values),
 		std::move(ai_chance)
-	})) {
-		area->tech_count++;
-		return true;
-	} else {
+	)) {
 		return false;
 	}
+
+	area->tech_count++;
+	return true;
 }
 
 bool TechnologyManager::add_technology_school(std::string_view identifier, ModifierValue&& values) {
@@ -115,7 +122,10 @@ bool TechnologyManager::add_technology_school(std::string_view identifier, Modif
 		return false;
 	}
 
-	return technology_schools.add_item({ identifier, std::move(values) });
+	return technology_schools.emplace_item(
+		identifier,
+		identifier, std::move(values)
+	);
 }
 
 bool TechnologyManager::load_technology_file_folders_and_areas(ast::NodeCPtr root) {

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -13,6 +13,7 @@
 
 namespace OpenVic {
 	struct TechnologyArea;
+	struct TechnologyManager;
 
 	struct TechnologyFolder : HasIdentifier, HasIndex<TechnologyFolder> {
 		friend struct TechnologyManager;
@@ -20,9 +21,8 @@ namespace OpenVic {
 	private:
 		memory::vector<TechnologyArea const*> PROPERTY(technology_areas);
 
-		TechnologyFolder(std::string_view new_identifier, index_t new_index);
-
 	public:
+		TechnologyFolder(std::string_view new_identifier, index_t new_index);
 		TechnologyFolder(TechnologyFolder&&) = default;
 	};
 
@@ -36,9 +36,8 @@ namespace OpenVic {
 		memory::vector<Technology const*> PROPERTY(technologies);
 		size_t PROPERTY(tech_count, 0);
 
-		TechnologyArea(std::string_view new_identifier, TechnologyFolder const& new_folder);
-
 	public:
+		TechnologyArea(std::string_view new_identifier, TechnologyFolder const& new_folder);
 		TechnologyArea(TechnologyArea&&) = default;
 	};
 
@@ -60,6 +59,9 @@ namespace OpenVic {
 		building_set_t PROPERTY(activated_buildings);
 		ConditionalWeightFactorMul PROPERTY(ai_chance);
 
+		bool parse_scripts(DefinitionManager const& definition_manager);
+
+	public:
 		Technology(
 			std::string_view new_identifier,
 			index_t new_index,
@@ -74,17 +76,11 @@ namespace OpenVic {
 			ModifierValue&& new_values,
 			ConditionalWeightFactorMul&& new_ai_chance
 		);
-
-		bool parse_scripts(DefinitionManager const& definition_manager);
-
-	public:
 		Technology(Technology&&) = default;
 	};
 
 	struct TechnologySchool : Modifier {
-		friend struct TechnologyManager;
-
-	private:
+	public:
 		TechnologySchool(std::string_view new_identifier, ModifierValue&& new_values);
 	};
 

--- a/src/openvic-simulation/scripts/Condition.cpp
+++ b/src/openvic-simulation/scripts/Condition.cpp
@@ -56,14 +56,10 @@ bool ConditionManager::add_condition(
 		}
 	}
 
-	return conditions.add_item({
+	return conditions.emplace_item(
 		identifier,
-		value_type,
-		scope,
-		scope_change,
-		key_identifier_type,
-		value_identifier_type
-	});
+		identifier, value_type,	scope, scope_change, key_identifier_type, value_identifier_type
+	);
 }
 
 bool ConditionManager::setup_conditions(DefinitionManager const& definition_manager) {

--- a/src/openvic-simulation/scripts/Condition.hpp
+++ b/src/openvic-simulation/scripts/Condition.hpp
@@ -205,13 +205,12 @@ namespace OpenVic {
 		const identifier_type_t PROPERTY(key_identifier_type);
 		const identifier_type_t PROPERTY(value_identifier_type);
 
+	public:
 		Condition(
 			std::string_view new_identifier, value_type_t new_value_type, scope_type_t new_scope,
 			scope_type_t new_scope_change, identifier_type_t new_key_identifier_type,
 			identifier_type_t new_value_identifier_type
 		);
-
-	public:
 		Condition(Condition&&) = default;
 	};
 


### PR DESCRIPTION
Refactor IdentifierRegistry to construct items via emplace instead of constructing and then moving.
This saves moving and if the IdentifierRegistry reserves enough space beforehand, will ensure instances are never moved.
This gives us pointer stability inside the constructor already.