### PR TITLE
Use 0 for comparisons instead of fixed_point_t::_0

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -183,7 +183,7 @@ CountryInstance::CountryInstance(
 	}},
 	research_progress{[this](DependencyTracker& tracker)->fixed_point_t {
 		const fixed_point_t current_research_cost_copy = current_research_cost.get(tracker);
-		return current_research_cost_copy > fixed_point_t::_0
+		return current_research_cost_copy > 0
 			? invested_research_points.get(tracker) / current_research_cost_copy
 			: fixed_point_t::_0;
 	}},
@@ -1296,7 +1296,7 @@ void CountryInstance::_update_production() {
 }
 
 static inline constexpr fixed_point_t nonzero_or_one(fixed_point_t const& value) {
-	return value == fixed_point_t::_0 ? fixed_point_t::_1 : value;
+	return value == 0 ? fixed_point_t::_1 : value;
 }
 
 void CountryInstance::_update_budget() {
@@ -1443,7 +1443,7 @@ void CountryInstance::_update_current_tech(const Date today) {
 	);
 
 	const fixed_point_t daily_research_points_copy = daily_research_points.get_untracked();
-	if (daily_research_points_copy > fixed_point_t::_0) {
+	if (daily_research_points_copy > 0) {
 		expected_research_completion_date.set(
 			today
 			+ static_cast<Timespan>(
@@ -1459,7 +1459,7 @@ void CountryInstance::_update_current_tech(const Date today) {
 }
 
 void CountryInstance::_update_technology(const Date today) {
-	if (research_point_stockpile.get_untracked() < fixed_point_t::_0) {
+	if (research_point_stockpile.get_untracked() < 0) {
 		research_point_stockpile.set(0);
 	}
 
@@ -1468,7 +1468,7 @@ void CountryInstance::_update_technology(const Date today) {
 		get_modifier_effect_value(*modifier_effect_cache.get_research_points_modifier()) +
 		get_modifier_effect_value(*modifier_effect_cache.get_increase_research());
 
-	if (daily_research_points.get_untracked() < fixed_point_t::_0) {
+	if (daily_research_points.get_untracked() < 0) {
 		daily_research_points.set(0);
 	}
 
@@ -1494,18 +1494,18 @@ void CountryInstance::_update_population() {
 	leadership_points_from_pop_types.clear();
 
 	for (auto const& [pop_type, pop_size] : get_population_by_type()) {
-		if (pop_type.get_research_leadership_optimum() > fixed_point_t::_0 && pop_size > 0) {
+		if (pop_type.get_research_leadership_optimum() > 0 && pop_size > 0) {
 			const fixed_point_t factor = std::min(
 				pop_size / (get_total_population() * pop_type.get_research_leadership_optimum()), fixed_point_t::_1
 			);
 
-			if (pop_type.get_research_points() != fixed_point_t::_0) {
+			if (pop_type.get_research_points() != 0) {
 				const fixed_point_t research_points = pop_type.get_research_points() * factor;
 				research_points_from_pop_types[&pop_type] = research_points;
 				daily_research_points += research_points;
 			}
 
-			if (pop_type.get_leadership_points() != fixed_point_t::_0) {
+			if (pop_type.get_leadership_points() != 0) {
 				const fixed_point_t leadership_points = pop_type.get_leadership_points() * factor;
 				leadership_points_from_pop_types[&pop_type] = leadership_points;
 				monthly_leadership_points = leadership_points;
@@ -1638,7 +1638,7 @@ void CountryInstance::_update_military() {
 	monthly_leadership_points *= fixed_point_t::_1 +
 		get_modifier_effect_value(*modifier_effect_cache.get_leadership_modifier());
 
-	if (monthly_leadership_points < fixed_point_t::_0) {
+	if (monthly_leadership_points < 0) {
 		monthly_leadership_points = 0;
 	}
 
@@ -1796,7 +1796,7 @@ void CountryInstance::update_gamestate(const Date today, MapInstance& map_instan
 			}
 		}
 
-		if (owned_cores_controlled_proportion != fixed_point_t::_0) {
+		if (owned_cores_controlled_proportion != 0) {
 			owned_cores_controlled_proportion /= owned_core_province_count;
 		}
 	}
@@ -1832,7 +1832,7 @@ void CountryInstance::update_gamestate(const Date today, MapInstance& map_instan
 		}
 	}
 
-	if (occupied_provinces_proportion != fixed_point_t::_0) {
+	if (occupied_provinces_proportion != 0) {
 		occupied_provinces_proportion /= owned_provinces.size();
 	}
 
@@ -2343,49 +2343,49 @@ void CountryInstance::request_salaries_and_welfare_and_import_subsidies(Pop& pop
 	const pop_size_t pop_size = pop.get_size();
 	SharedPopTypeValues const& pop_type_values = shared_country_values.get_shared_pop_type_values(pop_type);
 
-	if (actual_administration_budget > fixed_point_t::_0) {
+	if (actual_administration_budget > 0) {
 		const fixed_point_t administration_salary = fixed_point_t::mul_div(
 			pop_size * administration_salary_base_by_pop_type.at(pop_type).get_untracked(),
 			actual_administration_budget,
 			projected_administration_spending_unscaled_by_slider.get_untracked()
 		) / Pop::size_denominator;
-		if (administration_salary > fixed_point_t::_0) {
+		if (administration_salary > 0) {
 			pop.add_government_salary_administration(administration_salary);
 			actual_administration_spending += administration_salary;
 		}
 	}
 
-	if (actual_education_budget > fixed_point_t::_0) {
+	if (actual_education_budget > 0) {
 		const fixed_point_t education_salary = fixed_point_t::mul_div(
 			pop_size * education_salary_base_by_pop_type.at(pop_type).get_untracked(),
 			actual_education_budget,
 			projected_education_spending_unscaled_by_slider.get_untracked()
 		) / Pop::size_denominator;
-		if (education_salary > fixed_point_t::_0) {
+		if (education_salary > 0) {
 			pop.add_government_salary_education(education_salary);
 			actual_education_spending += education_salary;
 		}
 	}
 
-	if (actual_military_budget > fixed_point_t::_0) {
+	if (actual_military_budget > 0) {
 		const fixed_point_t military_salary = fixed_point_t::mul_div(
 			pop_size * military_salary_base_by_pop_type.at(pop_type).get_untracked(),
 			actual_military_budget,
 			projected_military_spending_unscaled_by_slider.get_untracked()
 		) / Pop::size_denominator;
-		if (military_salary > fixed_point_t::_0) {
+		if (military_salary > 0) {
 			pop.add_government_salary_military(military_salary);
 			actual_military_spending += military_salary;
 		}
 	}
 
-	if (actual_social_budget > fixed_point_t::_0) {
+	if (actual_social_budget > 0) {
 		const fixed_point_t pension_income = fixed_point_t::mul_div(
 			pop_size * calculate_pensions_base(pop_type),
 			actual_social_budget,
 			projected_social_spending_unscaled_by_slider.get_untracked()
 		) / Pop::size_denominator;
-		if (pension_income > fixed_point_t::_0) {
+		if (pension_income > 0) {
 			pop.add_pensions(pension_income);
 			actual_pensions_spending += pension_income;
 		}
@@ -2395,13 +2395,13 @@ void CountryInstance::request_salaries_and_welfare_and_import_subsidies(Pop& pop
 			actual_social_budget,
 			projected_social_spending_unscaled_by_slider.get_untracked()
 		) / Pop::size_denominator;
-		if (unemployment_subsidies > fixed_point_t::_0) {
+		if (unemployment_subsidies > 0) {
 			pop.add_unemployment_subsidies(unemployment_subsidies);
 			actual_unemployment_subsidies_spending += unemployment_subsidies;
 		}
 	}
 
-	if (actual_import_subsidies_budget > fixed_point_t::_0) {
+	if (actual_import_subsidies_budget > 0) {
 		const fixed_point_t import_subsidies = fixed_point_t::mul_div(
 			effective_tariff_rate.get_untracked() // < 0
 				* pop.get_yesterdays_import_value().get_copy_of_value(),

--- a/src/openvic-simulation/defines/Define.cpp
+++ b/src/openvic-simulation/defines/Define.cpp
@@ -25,7 +25,7 @@ bool DefineManager::load_defines_file(ast::NodeCPtr root) {
 
 	// TODO - move to MilitaryDefines?
 
-	if (military_defines.get_leader_recruit_cost() <= fixed_point_t::_0) {
+	if (military_defines.get_leader_recruit_cost() <= 0) {
 		spdlog::error_s(
 			"Invalid leader recruit cost: {} - must be greater than 0, changing to 1",
 			military_defines.get_leader_recruit_cost()

--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -57,7 +57,7 @@ void ArtisanalProducer::artisan_tick(
 		const fixed_point_t base_desired_quantity = it.value();
 		const ptrdiff_t i = it - input_goods.begin();
 		const fixed_point_t desired_quantity = demand_per_input[i] = base_desired_quantity * pop.get_size() / production_type.get_base_workforce_size();
-		if (desired_quantity == fixed_point_t::_0) {
+		if (desired_quantity == 0) {
 			continue;
 		}
 
@@ -87,13 +87,13 @@ void ArtisanalProducer::artisan_tick(
 		* inputs_bought_numerator * pop.get_size()
 		/ (inputs_bought_denominator * production_type.get_base_workforce_size());
 
-	if (current_production > fixed_point_t::_0) {
+	if (current_production > 0) {
 		if (country_to_report_economy_nullable != nullptr) {
 			country_to_report_economy_nullable->report_output(production_type, current_production);
 		}
 	}
 
-	if (inputs_bought_fraction > fixed_point_t::_0) {
+	if (inputs_bought_fraction > 0) {
 		for (auto it = input_goods.begin(); it < input_goods.end(); it++) {
 			GoodDefinition const& input_good = *it.key();
 			const fixed_point_t base_desired_quantity = it.value();
@@ -140,7 +140,7 @@ void ArtisanalProducer::artisan_tick(
 	const fixed_point_t total_cash_to_spend = pop.get_cash().get_copy_of_value() / max_cost_multiplier;
 	MarketInstance const& market_instance = pop.get_market_instance();
 
-	if (total_cash_to_spend > fixed_point_t::_0 && distinct_goods_to_buy > 0) {
+	if (total_cash_to_spend > 0 && distinct_goods_to_buy > 0) {
 		//Figure out the optimal amount of goods to buy based on their price, stockpiled quantiy & demand
 		fixed_point_t max_possible_satisfaction_numerator= 1,
 			max_possible_satisfaction_denominator= 1;
@@ -161,7 +161,7 @@ void ArtisanalProducer::artisan_tick(
 				total_stockpile_value += max_price * stockpile[&input_good];
 			}
 
-			if ( total_demand_value == fixed_point_t::_0) {
+			if ( total_demand_value == 0) {
 				max_possible_satisfaction_numerator = 1;
 				max_possible_satisfaction_denominator = 1;
 			} else {
@@ -208,7 +208,7 @@ void ArtisanalProducer::artisan_tick(
 			const fixed_point_t good_demand = demand_per_input[index_in_input_goods];
 			fixed_point_t& good_stockpile = stockpile[&input_good];
 			const fixed_point_t max_quantity_to_buy = good_demand - good_stockpile;
-			if (max_quantity_to_buy > fixed_point_t::_0) {
+			if (max_quantity_to_buy > 0) {
 				const fixed_point_t optimal_quantity = fixed_point_t::mul_div(
 					good_demand,
 					max_possible_satisfaction_numerator,
@@ -227,7 +227,7 @@ void ArtisanalProducer::artisan_tick(
 			}
 		}
 
-		if (OV_unlikely(debug_cash_left < fixed_point_t::_0)) {
+		if (OV_unlikely(debug_cash_left < 0)) {
 			spdlog::error_s("Artisan allocated more cash than the pop has. debug_cash_left: {}", debug_cash_left);
 		}
 	}
@@ -239,7 +239,7 @@ void ArtisanalProducer::artisan_tick(
 }
 
 fixed_point_t ArtisanalProducer::add_to_stockpile(GoodDefinition const& good, const fixed_point_t quantity) {
-	if (OV_unlikely(quantity < fixed_point_t::_0)) {
+	if (OV_unlikely(quantity < 0)) {
 		spdlog::error_s(
 			"Attempted to add negative quantity {} of {} to stockpile.",
 			quantity, good

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -73,7 +73,7 @@ void ResourceGatheringOperation::initialise_rgo_size_multiplier() {
 
 	const fixed_point_t size_modifier = calculate_size_modifier();
 	const fixed_point_t base_workforce_size = production_type.get_base_workforce_size();
-	if (size_modifier == fixed_point_t::_0) {
+	if (size_modifier == 0) {
 		size_multiplier = 0;
 	} else {
 		size_multiplier = ((total_worker_count_in_province / (size_modifier * base_workforce_size)).ceil() * fixed_point_t::_1_50).floor();
@@ -110,7 +110,7 @@ fixed_point_t ResourceGatheringOperation::calculate_size_modifier() const {
 	size_modifier += location.get_modifier_effect_value(
 		*modifier_effect_cache.get_good_effects(production_type.get_output_good()).get_rgo_size()
 	);
-	return size_modifier > fixed_point_t::_0 ? size_modifier : fixed_point_t::_0;
+	return size_modifier > 0 ? size_modifier : fixed_point_t::_0;
 }
 
 void ResourceGatheringOperation::rgo_tick(memory::vector<fixed_point_t>& reusable_vector) {
@@ -141,7 +141,7 @@ void ResourceGatheringOperation::rgo_tick(memory::vector<fixed_point_t>& reusabl
 	}
 
 	output_quantity_yesterday = produce();
-	if (output_quantity_yesterday > fixed_point_t::_0) {
+	if (output_quantity_yesterday > 0) {
 		CountryInstance* const country_to_report_economy_nullable = location.get_country_to_report_economy();
 		if (country_to_report_economy_nullable != nullptr) {
 			country_to_report_economy_nullable->report_output(production_type, output_quantity_yesterday);
@@ -217,7 +217,7 @@ void ResourceGatheringOperation::hire() {
 
 fixed_point_t ResourceGatheringOperation::produce() {
 	const fixed_point_t size_modifier = calculate_size_modifier();
-	if (size_modifier == fixed_point_t::_0){
+	if (size_modifier == 0){
 		return 0;
 	}
 
@@ -340,8 +340,8 @@ void ResourceGatheringOperation::pay_employees(memory::vector<fixed_point_t>& re
 
 	total_owner_income_cache = 0;
 	total_employee_income_cache = 0;
-	if (revenue <= fixed_point_t::_0 || total_worker_count_in_province_cache <= 0) {
-		if (revenue < fixed_point_t::_0) {
+	if (revenue <= 0 || total_worker_count_in_province_cache <= 0) {
+		if (revenue < 0) {
 			spdlog::error_s("Negative revenue for province {}", location);
 		}
 		if (total_worker_count_in_province_cache < 0) {
@@ -420,7 +420,7 @@ void ResourceGatheringOperation::pay_employees(memory::vector<fixed_point_t>& re
 				}
 				
 				const fixed_point_t minimum_wage = employee.get_minimum_wage_cached();
-				if (minimum_wage > fixed_point_t::_0 && incomes[i] == minimum_wage) {
+				if (minimum_wage > 0 && incomes[i] == minimum_wage) {
 					continue;
 				}
 
@@ -444,7 +444,7 @@ void ResourceGatheringOperation::pay_employees(memory::vector<fixed_point_t>& re
 				Employee& employee = employees[i];
 				Pop& employee_pop = employee.get_pop();
 				const fixed_point_t income_for_this_pop = incomes[i];
-				if (income_for_this_pop > fixed_point_t::_0) {
+				if (income_for_this_pop > 0) {
 					employee_pop.add_rgo_worker_income(income_for_this_pop);
 					total_employee_income_cache += income_for_this_pop;
 				}

--- a/src/openvic-simulation/economy/trading/GoodMarket.cpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.cpp
@@ -113,7 +113,7 @@ void GoodMarket::execute_orders(
 			new_price = std::min(max_next_price, max_affordable_price);
 		} else {
 			//TODO use Victoria 2's square root mechanic, see https://github.com/OpenVicProject/OpenVic/issues/288
-			if (demand_sum > fixed_point_t::_0) {
+			if (demand_sum > 0) {
 				new_price = max_next_price;
 			} else {
 				new_price = price;
@@ -152,7 +152,7 @@ void GoodMarket::execute_orders(
 
 			demand_sum += max_quantity;
 
-			if (money_to_spend <= fixed_point_t::_0) {
+			if (money_to_spend <= 0) {
 				purchasing_power_per_order[i] = 0;
 				continue;
 			}
@@ -230,7 +230,7 @@ void GoodMarket::execute_orders(
 			//sell below max_next_price
 			if (game_rules_manager.get_use_optimal_pricing()) {
 				//drop price while remaining_supply > 0 && new_price > min_next_price
-				while (remaining_supply > fixed_point_t::_0) {
+				while (remaining_supply > 0) {
 					const fixed_point_t possible_price = money_left_to_spend_sum / remaining_supply;
 
 					if (possible_price >= new_price) {
@@ -302,7 +302,7 @@ void GoodMarket::execute_orders(
 			for (GoodMarketSellOrder const& market_sell_order : market_sell_orders) {
 				const fixed_point_t quantity_sold = market_sell_order.get_quantity();
 				fixed_point_t money_gained;
-				if (quantity_sold == fixed_point_t::_0) {
+				if (quantity_sold == 0) {
 					money_gained = 0;
 				} else {
 					money_gained = std::max(
@@ -360,7 +360,7 @@ void GoodMarket::execute_orders(
 
 				const fixed_point_t quantity_sold = quantity_sold_domestically + fair_share_of_exports;
 				fixed_point_t money_gained;
-				if (quantity_sold == fixed_point_t::_0) {
+				if (quantity_sold == 0) {
 					money_gained = 0;
 				} else {
 					money_gained = std::max(
@@ -407,7 +407,7 @@ void GoodMarket::execute_buy_orders(
 		GoodBuyUpToOrder const& buy_up_to_order = buy_up_to_orders[i];
 		const fixed_point_t quantity_bought = quantity_bought_per_order[i];
 
-		if (quantity_bought == fixed_point_t::_0) {
+		if (quantity_bought == 0) {
 			buy_up_to_order.call_after_trade(BuyResult::no_purchase_result(good_definition));
 		} else {
 			quantity_traded_yesterday += quantity_bought;

--- a/src/openvic-simulation/map/TerrainType.cpp
+++ b/src/openvic-simulation/map/TerrainType.cpp
@@ -85,7 +85,7 @@ bool TerrainTypeManager::add_terrain_type(
 		return false;
 	}
 
-	if (movement_cost < fixed_point_t::_0) {
+	if (movement_cost < 0) {
 		spdlog::error_s(
 			"Invalid movement cost for terrain type \"{}\": {} (cannot be negative!)",
 			identifier, movement_cost

--- a/src/openvic-simulation/military/LeaderTrait.cpp
+++ b/src/openvic-simulation/military/LeaderTrait.cpp
@@ -32,7 +32,7 @@ bool LeaderTraitManager::setup_leader_prestige_modifier(
 
 	bool ret = true;
 
-	if (military_defines.get_leader_prestige_to_morale_factor() != fixed_point_t::_0) {
+	if (military_defines.get_leader_prestige_to_morale_factor() != 0) {
 		if (modifier_effect_cache.get_morale_leader() != nullptr) {
 			leader_prestige_modifier.set_effect(
 				*modifier_effect_cache.get_morale_leader(), military_defines.get_leader_prestige_to_morale_factor()
@@ -43,7 +43,7 @@ bool LeaderTraitManager::setup_leader_prestige_modifier(
 		}
 	}
 
-	if (military_defines.get_leader_prestige_to_max_org_factor() != fixed_point_t::_0) {
+	if (military_defines.get_leader_prestige_to_max_org_factor() != 0) {
 		if (modifier_effect_cache.get_organisation() != nullptr) {
 			leader_prestige_modifier.set_effect(
 				*modifier_effect_cache.get_organisation(), military_defines.get_leader_prestige_to_max_org_factor()

--- a/src/openvic-simulation/military/UnitInstanceGroup.cpp
+++ b/src/openvic-simulation/military/UnitInstanceGroup.cpp
@@ -209,11 +209,11 @@ bool UnitInstanceGroup::set_leader(LeaderInstance* new_leader) {
 
 // These values are only needed for the UI, so there's no need to pre-calculate and cache them for every unit on every update.
 fixed_point_t UnitInstanceGroup::get_organisation_proportion() const {
-	return total_max_organisation != fixed_point_t::_0 ? total_organisation / total_max_organisation : fixed_point_t::_0;
+	return total_max_organisation != 0 ? total_organisation / total_max_organisation : fixed_point_t::_0;
 }
 
 fixed_point_t UnitInstanceGroup::get_strength_proportion() const {
-	return total_max_strength != fixed_point_t::_0 ? total_strength / total_max_strength : fixed_point_t::_0;
+	return total_max_strength != 0 ? total_strength / total_max_strength : fixed_point_t::_0;
 }
 
 fixed_point_t UnitInstanceGroup::get_average_organisation() const {

--- a/src/openvic-simulation/modifier/ModifierSum.cpp
+++ b/src/openvic-simulation/modifier/ModifierSum.cpp
@@ -48,7 +48,7 @@ void ModifierSum::add_modifier(
 ) {
 	// We could test that excluded_targets != ALL_TARGETS, but in practice it's always
 	// called with an explcit/hardcoded value and so won't ever exclude everything.
-	if (multiplier != fixed_point_t::_0) {
+	if (multiplier != 0) {
 		modifier_entry_t const& new_entry = modifiers.emplace_back(
 			modifier,
 			multiplier,

--- a/src/openvic-simulation/modifier/ModifierSum.hpp
+++ b/src/openvic-simulation/modifier/ModifierSum.hpp
@@ -130,7 +130,7 @@ namespace OpenVic {
 			for (modifier_entry_t const& modifier_entry : modifiers) {
 				const fixed_point_t contribution = modifier_entry.get_modifier_effect_value(effect);
 
-				if (contribution != fixed_point_t::_0) {
+				if (contribution != 0) {
 					callback(modifier_entry, contribution);
 				}
 			}

--- a/src/openvic-simulation/modifier/ModifierValue.cpp
+++ b/src/openvic-simulation/modifier/ModifierValue.cpp
@@ -6,7 +6,7 @@ using namespace OpenVic;
 
 void ModifierValue::trim() {
 	erase_if(values, [](effect_map_t::value_type const& value) -> bool {
-		return value.second == fixed_point_t::_0;
+		return value.second == 0;
 	});
 }
 
@@ -109,7 +109,7 @@ void ModifierValue::multiply_add_exclude_targets(
 
 	if (multiplier == fixed_point_t::_1 && excluded_targets == NO_TARGETS) {
 		*this += other;
-	} else if (multiplier != fixed_point_t::_0) {
+	} else if (multiplier != 0) {
 		// We could test that excluded_targets != ALL_TARGETS, but in practice it's always
 		// called with an explcit/hardcoded value and so won't ever exclude everything.
 		for (effect_map_t::value_type const& value : other.values) {

--- a/src/openvic-simulation/scripts/ConditionalWeight.cpp
+++ b/src/openvic-simulation/scripts/ConditionalWeight.cpp
@@ -50,7 +50,7 @@ node_callback_t ConditionalWeight<TYPE>::expect_conditional_weight() {
 	} else if constexpr (TYPE == TIME) {
 		const auto time_callback = [this](std::string_view key, Timespan (*to_timespan)(Timespan::day_t)) -> auto {
 			return [this, key, to_timespan](uint32_t value) -> bool {
-				if (base == fixed_point_t::_0) {
+				if (base == 0) {
 					base = fixed_point_t::parse((*to_timespan)(value).to_int());
 					return true;
 				} else {

--- a/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
+++ b/src/openvic-simulation/types/fixed_point/FixedPointMap.hpp
@@ -29,7 +29,7 @@ namespace OpenVic {
 	constexpr fixed_point_map_t<T>& fixed_point_map_mul_add(
 		fixed_point_map_t<T>& lhs, fixed_point_map_t<T> const& rhs, fixed_point_t factor
 	) {
-		if (factor != fixed_point_t::_0) {
+		if (factor != 0) {
 			for (auto const& [key, value] : rhs) {
 				lhs[key] += value * factor;
 			}


### PR DESCRIPTION
Some time ago we agreed on just using 0 instead of fixed_point_t::_0 but never cleaned up old usages.
So I just did.