### PR TITLE
Use RingBuffer in ValueHistory

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -35,6 +35,7 @@ using namespace OpenVic;
 
 using enum CountryInstance::country_status_t;
 
+static constexpr size_t DAYS_OF_BALANCE_HISTORY = 30;
 static constexpr colour_t ERROR_COLOUR = colour_t::from_integer(0xFF0000);
 
 CountryInstance::CountryInstance(
@@ -72,7 +73,7 @@ CountryInstance::CountryInstance(
 	building_type_unlock_levels { building_type_keys },
 
 	/* Budget */
-	balance_history{30, 0},
+	balance_history{DAYS_OF_BALANCE_HISTORY},
 	taxable_income_by_pop_type { pop_type_keys },
 	effective_tax_rate_by_strata {
 		strata_keys,

--- a/src/openvic-simulation/types/RingBuffer.hpp
+++ b/src/openvic-simulation/types/RingBuffer.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <bit>
+#include <cassert>
 #include <cstddef>
 #include <cstdlib>
 #include <iterator>

--- a/src/openvic-simulation/types/ValueHistory.hpp
+++ b/src/openvic-simulation/types/ValueHistory.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <numeric>
 #include <ostream>
-#include <vector>
 
-#include "openvic-simulation/utility/Containers.hpp"
+#include "openvic-simulation/types/RingBuffer.hpp"
 
 namespace OpenVic {
 
-	template<typename T>
-	struct ValueHistory : private memory::vector<T> {
-		using base_type = memory::vector<T>;
+	template<typename T, typename Allocator = std::allocator<T>>
+	struct ValueHistory : private RingBuffer<T, Allocator> {
+		using base_type = RingBuffer<T, Allocator>;
 
+		using typename base_type::allocator_type;
+		using typename base_type::size_type;
 		using typename base_type::iterator;
 		using typename base_type::const_iterator;
 		using typename base_type::reverse_iterator;
@@ -22,7 +22,6 @@ namespace OpenVic {
 		using typename base_type::const_pointer;
 		using typename base_type::difference_type;
 		using base_type::operator[];
-		using base_type::data;
 		using base_type::size;
 		using base_type::empty;
 		using base_type::begin;
@@ -35,51 +34,17 @@ namespace OpenVic {
 		using base_type::crend;
 		using base_type::front;
 		using base_type::back;
+		using base_type::push_back;
 
 		constexpr ValueHistory() {};
-		ValueHistory(size_t history_size, T const& fill_value = {}) : base_type(history_size, fill_value) {}
-		ValueHistory(ValueHistory&&) = default;
+		explicit ValueHistory(size_type capacity) : base_type(capacity) {}
+		explicit ValueHistory(size_type capacity, allocator_type const& allocator) : base_type(capacity, allocator) {}
+		explicit ValueHistory(size_type size, T const& fill_value) : base_type(size) {
+			fill(fill_value);
+		}
 
 		void fill(T const& value) {
-			std::fill(begin(), end(), value);
-		}
-
-		T get_total() const {
-			return std::accumulate(begin(), end(), T {});
-		}
-
-		void push_back(T const& value) {
-			if (!empty()) {
-				// Move all values back by one (with the first value being discarded) and place the new value at the end
-				for (iterator it = begin(); it != end(); ++it) {
-					*it = *(it + 1);
-				}
-				back() = value;
-			}
-		}
-
-		void set_size(size_t new_size, T const& fill_value = {}) {
-			const difference_type size_diff = new_size - size();
-
-			if (size_diff < 0) {
-				// Move the last new_size elements to the front, discarding the values before them
-				for (iterator it = begin(); it != begin() + new_size; ++it) {
-					*it = *(it - size_diff);
-				}
-
-				base_type::resize(new_size);
-			} else if (size_diff > 0) {
-				// Move the existing values to the end and fill the front with fill_value
-				const size_t old_size = size();
-				base_type::resize(new_size);
-
-				for (reverse_iterator rit = rbegin(); rit != rbegin() + old_size; ++rit) {
-					*rit = *(rit + size_diff);
-				}
-				for (iterator it = begin(); it != begin() + size_diff; ++it) {
-					*it = fill_value;
-				}
-			}
+			base_type::resize(base_type::capacity(), value);
 		}
 	};
 


### PR DESCRIPTION
Replaces #574

#545 added tracking balance history per country.
Also price history is tracked since #288 

They used ValueHistory which is flawed in several ways:
- it has a static size so you don't know how many periods of history it has (required for UI).
- it requires filling with a single value (0 isn't practical when you need to find a min and max, since 0 could be a normal value and thus can't be used to identify empty values)
- it uses a vector instead of array despite having a compile-time constant capacity available
- it's implementation deviates from the industry standard circular buffer or ring buffer

For these reasons, it is now based on Spartans RingBuffer (#575 )