### PR TITLE
Use IWYU pragma: keep

### DIFF
--- a/src/openvic-simulation/country/CountryParty.hpp
+++ b/src/openvic-simulation/country/CountryParty.hpp
@@ -2,7 +2,6 @@
 
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
-#include "openvic-simulation/types/IndexedFlatMap.hpp" //used by macro
 #include "openvic-simulation/types/IndexedFlatMapMacro.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -5,7 +5,6 @@
 #include "openvic-simulation/pop/PopsAggregate.hpp"
 #include "openvic-simulation/types/ColonyStatus.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
-#include "openvic-simulation/types/IndexedFlatMap.hpp" //for macro
 #include "openvic-simulation/types/IndexedFlatMapMacro.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 #include "openvic-simulation/utility/ForwardableSpan.hpp"

--- a/src/openvic-simulation/military/UnitBranchedGetterMacro.hpp
+++ b/src/openvic-simulation/military/UnitBranchedGetterMacro.hpp
@@ -1,4 +1,4 @@
-// depends on #include "openvic-simulation/types/UnitBranchType.hpp"
+#include "openvic-simulation/types/UnitBranchType.hpp" // IWYU pragma: keep for unit_branch_t
 
 #define _UNIT_BRANCHED_GETTER(name, land, naval, const) \
 	template<unit_branch_t Branch> \

--- a/src/openvic-simulation/modifier/ModifierEffectCache.hpp
+++ b/src/openvic-simulation/modifier/ModifierEffectCache.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "openvic-simulation/types/IndexedFlatMap.hpp" //for macro
 #include "openvic-simulation/types/IndexedFlatMapMacro.hpp"
 #include "openvic-simulation/types/UnitBranchType.hpp"
 #include "openvic-simulation/utility/Getters.hpp"

--- a/src/openvic-simulation/politics/PoliticsInstanceManager.hpp
+++ b/src/openvic-simulation/politics/PoliticsInstanceManager.hpp
@@ -3,7 +3,6 @@
 #include <optional>
 
 #include "openvic-simulation/types/Date.hpp"
-#include "openvic-simulation/types/IndexedFlatMap.hpp" //for macro
 #include "openvic-simulation/types/IndexedFlatMapMacro.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -1,4 +1,4 @@
-#include <concepts> //used in lambda
+#include <concepts> // IWYU pragma: keep for lambda
 #include <cstddef>
 #include <cstdint>
 #include <ranges>
@@ -10,7 +10,7 @@
 #undef KEEP_DO_FOR_ALL_TYPES_OF_EXPENSES
 
 #include "openvic-simulation/country/CountryParty.hpp"
-#include "openvic-simulation/country/CountryDefinition.hpp" //for ->get_parties()
+#include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/defines/Define.hpp"
 #include "openvic-simulation/economy/GoodDefinition.hpp"
@@ -32,9 +32,9 @@
 #include "openvic-simulation/pop/PopValuesFromProvince.hpp"
 #include "openvic-simulation/pop/Religion.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
 #include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/OrderedContainers.hpp"
-#include "openvic-simulation/types/OrderedContainersMath.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
 #include "openvic-simulation/utility/Utility.hpp"
@@ -180,7 +180,12 @@ void Pop::update_location_based_attributes() {
 	if (owner == nullptr) {
 		return;
 	}
-	auto view = owner->get_country_definition()->get_parties() | std::views::transform(
+	CountryDefinition const* country_definition = owner ->get_country_definition();
+	if (country_definition == nullptr) {
+		return;
+	}
+
+	auto view = country_definition->get_parties() | std::views::transform(
 		[](CountryParty const& key) {
 			return std::make_pair(&key, fixed_point_t::_0);
 		}

--- a/src/openvic-simulation/pop/PopValuesFromProvince.cpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.cpp
@@ -2,7 +2,7 @@
 
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/defines/PopsDefines.hpp"
-#include "openvic-simulation/economy/GoodDefinition.hpp" // for constructor requirement
+#include "openvic-simulation/economy/GoodDefinition.hpp" // IWYU pragma: keep for constructor requirement
 #include "openvic-simulation/modifier/ModifierEffectCache.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/pop/PopType.hpp"

--- a/src/openvic-simulation/types/Colour.cpp
+++ b/src/openvic-simulation/types/Colour.cpp
@@ -1,4 +1,4 @@
-#include "openvic-simulation/types/Colour.hpp" // IWYU pragma: keep
+#include "Colour.hpp"
 
 namespace OpenVic {
 	template struct basic_colour_t<std::uint8_t, std::uint32_t>;

--- a/src/openvic-simulation/types/IndexedFlatMapMacro.hpp
+++ b/src/openvic-simulation/types/IndexedFlatMapMacro.hpp
@@ -1,5 +1,5 @@
-// depends on #include "openvic-simulation/types/IndexedFlatMap.hpp"
-// depends on #include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp" // IWYU pragma: keep for field type
+#include "openvic-simulation/utility/Getters.hpp" // IWYU pragma: keep for _get_property
 
 #define IndexedFlatMap_PROPERTY(KEYTYPE, VALUETYPE, NAME) IndexedFlatMap_PROPERTY_ACCESS(KEYTYPE, VALUETYPE, NAME, private)
 #define IndexedFlatMap_PROPERTY_ACCESS(KEYTYPE, VALUETYPE, NAME, ACCESS) \

--- a/src/openvic-simulation/types/Vector.cpp
+++ b/src/openvic-simulation/types/Vector.cpp
@@ -1,4 +1,4 @@
-#include "openvic-simulation/types/Vector.hpp" // IWYU pragma: keep
+#include "Vector.hpp" // IWYU pragma: keep
 
 namespace OpenVic {
 #define MAKE_VEC_ALIAS(prefix, type, size) template struct vec##size##_t<type>;

--- a/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "openvic-simulation/types/OrderedContainers.hpp"
+#include "openvic-simulation/types/OrderedContainersMath.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 
 namespace OpenVic {

--- a/src/openvic-simulation/utility/ErrorMacros.hpp
+++ b/src/openvic-simulation/utility/ErrorMacros.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "openvic-simulation/utility/Logger.hpp" // IWYU pragma: keep
+#include "openvic-simulation/utility/Logger.hpp" // IWYU pragma: keep for macros
 #include "openvic-simulation/utility/Utility.hpp"
 
 /**


### PR DESCRIPTION
Replace `// depends on ...` with actual imports inside macro headers.
Use `// IWYU pragma: keep` to tell the IDE to keep imports.
Added comments explaining why `// IWYU pragma: keep` is used.
Shortened imports of .hpp file in related .cpp file to `Vector.hpp` instead of `openvic-simulation/types/Vector.hpp`
Split up `auto view = owner->get_country_definition()->get_parties()` to check for null and explicitly use CountryDefintion, so the IDE will keep the header import.