### PR TITLE
Remove CountryInstance methods without implementation

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -418,9 +418,6 @@ namespace OpenVic {
 		}
 
 		std::string_view get_identifier() const;
-		fixed_point_t get_tariff_efficiency() const;
-
-		void update_country_definition_based_attributes();
 
 		bool exists() const;
 		bool is_civilised() const;


### PR DESCRIPTION
`fixed_point_t get_tariff_efficiency() const;` was replaced by `DerivedState<fixed_point_t> tariff_efficiency;` See #523 
`void update_country_definition_based_attributes();` is no longer relevant since country definition is const. See #526 