### PR TITLE
Remove official support for macOS builds in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -65,18 +65,18 @@ jobs:
             target: template_release
             platform: windows
             arch: x86_64
-          - identifier: macos-debug
-            os: macos-latest
-            name: 🍎 macOS (universal) Debug
-            target: template_debug
-            platform: macos
-            arch: universal
-          - identifier: macos-release
-            os: macos-latest
-            name: 🍎 macOS (universal) Release
-            target: template_release
-            platform: macos
-            arch: universal
+          # - identifier: macos-debug
+          #   os: macos-latest
+          #   name: 🍎 macOS (universal) Debug
+          #   target: template_debug
+          #   platform: macos
+          #   arch: universal
+          # - identifier: macos-release
+          #   os: macos-latest
+          #   name: 🍎 macOS (universal) Release
+          #   target: template_release
+          #   platform: macos
+          #   arch: universal
           - identifier: linux-debug
             os: ubuntu-latest
             name: 🐧 Linux Debug


### PR DESCRIPTION
This does not intend to inhibit unofficial macOS builds, however due to the difficulty of dealing with the platform and in testing it we will no longer be validating its functionality nor officially supporting. We will not be going out of our way to harm macOS builds nor will we add anything that intentionally inhibits building on mac.