### PR TITLE
Lock is_dirty_lock shorter

### DIFF
--- a/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
+++ b/src/openvic-simulation/utility/reactive/DependencyTracker.hpp
@@ -15,13 +15,16 @@ namespace OpenVic {
 				return;
 			}
 
-			const std::lock_guard<std::mutex> lock_guard { is_dirty_lock };
-			if (is_dirty) {
-				return;
+			{
+				const std::lock_guard<std::mutex> lock_guard { is_dirty_lock };
+				if (is_dirty) {
+					return;
+				}
+
+				disconnect_all();
+				is_dirty = true;
 			}
 
-			disconnect_all();
-			is_dirty = true;
 			changed();
 		}
 	protected:

--- a/tests/src/utility/reactive/DerivedState.cpp
+++ b/tests/src/utility/reactive/DerivedState.cpp
@@ -1,3 +1,4 @@
+#include "openvic-simulation/types/Signal.hpp"
 #include "openvic-simulation/utility/reactive/DependencyTracker.hpp"
 #include "openvic-simulation/utility/reactive/DerivedState.hpp"
 #include "openvic-simulation/utility/reactive/MutableState.hpp"
@@ -52,4 +53,27 @@ TEST_CASE("DerivedState reactive", "[DerivedState-reactive]") {
 	CHECK(sum.get_untracked() == 4);
 	mutable_state_a.set(3);
 	CHECK(times_marked_dirty == 2);
+}
+
+TEST_CASE("DerivedState untracked in callback", "[DerivedState-untracked-in-callback]") {
+	MutableState<int> mutable_state_a(0);
+	MutableState<int> mutable_state_b(0);
+	DerivedState<int> sum([
+		&a=static_cast<ReadOnlyMutableState<int>&>(mutable_state_a),
+		&b=static_cast<ReadOnlyMutableState<int>&>(mutable_state_b)
+	](DependencyTracker& tracker)->int {
+		return a.get(tracker) + b.get(tracker);
+	});
+
+	connection conn;
+	int sum_value = sum.get([&sum,&conn,&sum_value](OpenVic::signal<>& sum_changed) mutable -> void {
+		conn = sum_changed.connect([&sum,&sum_value]() mutable -> void {
+			sum_value = sum.get_untracked();
+		});
+	});
+	CHECK(sum_value == 0);
+	mutable_state_a.set(1);
+	CHECK(sum_value == 1);
+	mutable_state_a.set(2);
+	CHECK(sum_value == 2);
 }


### PR DESCRIPTION
is_dirty_lock is meant to only protect is_dirty.
The changed() callback could request the up to date value, which would mark is_dirty false.

Unit test included.