### PR TITLE
Parallelise country ticks

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -30,26 +30,31 @@ InstanceManager::InstanceManager(
 	},
 	global_flags { "global" },
 	country_instance_manager {
+		thread_pool,
 		new_definition_manager.get_country_definition_manager(),
 		new_definition_manager.get_modifier_manager().get_modifier_effect_cache(),
+		new_definition_manager.get_define_manager().get_end_date(),
 		new_definition_manager.get_define_manager().get_country_defines(),
+		new_definition_manager.get_define_manager().get_diplomacy_defines(),
+		new_definition_manager.get_define_manager().get_economy_defines(),
+		new_definition_manager.get_define_manager().get_military_defines(),
 		new_definition_manager.get_define_manager().get_pops_defines(),
-		definition_manager.get_economy_manager().get_building_type_manager().get_building_types(),
-		definition_manager.get_research_manager().get_technology_manager().get_technologies(),
-		definition_manager.get_research_manager().get_invention_manager().get_inventions(),
-		definition_manager.get_politics_manager().get_issue_manager().get_reform_groups(),
-		definition_manager.get_politics_manager().get_government_type_manager().get_government_types(),
-		definition_manager.get_crime_manager().get_crime_modifiers(),
+		new_definition_manager.get_economy_manager().get_building_type_manager().get_building_types(),
+		new_definition_manager.get_research_manager().get_technology_manager().get_technologies(),
+		new_definition_manager.get_research_manager().get_invention_manager().get_inventions(),
+		new_definition_manager.get_politics_manager().get_issue_manager().get_reform_groups(),
+		new_definition_manager.get_politics_manager().get_government_type_manager().get_government_types(),
+		new_definition_manager.get_crime_manager().get_crime_modifiers(),
 		good_instance_manager.get_good_instances(),
-		definition_manager.get_military_manager().get_unit_type_manager().get_regiment_types(),
-		definition_manager.get_military_manager().get_unit_type_manager().get_ship_types(),
-		definition_manager.get_pop_manager().get_stratas(),
-		definition_manager.get_pop_manager().get_pop_types(),
-		definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
+		new_definition_manager.get_military_manager().get_unit_type_manager().get_regiment_types(),
+		new_definition_manager.get_military_manager().get_unit_type_manager().get_ship_types(),
+		new_definition_manager.get_pop_manager().get_stratas(),
+		new_definition_manager.get_pop_manager().get_pop_types(),
+		new_definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
 		new_game_rules_manager,
 		country_relation_manager,
 		good_instance_manager,
-		definition_manager.get_define_manager().get_economy_defines()
+		new_definition_manager.get_military_manager().get_unit_type_manager()
 	},
 	unit_instance_manager {
 		new_definition_manager.get_pop_manager().get_culture_manager(),
@@ -106,7 +111,7 @@ void InstanceManager::update_gamestate() {
 
 	// Update gamestate...
 	map_instance.update_gamestate(*this);
-	country_instance_manager.update_gamestate(*this);
+	country_instance_manager.update_gamestate(today, map_instance);
 	unit_instance_manager.update_gamestate();
 
 	gamestate_updated();
@@ -125,10 +130,10 @@ void InstanceManager::tick() {
 	SPDLOG_INFO("Tick: {}", today);
 
 	// Tick...
-	country_instance_manager.country_manager_tick_before_map(*this);
+	country_instance_manager.country_manager_tick_before_map();
 	map_instance.map_tick();
 	market_instance.execute_orders();
-	country_instance_manager.country_manager_tick_after_map(*this);
+	country_instance_manager.country_manager_tick_after_map();
 	unit_instance_manager.tick();
 
 	if (today.is_month_start()) {
@@ -172,10 +177,10 @@ bool InstanceManager::setup() {
 
 	thread_pool.initialise_threadpool(
 		definition_manager.get_define_manager().get_pops_defines(),
-		country_instance_manager.get_country_instances(),
 		good_instance_manager.get_good_definition_manager().get_good_definitions(),
 		definition_manager.get_pop_manager().get_stratas(),
 		good_instance_manager.get_good_instances(),
+		country_instance_manager.get_country_instances(),
 		map_instance.get_province_instances()
 	);
 
@@ -244,7 +249,7 @@ bool InstanceManager::load_bookmark(Bookmark const* new_bookmark) {
 
 	update_modifier_sums();
 	map_instance.initialise_for_new_game(*this);
-	country_instance_manager.update_gamestate(*this);
+	country_instance_manager.update_gamestate(today, map_instance);
 	market_instance.execute_orders();
 
 	return ret;

--- a/src/openvic-simulation/country/SharedCountryValues.cpp
+++ b/src/openvic-simulation/country/SharedCountryValues.cpp
@@ -9,13 +9,11 @@
 using namespace OpenVic;
 
 SharedCountryValues::SharedCountryValues(
-	ModifierEffectCache const& new_modifier_effect_cache,
-	CountryDefines const& new_country_defines,
 	PopsDefines const& new_pop_defines,
+	GoodInstanceManager const& new_good_instance_manager,
 	decltype(shared_pop_type_values)::keys_span_type pop_type_keys
-) : modifier_effect_cache { new_modifier_effect_cache },
-	country_defines { new_country_defines },
-	pop_defines { new_pop_defines },
+) : pop_defines { new_pop_defines },
+	good_instance_manager { new_good_instance_manager },
 	shared_pop_type_values { pop_type_keys }
 	{}
 
@@ -23,7 +21,7 @@ SharedPopTypeValues& SharedCountryValues::get_shared_pop_type_values(PopType con
 	return shared_pop_type_values.at(pop_type);
 }
 
-void SharedCountryValues::update_costs(GoodInstanceManager const& good_instance_manager) {
+void SharedCountryValues::update_costs() {
 	for (SharedPopTypeValues& value : shared_pop_type_values.get_values()) {
 		value.update_costs(pop_defines, good_instance_manager);
 	}

--- a/src/openvic-simulation/country/SharedCountryValues.hpp
+++ b/src/openvic-simulation/country/SharedCountryValues.hpp
@@ -7,10 +7,8 @@
 #include "openvic-simulation/utility/reactive/MutableState.hpp"
 
 namespace OpenVic {
-	struct CountryDefines;
 	struct CountryInstanceManager;
 	struct GoodInstanceManager;
-	struct ModifierEffectCache;
 	struct PopsDefines;
 	struct PopType;
 	struct SharedCountryValues;
@@ -37,20 +35,18 @@ namespace OpenVic {
 	struct SharedCountryValues {
 		friend CountryInstanceManager;
 	private:
-		ModifierEffectCache const& PROPERTY(modifier_effect_cache);
-		CountryDefines const& PROPERTY(country_defines);
 		PopsDefines const& pop_defines;
+		GoodInstanceManager const& good_instance_manager;
 		IndexedFlatMap<PopType, SharedPopTypeValues> shared_pop_type_values;
 
-		void update_costs(GoodInstanceManager const& good_instance_manager);
+		void update_costs();
 
 	public:
 		SharedPopTypeValues& get_shared_pop_type_values(PopType const& pop_type);
 
 		SharedCountryValues(
-			ModifierEffectCache const& new_modifier_effect_cache,
-			CountryDefines const& new_country_defines,
 			PopsDefines const& new_pop_defines,
+			GoodInstanceManager const& new_good_instance_manager,
 			decltype(shared_pop_type_values)::keys_span_type pop_type_keys
 		);
 		SharedCountryValues(SharedCountryValues&&) = delete;

--- a/src/openvic-simulation/misc/GameAction.cpp
+++ b/src/openvic-simulation/misc/GameAction.cpp
@@ -400,7 +400,7 @@ bool GameActionManager::game_action_callback_start_research(game_action_argument
 
 	Technology const* old_research = country->get_current_research_untracked();
 
-	country->start_research(*technology, instance_manager);
+	country->start_research(*technology, instance_manager.get_today());
 
 	return old_research != country->get_current_research_untracked();
 }

--- a/src/openvic-simulation/utility/ThreadPool.hpp
+++ b/src/openvic-simulation/utility/ThreadPool.hpp
@@ -23,7 +23,9 @@ namespace OpenVic {
 			NONE,
 			GOOD_EXECUTE_ORDERS,
 			PROVINCE_INITIALISE_FOR_NEW_GAME,
-			PROVINCE_TICK
+			PROVINCE_TICK,
+			COUNTRY_TICK_BEFORE_MAP,
+			COUNTRY_TICK_AFTER_MAP
 		};
 
 		void loop_until_cancelled(
@@ -33,6 +35,7 @@ namespace OpenVic {
 			utility::forwardable_span<const GoodDefinition> good_keys,
 			utility::forwardable_span<const Strata> strata_keys,
 			utility::forwardable_span<GoodInstance> goods_chunk,
+			utility::forwardable_span<CountryInstance> countries_chunk,
 			utility::forwardable_span<ProvinceInstance> provinces_chunk
 		);
 
@@ -55,15 +58,17 @@ namespace OpenVic {
 
 		void initialise_threadpool(
 			PopsDefines const& pop_defines,
-			utility::forwardable_span<const CountryInstance> country_keys,
 			utility::forwardable_span<const GoodDefinition> good_keys,
 			utility::forwardable_span<const Strata> strata_keys,			
 			utility::forwardable_span<GoodInstance> goods,
+			utility::forwardable_span<CountryInstance> countries,
 			utility::forwardable_span<ProvinceInstance> provinces
 		);
 
 		void process_good_execute_orders();
 		void process_province_ticks();
 		void process_province_initialise_for_new_game();
+		void process_country_ticks_before_map();
+		void process_country_ticks_after_map();
 	};
 }


### PR DESCRIPTION
Execute country ticks via threadpool so they can be parallelised.

Also cleaned up service locator pattern and stored managers as fields instead.
This reduces arguments for methods and standardises code.

I left `update_gamestate` out as it requires a `MapInstance&` to refresh the `neighbouring_countries`.
This seems like something the `MapInstance` could do. Also it's unclear to me why `neighbouring_countries` are non-const references. Parallelising `update_gamestate` deserves its own follow up PR.