### PR TITLE
Automatic dependency tracking

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -179,13 +179,13 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 	if (game_manager.get_instance_manager()) {
 		const auto print_ranking_list = [](std::string_view title, OpenVic::utility::forwardable_span<CountryInstance* const> countries) -> void {
 			memory::string text;
-			for (CountryInstance const* country : countries) {
+			for (CountryInstance* country : countries) {
 				text += StringUtils::append_string_views(
 					"\n    ", country->get_identifier(),
-					" - Total #", std::to_string(country->get_total_rank()), " (", country->get_total_score().to_string(1),
-					"), Prestige #", std::to_string(country->get_prestige_rank()), " (", country->get_prestige().to_string(1),
-					"), Industry #", std::to_string(country->get_industrial_rank()), " (", country->get_industrial_power().to_string(1),
-					"), Military #", std::to_string(country->get_military_rank()), " (", country->get_military_power().to_string(1), ")"
+					" - Total #", std::to_string(country->get_total_rank()), " (", country->total_score.get_untracked().to_string(1),
+					"), Prestige #", std::to_string(country->get_prestige_rank()), " (", country->get_prestige_untracked().to_string(1),
+					"), Industry #", std::to_string(country->get_industrial_rank()), " (", country->get_industrial_power_untracked().to_string(1),
+					"), Military #", std::to_string(country->get_military_rank()), " (", country->military_power.get_untracked().to_string(1), ")"
 				);
 			}
 			Logger::info(title, ":", text);

--- a/src/openvic-simulation/country/SharedCountryValues.hpp
+++ b/src/openvic-simulation/country/SharedCountryValues.hpp
@@ -4,49 +4,59 @@
 #include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/IndexedFlatMapMacro.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
-#include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/reactive/MutableState.hpp"
 
 namespace OpenVic {
 	struct CountryDefines;
+	struct CountryInstanceManager;
 	struct GoodInstanceManager;
 	struct ModifierEffectCache;
 	struct PopsDefines;
 	struct PopType;
+	struct SharedCountryValues;
 
 	struct SharedPopTypeValues {
+		friend SharedCountryValues;
 	private:
+		PopType const& pop_type;
 		#define NEED_COST_FIELD(need_category) \
 			fixed_point_t base_##need_category##_need_costs;
 		DO_FOR_ALL_NEED_CATEGORIES(NEED_COST_FIELD)
 		#undef NEED_COST_FIELD
 
-		fixed_point_t PROPERTY(administration_salary_base);
-		fixed_point_t PROPERTY(education_salary_base);
-		fixed_point_t PROPERTY(military_salary_base);
+		STATE_PROPERTY(fixed_point_t, administration_salary_base);
+		STATE_PROPERTY(fixed_point_t, education_salary_base);
+		STATE_PROPERTY(fixed_point_t, military_salary_base);
+		STATE_PROPERTY(fixed_point_t, social_income_variant_base);
 
+		void update_costs(PopsDefines const& pop_defines, GoodInstanceManager const& good_instance_manager);
 	public:
-		void update_costs(PopType const& pop_type, PopsDefines const& pop_defines, GoodInstanceManager const& good_instance_manager);
-		constexpr fixed_point_t get_social_income_variant_base() const {
-			return 2 * base_life_need_costs;
-		}
+		constexpr SharedPopTypeValues(PopType const& new_pop_type) : pop_type { new_pop_type } {};
 	};
 
 	struct SharedCountryValues {
+		friend CountryInstanceManager;
 	private:
 		ModifierEffectCache const& PROPERTY(modifier_effect_cache);
 		CountryDefines const& PROPERTY(country_defines);
 		PopsDefines const& pop_defines;
-		IndexedFlatMap_PROPERTY(PopType, SharedPopTypeValues, shared_pop_type_values);
+		IndexedFlatMap<PopType, SharedPopTypeValues> shared_pop_type_values;
+
+		void update_costs(GoodInstanceManager const& good_instance_manager);
 
 	public:
+		SharedPopTypeValues& get_shared_pop_type_values(PopType const& pop_type);
+
 		SharedCountryValues(
 			ModifierEffectCache const& new_modifier_effect_cache,
 			CountryDefines const& new_country_defines,
 			PopsDefines const& new_pop_defines,
 			decltype(shared_pop_type_values)::keys_span_type pop_type_keys
 		);
-		SharedCountryValues(SharedCountryValues&&) = default;
-		void update_costs(GoodInstanceManager const& good_instance_manager);
+		SharedCountryValues(SharedCountryValues&&) = delete;
+		SharedCountryValues(SharedCountryValues const&) = delete;
+		SharedCountryValues& operator=(SharedCountryValues&&) = delete;
+		SharedCountryValues& operator=(SharedCountryValues const&) = delete;
 	};
 }
 

--- a/src/openvic-simulation/economy/production/Employee.cpp
+++ b/src/openvic-simulation/economy/production/Employee.cpp
@@ -10,7 +10,7 @@ Employee::Employee(Pop& new_pop, const pop_size_t new_size)
 	size { new_size }
 	{}
 
-fixed_point_t Employee::update_minimum_wage(CountryInstance const& country_to_report_economy) {
+fixed_point_t Employee::update_minimum_wage(CountryInstance& country_to_report_economy) {
 	const fixed_point_t minimum_wage_base = country_to_report_economy.calculate_minimum_wage_base(*pop.get_type());
 	return minimum_wage_cached = minimum_wage_base * size / Pop::size_denominator;
 }

--- a/src/openvic-simulation/economy/production/Employee.hpp
+++ b/src/openvic-simulation/economy/production/Employee.hpp
@@ -14,6 +14,6 @@ namespace OpenVic {
 		fixed_point_t PROPERTY_RW(minimum_wage_cached);
 	public:
 		Employee(Pop& new_pop, const pop_size_t new_size);
-		fixed_point_t update_minimum_wage(CountryInstance const& country_to_report_economy);
+		fixed_point_t update_minimum_wage(CountryInstance& country_to_report_economy);
 	};
 }

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -350,10 +350,10 @@ void ResourceGatheringOperation::pay_employees(memory::vector<fixed_point_t>& re
 		return;
 	}
 
-	CountryInstance const* const country_to_report_economy_nullable = location.get_country_to_report_economy();
+	CountryInstance* const country_to_report_economy_nullable = location.get_country_to_report_economy();
 	fixed_point_t total_minimum_wage = 0;
 	if (country_to_report_economy_nullable != nullptr) {
-		CountryInstance const& country_to_report_economy = *country_to_report_economy_nullable;
+		CountryInstance& country_to_report_economy = *country_to_report_economy_nullable;
 		for (Employee& employee : employees) {
 			total_minimum_wage += employee.update_minimum_wage(country_to_report_economy);
 		}

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/map/MapInstance.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/map/Region.hpp"
+#include "openvic-simulation/pop/Pop.hpp"
 #include "openvic-simulation/pop/PopType.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/StringUtils.hpp"
@@ -50,7 +51,7 @@ void State::update_gamestate() {
 		pops_cache.clear();
 	}
 
-	for (ProvinceInstance const* const province : provinces) {
+	for (ProvinceInstance* const province : provinces) {
 		add_pops_aggregate(*province);
 
 		for (auto const& [pop_type, province_pops_of_type] : province->get_pops_cache_by_type()) {
@@ -147,11 +148,12 @@ bool StateManager::add_state_set(
 
 		CountryInstance* owner = capital->get_owner();
 
-		State& state = *state_set.states.insert({
+		State& state = *state_set.states.emplace(
 			/* TODO: capital province logic */
-			state_set, owner, capital, std::move(provinces), capital->get_colony_status(), strata_keys, pop_type_keys,
-			ideology_keys
-		});
+			state_set, owner, capital,
+			std::move(provinces), capital->get_colony_status(),
+			strata_keys, pop_type_keys, ideology_keys
+		);
 
 		for (ProvinceInstance* province : state.get_provinces()) {
 			province->set_state(&state);

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -33,11 +33,11 @@ namespace OpenVic {
 		ProvinceInstance* PROPERTY_PTR(capital);
 		memory::vector<ProvinceInstance*> SPAN_PROPERTY(provinces);
 		colony_status_t PROPERTY(colony_status);
-
-		IndexedFlatMap_PROPERTY(PopType, memory::vector<Pop*>, pops_cache_by_type);
-	private:
 		fixed_point_t PROPERTY(industrial_power);
 
+		IndexedFlatMap_PROPERTY(PopType, memory::vector<Pop*>, pops_cache_by_type);
+
+	public:
 		State(
 			StateSet const& new_state_set,
 			CountryInstance* new_owner,
@@ -48,8 +48,11 @@ namespace OpenVic {
 			utility::forwardable_span<const PopType> pop_type_keys,
 			utility::forwardable_span<const Ideology> ideology_keys
 		);
+		State(State&&) = delete;
+		State(State const&) = delete;
+		State& operator=(State&&) = delete;
+		State& operator=(State const&) = delete;
 
-	public:
 		memory::string get_identifier() const;
 
 		constexpr bool is_colonial_state() const {

--- a/src/openvic-simulation/misc/GameAction.cpp
+++ b/src/openvic-simulation/misc/GameAction.cpp
@@ -440,11 +440,11 @@ bool GameActionManager::game_action_callback_start_research(game_action_argument
 		return false;
 	}
 
-	Technology const* old_research = country->get_current_research();
+	Technology const* old_research = country->get_current_research_untracked();
 
 	country->start_research(*technology, instance_manager);
 
-	return old_research != country->get_current_research();
+	return old_research != country->get_current_research_untracked();
 }
 
 // Politics

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -295,7 +295,7 @@ void Pop::pay_income_tax(fixed_point_t& income) {
 	if (tax_collector_nullable == nullptr) {
 		return;
 	}
-	const fixed_point_t effective_tax_rate = tax_collector_nullable->get_effective_tax_rate_by_strata(type->get_strata());
+	const fixed_point_t effective_tax_rate = tax_collector_nullable->get_effective_tax_rate_by_strata(type->get_strata()).get_untracked();
 	const fixed_point_t tax = effective_tax_rate * income;
 	tax_collector_nullable->report_pop_income_tax(*type, income, tax);
 	income -= tax;
@@ -449,7 +449,7 @@ void Pop::pop_tick_without_cleanup(
 	fixed_point_t max_cost_multiplier = 1;
 	if (country_to_report_economy_nullable != nullptr) {
 		country_to_report_economy_nullable->request_salaries_and_welfare_and_import_subsidies(*this);
-		const fixed_point_t tariff_rate = country_to_report_economy_nullable->get_effective_tariff_rate();
+		const fixed_point_t tariff_rate = country_to_report_economy_nullable->effective_tariff_rate.get_untracked();
 		if (tariff_rate > fixed_point_t::_0) {
 			max_cost_multiplier += tariff_rate; //max (domestic cost, imported cost)
 		}

--- a/src/openvic-simulation/pop/PopType.hpp
+++ b/src/openvic-simulation/pop/PopType.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "openvic-simulation/scripts/ConditionalWeight.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
+#include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
 #include "openvic-simulation/types/HasIndex.hpp"
+#include "openvic-simulation/types/IndexedFlatMap.hpp"
 #include "openvic-simulation/types/PopSize.hpp"
 #include "openvic-simulation/types/PopSprite.hpp"
 #include "openvic-simulation/utility/Containers.hpp"

--- a/src/openvic-simulation/pop/PopValuesFromProvince.cpp
+++ b/src/openvic-simulation/pop/PopValuesFromProvince.cpp
@@ -24,8 +24,8 @@ void PopStrataValuesFromProvince::update_pop_strata_values_from_province(
 	CountryInstance const* const owner_nullable = province.get_owner();
 	if (owner_nullable != nullptr) {
 		CountryInstance const& owner = *owner_nullable;
-		shared_base_needs_scalar *= fixed_point_t::_1 + owner.get_plurality() / 100;
-		invention_needs_scalar += owner.get_inventions_count() * defines.get_invention_impact_on_demand();
+		shared_base_needs_scalar *= fixed_point_t::_1 + owner.get_plurality_untracked() / 100;
+		invention_needs_scalar += owner.get_inventions_count_untracked() * defines.get_invention_impact_on_demand();
 	}
 
 	shared_life_needs_scalar = shared_base_needs_scalar

--- a/src/openvic-simulation/pop/PopsAggregate.cpp
+++ b/src/openvic-simulation/pop/PopsAggregate.cpp
@@ -84,7 +84,7 @@ fixed_point_t PopsAggregate::get_luxury_needs_fulfilled_by_strata(Strata const& 
 void PopsAggregate::clear_pops_aggregate() {
 	total_population = 0;
 	max_supported_regiment_count = 0;
-	yesterdays_import_value = fixed_point_t::_0;
+	_yesterdays_import_value_running_total = fixed_point_t::_0;
 
 	average_literacy = fixed_point_t::_0;
 	average_consciousness = fixed_point_t::_0;
@@ -105,10 +105,10 @@ void PopsAggregate::clear_pops_aggregate() {
 	population_by_religion.clear();
 }
 
-void PopsAggregate::add_pops_aggregate(PopsAggregate const& part) {
+void PopsAggregate::add_pops_aggregate(PopsAggregate& part) {
 	total_population += part.get_total_population();
 	max_supported_regiment_count += part.get_max_supported_regiment_count();
-	yesterdays_import_value += part.get_yesterdays_import_value();
+	_yesterdays_import_value_running_total += part.get_yesterdays_import_value_untracked();
 
 	// TODO - change casting if pop_size_t changes type
 	const fixed_point_t part_population = fixed_point_t::parse(part.get_total_population());
@@ -165,6 +165,7 @@ void PopsAggregate::add_pops_aggregate(Pop const& pop) {
 	population_by_religion[&pop.get_religion()] += pop_size;
 
 	max_supported_regiment_count += pop.get_max_supported_regiments();
+	yesterdays_import_value.set(_yesterdays_import_value_running_total);
 }
 
 void PopsAggregate::normalise_pops_aggregate() {

--- a/src/openvic-simulation/pop/PopsAggregate.hpp
+++ b/src/openvic-simulation/pop/PopsAggregate.hpp
@@ -7,6 +7,7 @@
 #include "openvic-simulation/types/OrderedContainers.hpp"
 #include "openvic-simulation/types/PopSize.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/reactive/MutableState.hpp"
 
 namespace OpenVic {
 	struct BaseIssue;
@@ -24,7 +25,8 @@ namespace OpenVic {
 	private:
 		pop_size_t PROPERTY(total_population, 0);
 		size_t PROPERTY(max_supported_regiment_count, 0);
-		fixed_point_t PROPERTY(yesterdays_import_value); //>= 0
+		fixed_point_t _yesterdays_import_value_running_total;
+		STATE_PROPERTY(fixed_point_t, yesterdays_import_value); //>= 0
 
 		// TODO - population change (growth + migration), monthly totals + breakdown by source/destination
 		fixed_point_t PROPERTY(average_literacy);
@@ -53,7 +55,7 @@ namespace OpenVic {
 		);
 
 		void clear_pops_aggregate();
-		void add_pops_aggregate(PopsAggregate const& part);
+		void add_pops_aggregate(PopsAggregate& part);
 		void add_pops_aggregate(Pop const& pop);
 		void normalise_pops_aggregate();
 		void update_parties_for_votes(CountryDefinition const* country_definition);

--- a/src/openvic-simulation/types/Signal.hpp
+++ b/src/openvic-simulation/types/Signal.hpp
@@ -506,9 +506,9 @@ namespace OpenVic::_detail::signal {
 
 	template<typename Lockable>
 	struct basic_observer : private observer_type {
+	protected:
 		virtual ~basic_observer() = default;
 
-	protected:
 		/**
 		 * Disconnect all signals connected to this object.
 		 *

--- a/src/openvic-simulation/types/SliderValue.hpp
+++ b/src/openvic-simulation/types/SliderValue.hpp
@@ -4,6 +4,7 @@
 
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/reactive/MutableState.hpp"
 
 namespace OpenVic {
 
@@ -11,30 +12,30 @@ namespace OpenVic {
 	private:
 		fixed_point_t PROPERTY(min);
 		fixed_point_t PROPERTY(max);
-		fixed_point_t PROPERTY(value);
+		STATE_PROPERTY(fixed_point_t, value);
 
 	public:
 		constexpr SliderValue() {};
 
-		constexpr void set_value(fixed_point_t new_value) {
+		void set_value(fixed_point_t new_value) {
 			if (min <= max) {
-				value = std::clamp(new_value, min, max);
+				value.set(std::clamp(new_value, min, max));
 			} else {
 				// You *can* actually have min > max in Victoria 2
 				// Such a situation will result in only being able to be move between the max and min value.
 				// This logic replicates this "feature"
 				if (new_value > max) {
-					value = min;
+					value.set(min);
 				} else {
-					value = max;
+					value.set(max);
 				}
 			}
 		}
 
-		constexpr void set_bounds(fixed_point_t new_min, fixed_point_t new_max) {
+		void set_bounds(fixed_point_t new_min, fixed_point_t new_max) {
 			min = new_min;
 			max = new_max;
-			set_value(value);
+			set_value(value.get_untracked());
 		}
 	};
 }

--- a/src/openvic-simulation/utility/MathConcepts.hpp
+++ b/src/openvic-simulation/utility/MathConcepts.hpp
@@ -7,6 +7,38 @@ namespace OpenVic {
 	concept UnaryNegatable = requires(T const& a) {
 		{ -a } -> std::same_as<T>;
 	};
+	
+	// Concept: PreIncrementable
+	// Describes types that support the pre-increment operator (++a).
+	// The result of ++a must be a reference to T.
+	template <typename T>
+	concept PreIncrementable = requires(T a) {
+		{ ++a } -> std::same_as<T&>;
+	};
+
+	// Concept: PostIncrementable
+	// Describes types that support the post-increment operator (a++).
+	// The result of a++ must be a value of T.
+	template <typename T>
+	concept PostIncrementable = requires(T a) {
+		{ a++ } -> std::same_as<T>;
+	};
+	
+	// Concept: PreDecrementable
+	// Describes types that support the pre-decrement operator (++a).
+	// The result of ++a must be a reference to T.
+	template <typename T>
+	concept PreDecrementable = requires(T a) {
+		{ --a } -> std::same_as<T&>;
+	};
+
+	// Concept: PostDecrementable
+	// Describes types that support the post-decrement operator (a++).
+	// The result of a++ must be a value of T.
+	template <typename T>
+	concept PostDecrementable = requires(T a) {
+		{ a-- } -> std::same_as<T>;
+	};
 
 	template <typename Lhs, typename Rhs = Lhs, typename Result = std::common_type_t<Lhs, Rhs>>
 	concept Addable = requires(Lhs const& lhs, Rhs const& rhs) {

--- a/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
+++ b/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <mutex>
+
+#include <function2/function2.hpp>
+
+#include "openvic-simulation/types/Signal.hpp"
+
+namespace OpenVic {
+	struct DependencyTracker {
+	private:
+		memory::vector<scoped_connection> connections;
+		std::mutex connections_lock;
+
+		void mark_dirty() {
+			if (is_dirty) {
+				return;
+			}
+
+			const std::lock_guard<std::mutex> lock_guard { is_dirty_lock };
+			if (is_dirty) {
+				return;
+			}
+
+			disconnect_all();
+			is_dirty = true;
+			changed();
+		}
+	protected:
+		signal<> changed;
+		bool is_dirty = true;
+		std::mutex is_dirty_lock;
+		
+		virtual ~DependencyTracker() {
+			disconnect_all();
+		}
+
+		constexpr bool has_no_connections() const {
+			return connections.empty();
+		}
+
+		void disconnect_all() {
+			const std::lock_guard<std::mutex> lock_guard { connections_lock };
+			connections.clear();
+		}
+	public:
+		void track(signal<>& dependency_changed) {
+			const std::lock_guard<std::mutex> lock_guard { connections_lock };
+			connections.emplace_back(
+				dependency_changed.connect(&DependencyTracker::mark_dirty, this)
+			);
+		}
+
+		template<typename... Args>
+		void track(signal<Args...>& dependency_changed) {
+			const std::lock_guard<std::mutex> lock_guard { connections_lock };
+			connections.emplace_back(
+				dependency_changed.connect([this](Args...) { mark_dirty(); })
+			);
+		}
+	};
+}

--- a/src/openvic-simulation/utility/reactive/DerivedState.hpp
+++ b/src/openvic-simulation/utility/reactive/DerivedState.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "DependencyTracker.hpp"
+
+#include <function2/function2.hpp>
+
+#include "openvic-simulation/types/Signal.hpp"
+#include "openvic-simulation/utility/Getters.hpp"
+#include "openvic-simulation/utility/Logger.hpp"
+#include "openvic-simulation/utility/reactive/DependencyTracker.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	struct DerivedState : public DependencyTracker {
+	private:
+		T cached_value;
+		fu2::function<const T(DependencyTracker&)> calculate;
+
+		void recalculate_if_dirty() {
+			if (!is_dirty) {
+				return;
+			}
+			const std::lock_guard<std::mutex> lock_guard { is_dirty_lock };
+			if (!is_dirty) {
+				return;
+			}
+
+			T value = calculate(*this);
+
+			if (has_no_connections()) {
+				Logger::warning(
+					"DEVELOPER WARNING: OpenVic::DerivedState<",
+					OpenVic::utility::type_name<T>(),
+					"> has no reactive dependencies. Its value will never change again.",
+					"If it should be reactive, ensure 'calculate' accesses its dependencies. ",
+					"Alternatively use a plain variable or MutableState<T>."
+				);
+			}
+
+			cached_value = std::move(value);
+			is_dirty = false;
+		}
+
+	public:
+		template<typename Func>
+		explicit DerivedState(Func&& new_calculate)
+		requires std::is_default_constructible_v<T>
+			&& std::is_convertible_v<Func, fu2::function<const T(DependencyTracker&)>>
+			: calculate { std::forward<Func>(new_calculate) },
+			cached_value() {}
+
+		template<typename Func, typename InitialValue>
+		requires std::is_convertible_v<InitialValue, T>
+			&& std::is_convertible_v<Func, fu2::function<const T(DependencyTracker&)>>
+		explicit DerivedState(Func&& new_calculate, InitialValue&& empty_initial_value)
+			: calculate { std::forward<Func>(new_calculate) },
+			cached_value { std::forward<InitialValue>(empty_initial_value) } {}
+
+		DerivedState(DerivedState&&) = delete;
+		DerivedState(DerivedState const&) = delete;
+		DerivedState& operator=(DerivedState&&) = delete;
+		DerivedState& operator=(DerivedState const&) = delete;
+
+		[[nodiscard]] T const& get(DependencyTracker& tracker) {
+			recalculate_if_dirty();
+			tracker.track(changed);
+			return cached_value;
+		}
+		[[nodiscard]] T const& get_untracked() {
+			recalculate_if_dirty();
+			return cached_value;
+		}
+		
+		//special case where connection may be discarded as the observer handles it
+		template<typename Pmf, OpenVic::_detail::signal::Observer Ptr>
+		requires OpenVic::_detail::signal::Callable<Pmf, Ptr>
+		connection connect_using_observer(Pmf&& pmf, Ptr&& ptr, OpenVic::_detail::signal::group_id gid = 0) {
+			return changed.connect(pmf, ptr, gid);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect(Ts&&... args) const {
+			return changed.connect(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect_extended(Ts&&... args) const {
+			return changed.connect_extended(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] scoped_connection connect_scoped(Ts&&... args) const {
+			return changed.connect_scoped(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		void disconnect(Ts&&... args) const {
+			return changed.disconnect(std::forward<Ts>(args)...);
+		}
+	};
+}

--- a/src/openvic-simulation/utility/reactive/MutableState.hpp
+++ b/src/openvic-simulation/utility/reactive/MutableState.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "openvic-simulation/types/Signal.hpp"
+#include "openvic-simulation/utility/MathConcepts.hpp"
+#include "openvic-simulation/utility/reactive/DependencyTracker.hpp"
+
+namespace OpenVic {
+	template <typename T>
+	struct MutableState {
+	private:
+		T value;
+		signal<T> changed;
+	public:
+		constexpr MutableState() requires std::is_default_constructible_v<T> : value() {}
+		constexpr explicit MutableState(T const& new_value) : value { new_value } {}
+		constexpr explicit MutableState(T&& new_value) : value { std::move(new_value) } {}
+		MutableState(MutableState&&) = delete;
+		MutableState(MutableState const&) = delete;
+		MutableState& operator=(MutableState&&) = delete;
+		MutableState& operator=(MutableState const&) = delete;
+
+		[[nodiscard]] T const& get(DependencyTracker& tracker) {
+			tracker.track(changed);
+			return value;
+		}
+		[[nodiscard]] constexpr T const& get_untracked() const {
+			return value;
+		}
+
+		void set(T&& new_value) {
+			value = std::move(new_value);
+			changed(value);
+		}
+
+		void set(T const& new_value) {
+			value = new_value;
+			changed(value);
+		}
+		
+		MutableState<T>& operator++() requires PreIncrementable<T> {
+			set(++value);
+			return *this;
+		}
+
+		void operator++(int) requires PostIncrementable<T> {
+			set(value++);
+		}
+
+		MutableState<T>& operator--() requires PreDecrementable<T> {
+			set(--value);
+			return *this;
+		}
+
+		void operator--(int) requires PostDecrementable<T> {
+			set(value--);
+		}
+
+		template<typename RHS>
+		requires Addable<T, RHS, T>
+		MutableState<T>& operator+=(RHS const& rhs) {
+			set(value + rhs);
+			return *this;
+		}
+		template<typename RHS>
+		requires Subtractable<T, RHS, T>
+		MutableState<T>& operator-=(RHS const& rhs) {
+			set(value - rhs);
+			return *this;
+		}
+		template<typename RHS>
+		requires Multipliable<T, RHS, T>
+		MutableState<T>& operator*=(RHS const& rhs) {
+			set(value * rhs);
+			return *this;
+		}
+		template<typename RHS>
+		requires Divisible<T, RHS, T>
+		MutableState<T>& operator/=(RHS const& rhs) {
+			set(value / rhs);
+			return *this;
+		}
+		
+		//special case where connection may be discarded as the observer handles it
+		template<typename Pmf, OpenVic::_detail::signal::Observer Ptr>
+		requires OpenVic::_detail::signal::Callable<Pmf, Ptr>
+		connection connect_using_observer(Pmf&& pmf, Ptr&& ptr, OpenVic::_detail::signal::group_id gid = 0) {
+			return changed.connect(pmf, ptr, gid);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect(Ts&&... args) const {
+			return changed.connect(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] connection connect_extended(Ts&&... args) const {
+			return changed.connect_extended(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		[[nodiscard]] scoped_connection connect_scoped(Ts&&... args) const {
+			return changed.connect_scoped(std::forward<Ts>(args)...);
+		}
+
+		template<typename... Ts>
+		void disconnect(Ts&&... args) const {
+			return changed.disconnect(std::forward<Ts>(args)...);
+		}
+	};
+
+#define STATE_PROPERTY(T, NAME) STATE_PROPERTY_ACCESS(T, NAME, private)
+#define STATE_PROPERTY_ACCESS(T, NAME, ACCESS) \
+	MutableState<T> NAME; \
+\
+public: \
+	[[nodiscard]] T get_##NAME(DependencyTracker& tracker) { \
+		return NAME.get(tracker); \
+	} \
+	[[nodiscard]] T get_##NAME##_untracked() const { \
+		return NAME.get_untracked(); \
+	} \
+	ACCESS:
+}


### PR DESCRIPTION
- Supersedes #508 

When it comes to reactivity in the UI I'd love to use a reactive pull based model.
Where the reactive part is event-driven marking data as dirty.
The pull part would be the UI updating all elements marked dirty.
This would be kinda like Svelte, but Svelte does it compile-time.

Sadly according to Gemini and my own research neither godot nor C++ have something like this.
We're stuck with signals and manually invalidating or directly updating UI elements.
Also we have to ensure that signals can't flood the UI with updates.

This is a error-prone approach.

I thought about it some more and came up with the following high-level idea:
Split state up into:

    constant state
    mutable state (properties with events)
    derived state (tracks dependencies is marked dirty when they update. recalculates if dirty when requested)
    manually tracked derived state

We can use signal for the events.
signal_property would have to be replaced with mutable state that exposes a get() method and changed signal.
Manually tracked derived state would be pop distributions and other aggregates that we know when to update in the sim.
You don't want to track every pop his size in the province + the list of all pops. You could just manually update that like we do now.
Mutable, derived & manually tracked derived state all implement the same interface of a get() method and changed signal.
The derived state (mainly for UI purposes) should automatically handle tracking.