### PR TITLE
Market tick before country_manager_tick_after_map

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -127,9 +127,9 @@ void InstanceManager::tick() {
 	// Tick...
 	country_instance_manager.country_manager_tick_before_map(*this);
 	map_instance.map_tick();
+	market_instance.execute_orders();
 	country_instance_manager.country_manager_tick_after_map(*this);
 	unit_instance_manager.tick();
-	market_instance.execute_orders();
 
 	if (today.is_month_start()) {
 		market_instance.record_price_history();


### PR DESCRIPTION
country_manager_tick_after_map expects the market to have excuted all orders and all taxes to have been levied.
This is because it needs to compare the budget at the start of the tick with the budget at the end of the tick to calculate the balance.