### PR TITLE
Add iterators to vector types

### DIFF
--- a/src/openvic-simulation/types/Vector.hpp
+++ b/src/openvic-simulation/types/Vector.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cmath>
+#include <iterator>
 
+#include "openvic-simulation/types/BasicIterator.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/utility/Utility.hpp"
 

--- a/src/openvic-simulation/types/VectorN.inc
+++ b/src/openvic-simulation/types/VectorN.inc
@@ -35,6 +35,11 @@ namespace OpenVic {
 
 		using type = T;
 
+		using iterator = basic_iterator<type*, VEC_TYPE>;
+		using const_iterator = basic_iterator<type const*, VEC_TYPE>;
+		using reverse_iterator = std::reverse_iterator<iterator>;
+		using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
 #define VEC_COMPONENT_ONE(v) 1
 		static constexpr std::integral_constant<std::size_t, FOR_VEC_COMPONENTS(VEC_COMPONENT_ONE, +)> size = {};
 #undef VEC_COMPONENT_ONE
@@ -46,6 +51,54 @@ namespace OpenVic {
 
 			T components[size];
 		};
+
+		constexpr iterator begin() {
+			return iterator(components);
+		}
+
+		constexpr const_iterator begin() const {
+			return const_iterator(components);
+		}
+
+		constexpr const_iterator cbegin() const {
+			return begin();
+		}
+
+		constexpr iterator end() {
+			return iterator(components + size());
+		}
+
+		constexpr const_iterator end() const {
+			return const_iterator(components + size());
+		}
+
+		constexpr const_iterator cend() const {
+			return end();
+		}
+
+		constexpr reverse_iterator rbegin() {
+			return reverse_iterator(end());
+		}
+
+		constexpr const_reverse_iterator rbegin() const {
+			return const_reverse_iterator(end());
+		}
+
+		constexpr const_reverse_iterator crbegin() const {
+			return rbegin();
+		}
+
+		constexpr reverse_iterator rend() {
+			return reverse_iterator(begin());
+		}
+
+		constexpr const_reverse_iterator rend() const {
+			return const_reverse_iterator(begin());
+		}
+
+		constexpr const_reverse_iterator crend() const {
+			return rend();
+		}
 
 #define VEC_CONSTRUCTOR_ARG(v) T new_##v
 #define VEC_CONSTRUCTOR_INITIALISE(v) v { new_##v }

--- a/tests/src/types/Vector2.cpp
+++ b/tests/src/types/Vector2.cpp
@@ -73,6 +73,40 @@ TEMPLATE_LIST_TEST_CASE("vec2_t Linear algebra methods", "[vec2_t][vec2_t-linear
 	CONSTEXPR_CHECK(vec2_t<TestType>(-a.x, a.y).dot(vec2_t<TestType>(b.x, -b.y)) == -47);
 }
 
+TEMPLATE_LIST_TEST_CASE("vec2_t Iterator", "[vec2_t][vec2_t-iterator]", VectorValueTypes) {
+	static constexpr vec2_t<TestType> vector1 = vec2_t<TestType>(5, 4);
+
+	CONSTEXPR_CHECK(vector1.begin() == typename vec2_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.end() == typename vec2_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.cbegin() == typename vec2_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.cend() == typename vec2_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.rbegin() == typename vec2_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.rend() == typename vec2_t<TestType>::const_reverse_iterator(vector1.begin()));
+	CONSTEXPR_CHECK(vector1.crbegin() == typename vec2_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.crend() == typename vec2_t<TestType>::const_reverse_iterator(vector1.begin()));
+
+	for (size_t i = 0; TestType const& v : vector1) {
+		CHECK(vector1[i] == v);
+		++i;
+	}
+
+	vec2_t<TestType> vector2 = vector1;
+	CONSTEXPR_CHECK(vector2.begin() == typename vec2_t<TestType>::iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.end() == typename vec2_t<TestType>::iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.cbegin() == typename vec2_t<TestType>::const_iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.cend() == typename vec2_t<TestType>::const_iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.rbegin() == typename vec2_t<TestType>::reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.rend() == typename vec2_t<TestType>::reverse_iterator(vector2.begin()));
+	CONSTEXPR_CHECK(vector2.crbegin() == typename vec2_t<TestType>::const_reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.crend() == typename vec2_t<TestType>::const_reverse_iterator(vector2.begin()));
+
+	for (TestType& v : vector2) {
+		v *= 2;
+	}
+
+	CHECK(vector2 == vector1 * 2);
+}
+
 TEST_CASE("fvec2_t Length methods", "[vec2_t][fvec2_t][fvec2_t-length]") {
 	static constexpr fvec2_t vector1 = fvec2_t(10, 10);
 	static constexpr fvec2_t vector2 = fvec2_t(20, 30);

--- a/tests/src/types/Vector3.cpp
+++ b/tests/src/types/Vector3.cpp
@@ -63,6 +63,40 @@ TEMPLATE_LIST_TEST_CASE("vec3_t Linear algebra methods", "[vec3_t][vec3_t-linear
 	CONSTEXPR_CHECK(vec3_t<TestType>(-a.x, a.y, -a.z).dot(vec3_t<TestType>(b.x, -b.y, b.z)) == -61);
 }
 
+TEMPLATE_LIST_TEST_CASE("vec3_t Iterator", "[vec3_t][vec3_t-iterator]", VectorValueTypes) {
+	static constexpr vec3_t<TestType> vector1 = vec3_t<TestType>(5, 4, 7);
+
+	CONSTEXPR_CHECK(vector1.begin() == typename vec3_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.end() == typename vec3_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.cbegin() == typename vec3_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.cend() == typename vec3_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.rbegin() == typename vec3_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.rend() == typename vec3_t<TestType>::const_reverse_iterator(vector1.begin()));
+	CONSTEXPR_CHECK(vector1.crbegin() == typename vec3_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.crend() == typename vec3_t<TestType>::const_reverse_iterator(vector1.begin()));
+
+	for (size_t i = 0; TestType const& v : vector1) {
+		CHECK(vector1[i] == v);
+		++i;
+	}
+
+	vec3_t<TestType> vector2 = vector1;
+	CONSTEXPR_CHECK(vector2.begin() == typename vec3_t<TestType>::iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.end() == typename vec3_t<TestType>::iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.cbegin() == typename vec3_t<TestType>::const_iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.cend() == typename vec3_t<TestType>::const_iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.rbegin() == typename vec3_t<TestType>::reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.rend() == typename vec3_t<TestType>::reverse_iterator(vector2.begin()));
+	CONSTEXPR_CHECK(vector2.crbegin() == typename vec3_t<TestType>::const_reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.crend() == typename vec3_t<TestType>::const_reverse_iterator(vector2.begin()));
+
+	for (TestType& v : vector2) {
+		v *= 2;
+	}
+
+	CHECK(vector2 == vector1 * 2);
+}
+
 TEST_CASE("fvec3_t Length methods", "[vec3_t][fvec3_t][fvec3_t-length]") {
 	static constexpr fvec3_t vector1 = fvec3_t(10, 10, 10);
 	static constexpr fvec3_t vector2 = fvec3_t(20, 30, 40);

--- a/tests/src/types/Vector4.cpp
+++ b/tests/src/types/Vector4.cpp
@@ -62,6 +62,40 @@ TEMPLATE_LIST_TEST_CASE("vec4_t Linear algebra methods", "[vec4_t][vec4_t-linear
 	CONSTEXPR_CHECK(vec4_t<TestType>(-a.x, a.y, -a.z, a.w).dot(vec4_t<TestType>(b.x, -b.y, b.z, b.w)) == -43);
 }
 
+TEMPLATE_LIST_TEST_CASE("vec4_t Iterator", "[vec4_t][vec4_t-iterator]", VectorValueTypes) {
+	static constexpr vec4_t<TestType> vector1 = vec4_t<TestType>(5, 4, 7, 2);
+
+	CONSTEXPR_CHECK(vector1.begin() == typename vec4_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.end() == typename vec4_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.cbegin() == typename vec4_t<TestType>::const_iterator(vector1.components));
+	CONSTEXPR_CHECK(vector1.cend() == typename vec4_t<TestType>::const_iterator(vector1.components + vector1.size()));
+	CONSTEXPR_CHECK(vector1.rbegin() == typename vec4_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.rend() == typename vec4_t<TestType>::const_reverse_iterator(vector1.begin()));
+	CONSTEXPR_CHECK(vector1.crbegin() == typename vec4_t<TestType>::const_reverse_iterator(vector1.end()));
+	CONSTEXPR_CHECK(vector1.crend() == typename vec4_t<TestType>::const_reverse_iterator(vector1.begin()));
+
+	for (size_t i = 0; TestType const& v : vector1) {
+		CHECK(vector1[i] == v);
+		++i;
+	}
+
+	vec4_t<TestType> vector2 = vector1;
+	CONSTEXPR_CHECK(vector2.begin() == typename vec4_t<TestType>::iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.end() == typename vec4_t<TestType>::iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.cbegin() == typename vec4_t<TestType>::const_iterator(vector2.components));
+	CONSTEXPR_CHECK(vector2.cend() == typename vec4_t<TestType>::const_iterator(vector2.components + vector2.size()));
+	CONSTEXPR_CHECK(vector2.rbegin() == typename vec4_t<TestType>::reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.rend() == typename vec4_t<TestType>::reverse_iterator(vector2.begin()));
+	CONSTEXPR_CHECK(vector2.crbegin() == typename vec4_t<TestType>::const_reverse_iterator(vector2.end()));
+	CONSTEXPR_CHECK(vector2.crend() == typename vec4_t<TestType>::const_reverse_iterator(vector2.begin()));
+
+	for (TestType& v : vector2) {
+		v *= 2;
+	}
+
+	CHECK(vector2 == vector1 * 2);
+}
+
 TEST_CASE("fvec4_t Length methods", "[vec4_t][fvec4_t][fvec4_t-length]") {
 	static constexpr fvec4_t vector1 = fvec4_t(10, 10, 10, 10);
 	static constexpr fvec4_t vector2 = fvec4_t(20, 30, 40, 50);


### PR DESCRIPTION
Add vector iterator tests

This also enables vector types to support [fmt's range format specifications](https://fmt.dev/11.2/syntax/#range-format-specifications) if `fmt/ranges.h` is included.