### PR TITLE
Update states and allowed regiment cultures

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -243,8 +243,8 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 	OV_ERR_FAIL_COND_V_MSG(!all_has_state, false, "At least one land province has no state");
 
 	update_modifier_sums();
-	country_instance_manager.update_gamestate(*this);
 	map_instance.initialise_for_new_game(*this);
+	country_instance_manager.update_gamestate(*this);
 	market_instance.execute_orders();
 
 	return ret;

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -28,8 +28,9 @@ namespace OpenVic {
 		friend struct StateManager;
 
 	private:
+		CountryInstance* previous_country_ptr = nullptr;	
+
 		StateSet const& PROPERTY(state_set);
-		CountryInstance* PROPERTY_PTR(owner);
 		ProvinceInstance* PROPERTY_PTR(capital);
 		memory::vector<ProvinceInstance*> SPAN_PROPERTY(provinces);
 		colony_status_t PROPERTY(colony_status);
@@ -37,10 +38,11 @@ namespace OpenVic {
 
 		IndexedFlatMap_PROPERTY(PopType, memory::vector<Pop*>, pops_cache_by_type);
 
+		void _update_country();
+
 	public:
 		State(
 			StateSet const& new_state_set,
-			CountryInstance* new_owner,
 			ProvinceInstance* new_capital,
 			memory::vector<ProvinceInstance*>&& new_provinces,
 			colony_status_t new_colony_status,
@@ -54,6 +56,7 @@ namespace OpenVic {
 		State& operator=(State const&) = delete;
 
 		memory::string get_identifier() const;
+		CountryInstance* get_owner() const;
 
 		constexpr bool is_colonial_state() const {
 			return is_colonial(colony_status);


### PR DESCRIPTION
States were never registered to the country instance. Also they stored their owner separately despite it being linked to the capital owner. This has changed. In the gamestate update and State constructor, the state adds itself from the country instance (and/or removes from the old). The owner is no longer stored as a field, instead it is retrieved via the capital province.

Countries can recruit regiments. Regiments can have cultural limitations (all cultures, all accepted or primary only). The country stores a field containing the most permissive cultural limitation based on the unlocked unit types. This was never updates.
Now it is updated whenever a regiment type is locked or unlocked.

In the InstanceManager, the order of execution when loading a bookmark is changed:
First `map_instance.initialise_for_new_game(*this);` and then `country_instance_manager.update_gamestate(*this);` instead of the other way around. This ensures that the states, provinces and pops have their state updated before we aggregate it in the countries. Note it now mimics the order in `InstanceManager::update_gamestate()`.