### PR TITLE
Correct requirement on DerivedState

### DIFF
--- a/src/openvic-simulation/utility/reactive/DerivedState.hpp
+++ b/src/openvic-simulation/utility/reactive/DerivedState.hpp
@@ -62,7 +62,7 @@ namespace OpenVic {
 		DerivedState& operator=(DerivedState const&) = delete;
 
 		template<typename ConnectTemplateType>
-		requires std::invocable<ConnectTemplateType, signal<T>&>
+		requires std::invocable<ConnectTemplateType, signal<>&>
 		[[nodiscard]] T const& get(ConnectTemplateType&& connect) {
 			recalculate_if_dirty();
 			connect(changed);


### PR DESCRIPTION
DerivedState<T> exposes a signal<>, not a signal<T> as the signal merely indicates that it has become dirty. The signal doesn't pass on a new value.