### PR TITLE
Add fmt specifier parsing to fixed_point_t

### DIFF
--- a/src/openvic-simulation/types/fixed_point/FixedPoint.cpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.cpp
@@ -1,14 +1,52 @@
 #include "FixedPoint.hpp"
 
+#include <fmt/base.h>
 #include <fmt/format.h>
 
 using namespace OpenVic;
 
-auto fmt::formatter<fixed_point_t>::format(fixed_point_t fp, format_context& ctx) const -> format_context::iterator {
-	fixed_point_t::stack_string result = fp.to_array();
-	if (OV_unlikely(result.empty())) {
-		return formatter<string_view>::format(string_view {}, ctx);
+fmt::format_context::iterator fmt::formatter<fixed_point_t>::format(fixed_point_t fp, format_context& ctx) const {
+	format_specs specs { _specs };
+	if (_specs.dynamic()) {
+		detail::handle_dynamic_spec(_specs.dynamic_precision(), specs.precision, _specs.precision_ref, ctx);
+		detail::handle_dynamic_spec(_specs.dynamic_width(), specs.width, _specs.width_ref, ctx);
 	}
 
-	return formatter<string_view>::format(string_view { result.data(), result.size() }, ctx);
+	fixed_point_t::stack_string result = fp.to_array(specs.precision);
+	if (OV_unlikely(result.empty())) {
+		return ctx.out();
+	}
+
+	string_view view { result.data(), result.size() };
+
+	sign s = fp.is_negative() ? sign::minus : _specs.sign();
+
+	format_context::iterator out = ctx.out();
+	if (_specs.align() == align::numeric && s != sign::none) {
+		if (s == sign::minus) {
+			view = { view.data() + 1, view.size() - 1 };
+		}
+
+		*out++ = detail::getsign<char>(s);
+		s = sign::none;
+		if (specs.width != 0) {
+			--specs.width;
+		}
+	}
+	// Prevents string precision behavior
+	specs.precision = -1;
+
+	if (s == sign::none || s == sign::minus) {
+		return detail::write<char>(out, view, specs, ctx.locale());
+	}
+
+	memory_buffer buffer;
+	buffer.resize(view.size() + 1);
+
+	decltype(buffer)::value_type* buf_out = buffer.data();
+	*buf_out++ = detail::getsign<char>(s);
+	buf_out = detail::write(buf_out, view);
+
+	view = { buffer.data(), buffer.size() };
+	return detail::write<char>(out, view, specs, ctx.locale());
 }

--- a/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPoint.hpp
@@ -10,7 +10,8 @@
 #include <string_view>
 #include <system_error>
 
-#include <fmt/core.h>
+#include <fmt/base.h>
+#include <fmt/format.h>
 
 #include "openvic-simulation/types/StackString.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
@@ -743,6 +744,29 @@ namespace OpenVic {
 }
 
 template<>
-struct fmt::formatter<OpenVic::fixed_point_t> : formatter<string_view> {
+struct fmt::formatter<OpenVic::fixed_point_t> {
+	constexpr format_parse_context::iterator parse(format_parse_context& ctx) {
+		if (ctx.begin() == ctx.end() || *ctx.begin() == '}') {
+			return ctx.begin();
+		}
+
+		format_parse_context::iterator end = parse_format_specs(ctx.begin(), ctx.end(), _specs, ctx, detail::type::double_type);
+
+		if (_specs.type() == presentation_type::general) {
+			report_error("OpenVic::fixed_point_t does not support 'g' or 'G' specifiers");
+		} else if (_specs.type() == presentation_type::exp) {
+			report_error("OpenVic::fixed_point_t does not support 'e' or 'E' specifiers");
+		} else if (_specs.type() == presentation_type::fixed) {
+			report_error("OpenVic::fixed_point_t does not support 'f' or 'F' specifiers");
+		} else if (_specs.type() == presentation_type::hexfloat) {
+			report_error("OpenVic::fixed_point_t does not support 'a' or 'A' specifiers");
+		}
+
+		return end;
+	}
+
 	format_context::iterator format(OpenVic::fixed_point_t fp, format_context& ctx) const;
+
+private:
+	fmt::detail::dynamic_format_specs<char> _specs;
 };

--- a/tests/src/types/FixedPoint.cpp
+++ b/tests/src/types/FixedPoint.cpp
@@ -285,3 +285,125 @@ TEST_CASE("fixed_point_t Operators", "[fixed_point_t][fixed_point_t-operators]")
 		fixed_point_t::parse_raw(1)
 	);
 }
+
+TEST_CASE("fixed_point_t Formatting", "[fixed_point_t][fixed_point_t-formatting]") {
+	static constexpr fixed_point_t decimal1 = fixed_point_t::_2 + fixed_point_t::_0_20 + fixed_point_t::_0_10;
+	static constexpr fixed_point_t int1 = 4;
+
+	CHECK(fmt::format("{}", decimal1) == "2.29998779296875"sv);
+	CHECK(fmt::format("{}", int1) == "4"sv);
+
+	CHECK(fmt::format("{:.0}", decimal1) == "2"sv);
+	CHECK(fmt::format("{:.0}", int1) == "4"sv);
+	CHECK(fmt::format("{:.0}", -decimal1) == "-2"sv);
+	CHECK(fmt::format("{:.0}", -int1) == "-4"sv);
+	CHECK(fmt::format("{:.1}", decimal1) == "2.3"sv);
+	CHECK(fmt::format("{:.1}", int1) == "4.0"sv);
+	CHECK(fmt::format("{:.1}", -decimal1) == "-2.3"sv);
+	CHECK(fmt::format("{:.1}", -int1) == "-4.0"sv);
+	CHECK(fmt::format("{:.2}", decimal1) == "2.30"sv);
+	CHECK(fmt::format("{:.2}", int1) == "4.00"sv);
+	CHECK(fmt::format("{:.2}", -decimal1) == "-2.30"sv);
+	CHECK(fmt::format("{:.2}", -int1) == "-4.00"sv);
+	CHECK(fmt::format("{:.3}", decimal1) == "2.300"sv);
+	CHECK(fmt::format("{:.3}", int1) == "4.000"sv);
+	CHECK(fmt::format("{:.3}", -decimal1) == "-2.300"sv);
+	CHECK(fmt::format("{:.3}", -int1) == "-4.000"sv);
+	CHECK(fmt::format("{:.4}", decimal1) == "2.3000"sv);
+	CHECK(fmt::format("{:.4}", int1) == "4.0000"sv);
+	CHECK(fmt::format("{:.4}", -decimal1) == "-2.3000"sv);
+	CHECK(fmt::format("{:.4}", -int1) == "-4.0000"sv);
+	CHECK(fmt::format("{:.5}", decimal1) == "2.29998"sv);
+	CHECK(fmt::format("{:.5}", int1) == "4.00000"sv);
+	CHECK(fmt::format("{:.5}", -decimal1) == "-2.29998"sv);
+	CHECK(fmt::format("{:.5}", -int1) == "-4.00000"sv);
+
+	CHECK(fmt::format("{: .0}", decimal1) == " 2"sv);
+	CHECK(fmt::format("{: .0}", int1) == " 4"sv);
+	CHECK(fmt::format("{: .0}", -decimal1) == "-2"sv);
+	CHECK(fmt::format("{: .0}", -int1) == "-4"sv);
+	CHECK(fmt::format("{: .1}", decimal1) == " 2.3"sv);
+	CHECK(fmt::format("{: .1}", int1) == " 4.0"sv);
+	CHECK(fmt::format("{: .1}", -decimal1) == "-2.3"sv);
+	CHECK(fmt::format("{: .1}", -int1) == "-4.0"sv);
+	CHECK(fmt::format("{: .2}", decimal1) == " 2.30"sv);
+	CHECK(fmt::format("{: .2}", int1) == " 4.00"sv);
+	CHECK(fmt::format("{: .2}", -decimal1) == "-2.30"sv);
+	CHECK(fmt::format("{: .2}", -int1) == "-4.00"sv);
+	CHECK(fmt::format("{: .3}", decimal1) == " 2.300"sv);
+	CHECK(fmt::format("{: .3}", int1) == " 4.000"sv);
+	CHECK(fmt::format("{: .3}", -decimal1) == "-2.300"sv);
+	CHECK(fmt::format("{: .3}", -int1) == "-4.000"sv);
+	CHECK(fmt::format("{: .4}", decimal1) == " 2.3000"sv);
+	CHECK(fmt::format("{: .4}", int1) == " 4.0000"sv);
+	CHECK(fmt::format("{: .4}", -decimal1) == "-2.3000"sv);
+	CHECK(fmt::format("{: .4}", -int1) == "-4.0000"sv);
+	CHECK(fmt::format("{: .5}", decimal1) == " 2.29998"sv);
+	CHECK(fmt::format("{: .5}", int1) == " 4.00000"sv);
+	CHECK(fmt::format("{: .5}", -decimal1) == "-2.29998"sv);
+	CHECK(fmt::format("{: .5}", -int1) == "-4.00000"sv);
+
+	CHECK(fmt::format("{:+.0}", decimal1) == "+2"sv);
+	CHECK(fmt::format("{:+.0}", int1) == "+4"sv);
+	CHECK(fmt::format("{:+.0}", -decimal1) == "-2"sv);
+	CHECK(fmt::format("{:+.0}", -int1) == "-4"sv);
+	CHECK(fmt::format("{:+.1}", decimal1) == "+2.3"sv);
+	CHECK(fmt::format("{:+.1}", int1) == "+4.0"sv);
+	CHECK(fmt::format("{:+.1}", -decimal1) == "-2.3"sv);
+	CHECK(fmt::format("{:+.1}", -int1) == "-4.0"sv);
+	CHECK(fmt::format("{:+.2}", decimal1) == "+2.30"sv);
+	CHECK(fmt::format("{:+.2}", int1) == "+4.00"sv);
+	CHECK(fmt::format("{:+.2}", -decimal1) == "-2.30"sv);
+	CHECK(fmt::format("{:+.2}", -int1) == "-4.00"sv);
+	CHECK(fmt::format("{:+.3}", decimal1) == "+2.300"sv);
+	CHECK(fmt::format("{:+.3}", int1) == "+4.000"sv);
+	CHECK(fmt::format("{:+.3}", -decimal1) == "-2.300"sv);
+	CHECK(fmt::format("{:+.3}", -int1) == "-4.000"sv);
+	CHECK(fmt::format("{:+.4}", decimal1) == "+2.3000"sv);
+	CHECK(fmt::format("{:+.4}", int1) == "+4.0000"sv);
+	CHECK(fmt::format("{:+.4}", -decimal1) == "-2.3000"sv);
+	CHECK(fmt::format("{:+.4}", -int1) == "-4.0000"sv);
+	CHECK(fmt::format("{:+.5}", decimal1) == "+2.29998"sv);
+	CHECK(fmt::format("{:+.5}", int1) == "+4.00000"sv);
+	CHECK(fmt::format("{:+.5}", -decimal1) == "-2.29998"sv);
+	CHECK(fmt::format("{:+.5}", -int1) == "-4.00000"sv);
+
+	CHECK(fmt::format("{:A< 10.5}", decimal1) == " 2.29998AA"sv);
+	CHECK(fmt::format("{:A< 10.5}", int1) == " 4.00000AA"sv);
+	CHECK(fmt::format("{:A> 10.5}", decimal1) == "AA 2.29998"sv);
+	CHECK(fmt::format("{:A> 10.5}", int1) == "AA 4.00000"sv);
+	CHECK(fmt::format("{:A^ 10.5}", decimal1) == "A 2.29998A"sv);
+	CHECK(fmt::format("{:A^ 10.5}", int1) == "A 4.00000A"sv);
+
+	CHECK(fmt::format("{:A<10.5}", decimal1) == "2.29998AAA"sv);
+	CHECK(fmt::format("{:A<10.5}", int1) == "4.00000AAA"sv);
+	CHECK(fmt::format("{:A>10.5}", decimal1) == "AAA2.29998"sv);
+	CHECK(fmt::format("{:A>10.5}", int1) == "AAA4.00000"sv);
+	CHECK(fmt::format("{:A^10.5}", decimal1) == "A2.29998AA"sv);
+	CHECK(fmt::format("{:A^10.5}", int1) == "A4.00000AA"sv);
+
+	CHECK(fmt::format("{:A<10.5}", -decimal1) == "-2.29998AA"sv);
+	CHECK(fmt::format("{:A<10.5}", -int1) == "-4.00000AA"sv);
+	CHECK(fmt::format("{:A>10.5}", -decimal1) == "AA-2.29998"sv);
+	CHECK(fmt::format("{:A>10.5}", -int1) == "AA-4.00000"sv);
+	CHECK(fmt::format("{:A^10.5}", -decimal1) == "A-2.29998A"sv);
+	CHECK(fmt::format("{:A^10.5}", -int1) == "A-4.00000A"sv);
+
+	int prec = 8;
+	int width = 12;
+	CHECK(fmt::format("{:A^{}.{}}", -decimal1, width, prec) == "-2.29998779A"sv);
+	++prec;
+	CHECK(fmt::format("{:A^{}.{}}", -decimal1, width, prec) == "-2.299987792"sv);
+	++width;
+	CHECK(fmt::format("{:A^{}.{}}", -decimal1, width, prec) == "-2.299987792A"sv);
+	prec -= 2;
+	CHECK(fmt::format("{:A^{}.{}}", -decimal1, width, prec) == "A-2.2999877AA"sv);
+	width += 2;
+	CHECK(fmt::format("{:A^{}.{}}", -decimal1, width, prec) == "AA-2.2999877AAA"sv);
+	CHECK(fmt::format("{0:A^{2}.{1}}", -decimal1, prec, width) == "AA-2.2999877AAA"sv);
+
+	CHECK(fmt::format("{:010.5}", -decimal1) == "-002.29998"sv);
+	CHECK(fmt::format("{:010.5}", decimal1) == "0002.29998"sv);
+	CHECK(fmt::format("{: 010.5}", decimal1) == " 002.29998"sv);
+	CHECK(fmt::format("{:+010.5}", decimal1) == "+002.29998"sv);
+}


### PR DESCRIPTION
Add tests for fixed_point_t specifier parsing

### Supports
- precision
- dynamic precision
- width
- dynamic width
- empty alignment
- fill alignment
- sign specifiers (`+`, `-`, ` `)
- sign-aware zero padding

Note: All supported specifiers adhere to [fmt's format specification syntax](https://fmt.dev/11.2/syntax/#format-specification-mini-language).