### PR TITLE
Explicit create empty for IndexedFlatMap

### DIFF
--- a/src/openvic-simulation/economy/production/ProductionType.cpp
+++ b/src/openvic-simulation/economy/production/ProductionType.cpp
@@ -76,8 +76,6 @@ bool ProductionType::parse_scripts(DefinitionManager const& definition_manager) 
 	return ret;
 }
 
-ProductionTypeManager::ProductionTypeManager() :
-	rgo_owner_sprite { 0 } {}
 
 ProductionType const* ProductionTypeManager::get_good_to_rgo_production_type(GoodDefinition const& key) const {
 	return good_to_rgo_production_type.at(key);

--- a/src/openvic-simulation/economy/production/ProductionType.hpp
+++ b/src/openvic-simulation/economy/production/ProductionType.hpp
@@ -110,7 +110,9 @@ namespace OpenVic {
 		);
 
 	public:
-		ProductionTypeManager();
+		constexpr ProductionTypeManager()
+			: rgo_owner_sprite { 0 },
+			good_to_rgo_production_type { decltype(good_to_rgo_production_type)::create_empty() } {}
 
 		bool add_production_type(
 			GameRulesManager const& game_rules_manager,

--- a/src/openvic-simulation/modifier/ModifierEffectCache.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.hpp
@@ -344,7 +344,16 @@ namespace OpenVic {
 
 		/* Technology Effects */
 		IndexedFlatMap_PROPERTY(TechnologyFolder, ModifierEffect const*, research_bonus_effects);
-		ModifierEffectCache() {}
+		constexpr ModifierEffectCache() :
+			building_type_effects { decltype(building_type_effects)::create_empty() },
+			good_effects { decltype(good_effects)::create_empty() },
+			regiment_type_effects { decltype(regiment_type_effects)::create_empty() },
+			ship_type_effects { decltype(ship_type_effects)::create_empty() },
+			unit_terrain_effects { decltype(unit_terrain_effects)::create_empty() },
+			rebel_org_gain_effects { decltype(rebel_org_gain_effects)::create_empty() },
+			strata_effects { decltype(strata_effects)::create_empty() },
+			research_bonus_effects { decltype(research_bonus_effects)::create_empty() }
+			{}
 
 	public:
 		ModifierEffectCache(ModifierEffectCache&&) = default;

--- a/src/openvic-simulation/pop/PopManager.cpp
+++ b/src/openvic-simulation/pop/PopManager.cpp
@@ -174,7 +174,7 @@ bool PopManager::add_pop_type(
 		static_cast<PopType const*>(nullptr),
 		std::move(country_migration_target),
 		std::move(migration_target),
-		PopType::poptype_weight_map_t{},
+		PopType::poptype_weight_map_t { PopType::poptype_weight_map_t::create_empty() },
 		std::move(ideologies),
 		PopType::issue_weight_map_t{}
 	))) {

--- a/src/openvic-simulation/types/IndexedFlatMap.hpp
+++ b/src/openvic-simulation/types/IndexedFlatMap.hpp
@@ -166,7 +166,13 @@ namespace OpenVic {
 			return true;
 		}
 
+		constexpr IndexedFlatMap() : values(), keys(), min_index(0), max_index(0) {}
+
 	public:
+		static constexpr IndexedFlatMap create_empty() {
+			return {};
+		}
+
 		/**
 		* @brief Constructs an IndexedFlatMap based on a provided span of ordered and continuous keys
 		* and a key-based generator.
@@ -220,12 +226,6 @@ namespace OpenVic {
 			// Resize and default-construct elements
 			values.resize(expected_capacity);
 		}
-
-		/**
-		* @brief Default constructor, creates an empty map.
-		* Useful for returning an invalid state on error in other operations.
-		*/
-		IndexedFlatMap() : values(), keys(), min_index(0), max_index(0) {}
 
 		/**
 		* @brief Sets the value associated with a key using copy assignment.


### PR DESCRIPTION
An empty IndexedFlatMap isn't useful at all. It is likely a mistake.
There are some cases where an IndexedFlatMap field is first initialised empty and later replaced by a filled instance.
To prevent accidentally initialising an empty IndexedFlatMap, the default constructor is made private and an explicit create_empty() method was added.