### PR TITLE
Refactor pop allocation

### DIFF
--- a/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
+++ b/src/openvic-simulation/economy/production/ArtisanalProducer.cpp
@@ -192,7 +192,7 @@ void ArtisanalProducer::artisan_tick(
 				if (stockpile[&input_good] >= optimal_quantity) {
 					at_or_below_optimum = false;
 					wants_more = false;
-					distinct_goods_to_buy--;
+					--distinct_goods_to_buy;
 				}				
 			}
 		}


### PR DESCRIPTION
Refactored the code that pops use to allocate funds to buy needs and artisanal inputs.
It now uses a while loop instead of resetting iterator and uses `weight` and `weights_sum` (renames only) just like [CountryInstance](https://github.com/OpenVicProject/OpenVic-Simulation/blob/master/src/openvic-simulation/country/CountryInstance.cpp#L2019).