### PR TITLE
Fixup `GameManager::load_mods`

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -162,7 +162,7 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 	ret &= game_manager.load_mod_descriptors();
 
 	Logger::info("===== Loading mods... =====");
-	ret &= game_manager.load_mods(roots, replace_paths, mods);
+	ret &= game_manager.load_mods(mods);
 
 	Logger::info("===== Loading definitions... =====");
 	ret &= game_manager.load_definitions(

--- a/src/openvic-simulation/GameManager.hpp
+++ b/src/openvic-simulation/GameManager.hpp
@@ -9,7 +9,7 @@
 #include "openvic-simulation/dataloader/Dataloader.hpp"
 #include "openvic-simulation/misc/GameRulesManager.hpp"
 #include "openvic-simulation/gen/commit_info.gen.hpp"
-#include "openvic-simulation/utility/ForwardableSpan.hpp"
+#include "openvic-simulation/utility/Containers.hpp"
 
 #include <function2/function2.hpp>
 
@@ -55,11 +55,7 @@ namespace OpenVic {
 
 		bool load_mod_descriptors();
 
-		bool load_mods(
-			Dataloader::path_vector_t& roots,
-			Dataloader::path_vector_t& replace_paths,
-			utility::forwardable_span<const memory::string> requested_mods
-		);
+		bool load_mods(memory::vector<memory::string> const& mods_to_find);
 
 		bool load_definitions(Dataloader::localisation_callback_t localisation_callback);
 


### PR DESCRIPTION
Rename `requested_mods` parameter to `mods_to_find`
Retype `mods_to_find` as `memory::vector const&`
Remove `roots` and `replace_paths` parameters

This reduces the capacity for misuse and cleans up the interface.