### PR TITLE
Fix default constructors

### DIFF
--- a/src/openvic-simulation/dataloader/Dataloader.hpp
+++ b/src/openvic-simulation/dataloader/Dataloader.hpp
@@ -74,7 +74,7 @@ namespace OpenVic {
 		void free_cache();
 
 	public:
-		Dataloader() = default;
+		constexpr Dataloader() {};
 
 		/// @brief Searches for the Victoria 2 install directory
 		///

--- a/src/openvic-simulation/diplomacy/CountryRelation.hpp
+++ b/src/openvic-simulation/diplomacy/CountryRelation.hpp
@@ -104,7 +104,7 @@ namespace OpenVic {
 			uint16_t value;
 
 		public:
-			constexpr influence_value_type() = default;
+			constexpr influence_value_type() {};
 			constexpr influence_value_type(uint16_t value) : value(std::min(value, MAX_VALUE)) {}
 
 #define BIN_OPERATOR(OP) \

--- a/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
+++ b/src/openvic-simulation/diplomacy/DiplomaticAction.hpp
@@ -127,7 +127,7 @@ namespace OpenVic {
 		IdentifierRegistry<DiplomaticActionTypeStorage> IDENTIFIER_REGISTRY(diplomatic_action_type);
 
 	public:
-		DiplomaticActionManager() = default;
+		constexpr DiplomaticActionManager() {};
 
 		bool add_diplomatic_action(std::string_view identifier, DiplomaticActionType::Initializer&& initializer);
 		bool add_cancelable_diplomatic_action(

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -36,7 +36,7 @@ namespace OpenVic {
 			naval_capacity_t naval_capacity = 0;
 			memory::vector<fixed_point_t> colonial_points;
 
-			building_type_args_t() = default;
+			building_type_args_t() {};
 			building_type_args_t(building_type_args_t&&) = default;
 		};
 

--- a/src/openvic-simulation/economy/production/ProductionType.hpp
+++ b/src/openvic-simulation/economy/production/ProductionType.hpp
@@ -36,7 +36,7 @@ namespace OpenVic {
 		);
 
 	public:
-		Job() = default;
+		constexpr Job() {};
 	};
 
 	struct ProductionType : HasIdentifier {

--- a/src/openvic-simulation/history/CountryHistory.hpp
+++ b/src/openvic-simulation/history/CountryHistory.hpp
@@ -100,7 +100,7 @@ namespace OpenVic {
 		bool locked = false;
 
 	public:
-		CountryHistoryManager() = default;
+		CountryHistoryManager() {};
 
 		void reserve_more_country_histories(size_t size);
 		void lock_country_histories();

--- a/src/openvic-simulation/history/HistoryMap.hpp
+++ b/src/openvic-simulation/history/HistoryMap.hpp
@@ -44,7 +44,7 @@ namespace OpenVic {
 		}
 
 	protected:
-		HistoryMap() = default;
+		constexpr HistoryMap() {};
 
 		virtual memory::unique_ptr<entry_type> _make_entry(Date date) const = 0;
 

--- a/src/openvic-simulation/history/ProvinceHistory.hpp
+++ b/src/openvic-simulation/history/ProvinceHistory.hpp
@@ -79,7 +79,7 @@ namespace OpenVic {
 		ProvinceHistoryMap* _get_or_make_province_history(ProvinceDefinition const& province);
 
 	public:
-		ProvinceHistoryManager() = default;
+		ProvinceHistoryManager() {};
 
 		void reserve_more_province_histories(size_t size);
 		void lock_province_histories(MapDefinition const& map_definition, bool detailed_errors);

--- a/src/openvic-simulation/interface/GFXObject.hpp
+++ b/src/openvic-simulation/interface/GFXObject.hpp
@@ -11,7 +11,7 @@ namespace OpenVic::GFX {
 
 	class Object : public Named<> {
 	protected:
-		Object() = default;
+		constexpr Object() {};
 
 	public:
 		Object(Object&&) = default;

--- a/src/openvic-simulation/interface/GFXSprite.hpp
+++ b/src/openvic-simulation/interface/GFXSprite.hpp
@@ -28,7 +28,7 @@ namespace OpenVic::GFX {
 
 	class Sprite : public Named<> {
 	protected:
-		Sprite() = default;
+		constexpr Sprite() {};
 
 	public:
 		Sprite(Sprite&&) = default;

--- a/src/openvic-simulation/interface/GUI.hpp
+++ b/src/openvic-simulation/interface/GUI.hpp
@@ -64,7 +64,7 @@ namespace OpenVic::GUI {
 		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
-		Scene() = default;
+		constexpr Scene() {};
 		Scene(Scene&&) = default;
 		virtual ~Scene() = default;
 
@@ -153,7 +153,7 @@ namespace OpenVic::GUI {
 		bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, UIManager const& ui_manager) override;
 
 	public:
-		Checkbox() = default;
+		Checkbox() {};
 		Checkbox(Checkbox&&) = default;
 		virtual ~Checkbox() = default;
 

--- a/src/openvic-simulation/interface/LoadBase.hpp
+++ b/src/openvic-simulation/interface/LoadBase.hpp
@@ -8,7 +8,7 @@ namespace OpenVic {
 	template<typename... Context>
 	class LoadBase {
 	protected:
-		LoadBase() = default;
+		constexpr LoadBase() {};
 
 		virtual bool _fill_key_map(NodeTools::case_insensitive_key_map_t&, Context...) = 0;
 
@@ -55,7 +55,7 @@ namespace OpenVic {
 		memory::string PROPERTY(name);
 
 	protected:
-		Named() = default;
+		constexpr Named() {};
 
 		virtual bool _fill_key_map(NodeTools::case_insensitive_key_map_t& key_map, Context...) override {
 			using namespace OpenVic::NodeTools;

--- a/src/openvic-simulation/map/Mapmode.hpp
+++ b/src/openvic-simulation/map/Mapmode.hpp
@@ -56,7 +56,7 @@ namespace OpenVic {
 		IdentifierRegistry<Mapmode> IDENTIFIER_REGISTRY(mapmode);
 
 	public:
-		MapmodeManager() = default;
+		constexpr MapmodeManager() {};
 
 		bool add_mapmode(
 			std::string_view identifier,

--- a/src/openvic-simulation/military/UnitType.hpp
+++ b/src/openvic-simulation/military/UnitType.hpp
@@ -45,7 +45,7 @@ namespace OpenVic {
 			fixed_point_map_t<GoodDefinition const*> build_cost, supply_cost;
 			terrain_modifier_values_t terrain_modifier_values;
 
-			unit_type_args_t() = default;
+			unit_type_args_t() {};
 			unit_type_args_t(unit_type_args_t&&) = default;
 		};
 
@@ -97,7 +97,7 @@ namespace OpenVic {
 			fixed_point_t reconnaissance = 0, attack = 0, defence = 0, discipline = 0, support = 0, maneuver = 0,
 				siege = 0;
 
-			regiment_type_args_t() = default;
+			constexpr regiment_type_args_t() {};
 			regiment_type_args_t(regiment_type_args_t&&) = default;
 		};
 
@@ -132,7 +132,7 @@ namespace OpenVic {
 			fixed_point_t colonial_points = 0, supply_consumption_score = 0, hull = 0, gun_power = 0, fire_range = 0,
 				evasion = 0, torpedo_attack = 0;
 
-			ship_type_args_t() = default;
+			constexpr ship_type_args_t() {};
 			ship_type_args_t(ship_type_args_t&&) = default;
 		};
 

--- a/src/openvic-simulation/modifier/ModifierEffectCache.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.hpp
@@ -217,7 +217,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(max_level, nullptr);
 
 		public:
-			building_type_effects_t() = default;
+			constexpr building_type_effects_t() {};
 		};
 
 	private:
@@ -241,7 +241,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(rgo_size, nullptr);
 
 		public:
-			good_effects_t() = default;
+			constexpr good_effects_t() {};
 		};
 
 	private:
@@ -261,7 +261,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(supply_consumption, nullptr);
 
 		protected:
-			unit_type_effects_t() = default;
+			constexpr unit_type_effects_t() {};
 		};
 
 		struct regiment_type_effects_t : unit_type_effects_t {
@@ -275,7 +275,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(siege, nullptr);
 
 		public:
-			regiment_type_effects_t() = default;
+			constexpr regiment_type_effects_t() {};
 		};
 
 		struct ship_type_effects_t : unit_type_effects_t {
@@ -291,7 +291,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(torpedo_attack, nullptr);
 
 		public:
-			ship_type_effects_t() = default;
+			constexpr ship_type_effects_t() {};
 		};
 
 	private:
@@ -312,7 +312,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(movement, nullptr);
 
 		public:
-			unit_terrain_effects_t() = default;
+			constexpr unit_terrain_effects_t() {};
 		};
 
 	private:
@@ -335,7 +335,7 @@ namespace OpenVic {
 			ModifierEffect const* PROPERTY(luxury_needs, nullptr);
 
 		public:
-			strata_effects_t() = default;
+			constexpr strata_effects_t() {};
 		};
 
 	private:

--- a/src/openvic-simulation/modifier/ModifierSum.hpp
+++ b/src/openvic-simulation/modifier/ModifierSum.hpp
@@ -99,7 +99,7 @@ namespace OpenVic {
 		ModifierValue PROPERTY(value_sum);
 
 	public:
-		ModifierSum() = default;
+		ModifierSum() {};
 		ModifierSum(ModifierSum const&) = default;
 		ModifierSum(ModifierSum&&) = default;
 		ModifierSum& operator=(ModifierSum const&) = default;

--- a/src/openvic-simulation/modifier/ModifierValue.cpp
+++ b/src/openvic-simulation/modifier/ModifierValue.cpp
@@ -4,14 +4,6 @@
 
 using namespace OpenVic;
 
-ModifierValue::ModifierValue() = default;
-ModifierValue::ModifierValue(effect_map_t&& new_values) : values { std::move(new_values) } {}
-ModifierValue::ModifierValue(ModifierValue const&) = default;
-ModifierValue::ModifierValue(ModifierValue&&) = default;
-
-ModifierValue& ModifierValue::operator=(ModifierValue const&) = default;
-ModifierValue& ModifierValue::operator=(ModifierValue&&) = default;
-
 void ModifierValue::trim() {
 	erase_if(values, [](effect_map_t::value_type const& value) -> bool {
 		return value.second == fixed_point_t::_0;

--- a/src/openvic-simulation/modifier/ModifierValue.hpp
+++ b/src/openvic-simulation/modifier/ModifierValue.hpp
@@ -13,13 +13,13 @@ namespace OpenVic {
 		effect_map_t PROPERTY(values);
 
 	public:
-		ModifierValue();
-		ModifierValue(effect_map_t&& new_values);
-		ModifierValue(ModifierValue const&);
-		ModifierValue(ModifierValue&&);
+		ModifierValue() {};
+		ModifierValue(effect_map_t&& new_values) : values { std::move(new_values) } {};
+		ModifierValue(ModifierValue const&) = default;
+		ModifierValue(ModifierValue&&) = default;
 
-		ModifierValue& operator=(ModifierValue const&);
-		ModifierValue& operator=(ModifierValue&&);
+		ModifierValue& operator=(ModifierValue const&) = default;
+		ModifierValue& operator=(ModifierValue&&) = default;
 
 		/* Removes effect entries with a value of zero. */
 		void trim();

--- a/src/openvic-simulation/pathfinding/PathingBase.hpp
+++ b/src/openvic-simulation/pathfinding/PathingBase.hpp
@@ -28,7 +28,7 @@ namespace OpenVic {
 		using search_iterator = search_map_type::iterator;
 		using search_const_iterator = search_map_type::const_iterator;
 
-		PathingNodeBase() = default;
+		constexpr PathingNodeBase() {};
 		PathingNodeBase(PointMap::points_value_type const* p) {
 			point = p;
 		}

--- a/src/openvic-simulation/pathfinding/PointMap.hpp
+++ b/src/openvic-simulation/pathfinding/PointMap.hpp
@@ -46,7 +46,7 @@ namespace OpenVic {
 				return key == s.key;
 			}
 
-			inline constexpr Segment() = default;
+			inline constexpr Segment() {};
 			inline constexpr Segment(points_key_type from, points_key_type to) {
 				if (from < to) {
 					key.first = from;

--- a/src/openvic-simulation/politics/Rule.hpp
+++ b/src/openvic-simulation/politics/Rule.hpp
@@ -47,7 +47,7 @@ namespace OpenVic {
 		rule_group_map_t PROPERTY(rule_groups);
 
 	public:
-		RuleSet() = default;
+		RuleSet() {};
 		RuleSet(rule_group_map_t&& new_rule_groups);
 		RuleSet(RuleSet const&) = default;
 		RuleSet(RuleSet&&) = default;

--- a/src/openvic-simulation/scripts/Script.hpp
+++ b/src/openvic-simulation/scripts/Script.hpp
@@ -15,7 +15,7 @@ namespace OpenVic {
 		virtual bool _parse_script(std::span<const ast::NodeCPtr> nodes, _Context... context) = 0;
 
 	public:
-		Script() = default;
+		constexpr Script() {};
 		Script(Script&&) = default;
 
 		constexpr bool has_defines_node() const {

--- a/src/openvic-simulation/types/BasicIterator.hpp
+++ b/src/openvic-simulation/types/BasicIterator.hpp
@@ -15,7 +15,7 @@ namespace OpenVic {
 		using iterator_category = typename std::iterator_traits<iterator_type>::iterator_category;
 		using iterator_concept = std::contiguous_iterator_tag;
 
-		OV_ALWAYS_INLINE constexpr basic_iterator() = default;
+		OV_ALWAYS_INLINE constexpr basic_iterator() {};
 		OV_ALWAYS_INLINE constexpr basic_iterator(Pointer const& ptr) : _current { ptr } {}
 
 		template<std::convertible_to<Pointer> It>

--- a/src/openvic-simulation/types/Colour.hpp
+++ b/src/openvic-simulation/types/Colour.hpp
@@ -151,7 +151,7 @@ namespace OpenVic {
 		static constexpr auto max_value = colour_traits::component;
 
 		struct empty_value {
-			constexpr empty_value() = default;
+			constexpr empty_value() {};
 			constexpr empty_value(value_type) {}
 			constexpr operator value_type() const {
 				return max_value;
@@ -480,7 +480,7 @@ namespace OpenVic {
 			std::array<char, array_length> array {};
 			uint8_t string_size = 0;
 
-			constexpr stack_string() = default;
+			constexpr stack_string() {};
 
 			friend inline constexpr stack_string basic_colour_t::to_hex_array(bool alpha) const;
 			friend inline constexpr stack_string basic_colour_t::to_argb_hex_array() const;

--- a/src/openvic-simulation/types/CowPtr.hpp
+++ b/src/openvic-simulation/types/CowPtr.hpp
@@ -176,7 +176,7 @@ namespace OpenVic {
 
 	private:
 		struct payload {
-			payload() = default;
+			constexpr payload() {};
 
 			template<typename... Args>
 			explicit payload(Args&&... args) : value(std::forward<Args>(args)...) {}

--- a/src/openvic-simulation/types/Date.hpp
+++ b/src/openvic-simulation/types/Date.hpp
@@ -332,7 +332,7 @@ namespace OpenVic {
 			std::array<char, array_length> array {};
 			uint8_t string_size = 0;
 
-			constexpr stack_string() = default;
+			constexpr stack_string() {};
 
 			friend inline constexpr stack_string Date::to_array(bool pad_year, bool pad_month, bool pad_day) const;
 

--- a/src/openvic-simulation/types/NullMutex.hpp
+++ b/src/openvic-simulation/types/NullMutex.hpp
@@ -2,7 +2,7 @@
 
 namespace OpenVic {
 	struct null_mutex {
-		null_mutex() = default;
+		constexpr null_mutex() {};
 		~null_mutex() = default;
 		null_mutex(null_mutex const&) = delete;
 		null_mutex& operator=(null_mutex const&) = delete;

--- a/src/openvic-simulation/types/Signal.hpp
+++ b/src/openvic-simulation/types/Signal.hpp
@@ -393,7 +393,7 @@ namespace OpenVic::_detail::signal {
 	};
 
 	struct connection_blocker {
-		connection_blocker() = default;
+		constexpr connection_blocker() {};
 		~connection_blocker() {
 			release();
 		}
@@ -427,7 +427,7 @@ namespace OpenVic::_detail::signal {
 	};
 
 	struct connection {
-		connection() = default;
+		constexpr connection() {};
 		virtual ~connection() = default;
 
 		connection(connection const&) = default;
@@ -479,7 +479,7 @@ namespace OpenVic::_detail::signal {
 	};
 
 	struct scoped_connection final : public connection {
-		scoped_connection() = default;
+		constexpr scoped_connection() {};
 		~scoped_connection() override {
 			disconnect();
 		}

--- a/src/openvic-simulation/types/SliderValue.hpp
+++ b/src/openvic-simulation/types/SliderValue.hpp
@@ -14,7 +14,7 @@ namespace OpenVic {
 		fixed_point_t PROPERTY(value);
 
 	public:
-		constexpr SliderValue() = default;
+		constexpr SliderValue() {};
 
 		constexpr void set_value(fixed_point_t new_value) {
 			if (min <= max) {

--- a/src/openvic-simulation/types/SpinMutex.hpp
+++ b/src/openvic-simulation/types/SpinMutex.hpp
@@ -5,7 +5,7 @@
 
 namespace OpenVic {
 	struct spin_mutex {
-		spin_mutex() = default;
+		constexpr spin_mutex() {};
 		~spin_mutex() = default;
 		spin_mutex(spin_mutex const&) = delete;
 		spin_mutex& operator=(spin_mutex const&) = delete;

--- a/src/openvic-simulation/types/ValueHistory.hpp
+++ b/src/openvic-simulation/types/ValueHistory.hpp
@@ -36,7 +36,7 @@ namespace OpenVic {
 		using base_type::front;
 		using base_type::back;
 
-		ValueHistory() = default;
+		constexpr ValueHistory() {};
 		ValueHistory(size_t history_size, T const& fill_value = {}) : base_type(history_size, fill_value) {}
 		ValueHistory(ValueHistory&&) = default;
 

--- a/src/openvic-simulation/types/fixed_point/Atomic.hpp
+++ b/src/openvic-simulation/types/fixed_point/Atomic.hpp
@@ -212,7 +212,7 @@ namespace OpenVic {
 		atomic_fixed_point_t value;
 
 	public:
-		OV_ALWAYS_INLINE moveable_atomic_fixed_point_t() = default;
+		OV_ALWAYS_INLINE constexpr moveable_atomic_fixed_point_t() {};
 		OV_ALWAYS_INLINE moveable_atomic_fixed_point_t(const atomic_fixed_point_t new_value) : value { new_value.load() } {}
 
 		OV_ALWAYS_INLINE moveable_atomic_fixed_point_t(moveable_atomic_fixed_point_t&& other) {

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -318,7 +318,7 @@ namespace OpenVic {
 			std::array<char, array_length> array {};
 			uint8_t string_size = 0;
 
-			constexpr stack_string() = default;
+			constexpr stack_string() {};
 
 			friend inline constexpr stack_string fixed_point_t::to_array(size_t decimal_places) const;
 

--- a/src/openvic-simulation/utility/BMP.hpp
+++ b/src/openvic-simulation/utility/BMP.hpp
@@ -45,7 +45,7 @@ namespace OpenVic {
 	public:
 		static constexpr uint32_t PALETTE_COLOUR_SIZE = sizeof(palette_colour_t);
 
-		BMP() = default;
+		BMP() {};
 		~BMP();
 
 		bool open(fs::path const& filepath);


### PR DESCRIPTION
```cpp
struct DemoType {
    int* value = nullptr;
};
static_assert(std::is_default_constructible_v<DemoType >);
```
The above fails in Clang and GCC. They require explicit `DemoType() {};`