### PR TITLE
Replace fixed_point_t conversions with template explicit conversions

### DIFF
--- a/src/openvic-simulation/dataloader/NodeTools.cpp
+++ b/src/openvic-simulation/dataloader/NodeTools.cpp
@@ -206,7 +206,7 @@ node_callback_t NodeTools::expect_colour(callback_t<colour_t> callback) {
 					} else if (!val.is_integer()) {
 						spdlog::warn_s("Fractional part of colour component #{} will be truncated: {}", components, val);
 					}
-					col[components++] = val.to_int64_t();
+					col[components++] = val.truncate<colour_t::value_type>();
 					return true;
 				}
 			}

--- a/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
+++ b/src/openvic-simulation/economy/production/ResourceGatheringOperation.cpp
@@ -79,7 +79,7 @@ void ResourceGatheringOperation::initialise_rgo_size_multiplier() {
 		size_multiplier = ((total_worker_count_in_province / (size_modifier * base_workforce_size)).ceil() * fixed_point_t::_1_50).floor();
 	}
 
-	max_employee_count_cache = (size_modifier * size_multiplier * base_workforce_size).floor();
+	max_employee_count_cache = (size_modifier * size_multiplier * base_workforce_size).floor<pop_size_t>();
 }
 
 fixed_point_t ResourceGatheringOperation::calculate_size_modifier() const {

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -143,9 +143,9 @@ bool MapDefinition::add_standard_adjacency(ProvinceDefinition& from, ProvinceDef
 		to.coastal = !to.is_water();
 
 		if (from.is_water()) {
-			path_map_sea.try_add_point(to.get_province_number(), { to.centre.x, to.centre.y });
+			path_map_sea.try_add_point(to.get_province_number(), { to.centre.x.round<int>(), to.centre.y.round<int>() });
 		} else {
-			path_map_sea.try_add_point(from.get_province_number(), { from.centre.x, from.centre.y });
+			path_map_sea.try_add_point(from.get_province_number(), { from.centre.x.round<int>(), from.centre.y.round<int>() });
 		}
 		/* Connect points on pathfinding map */
 		path_map_sea.connect_points(from.get_province_number(), to.get_province_number());
@@ -584,7 +584,7 @@ bool MapDefinition::load_province_definitions(std::span<const LineObject> lines)
 					}
 
 					ProvinceDefinition const& definition = province_definitions.back();
-					ret &= path_map_land.try_add_point(definition.get_province_number(), { definition.centre.x, definition.centre.y });
+					ret &= path_map_land.try_add_point(definition.get_province_number(), { definition.centre.x.round<int>(), definition.centre.y.round<int>() });
 					if (!ret) {
 						spdlog::error_s("Province {} could not be added to " _OV_STR(path_map_land), identifier);
 					}

--- a/src/openvic-simulation/pathfinding/PointMap.cpp
+++ b/src/openvic-simulation/pathfinding/PointMap.cpp
@@ -136,7 +136,7 @@ void PointMap::set_point_weight_scale(points_key_type id, fixed_point_t weight_s
 		it == points.end(), memory::fmt::format("Can't set point's weight scale. Point with id: {} doesn't exist.", id)
 	);
 	OV_ERR_FAIL_COND_MSG(
-		weight_scale < 0, memory::fmt::format("Can't set point's weight scale less than 0.0: {}.", weight_scale.to_double())
+		weight_scale < 0, memory::fmt::format("Can't set point's weight scale less than 0.0: {}.", weight_scale)
 	);
 
 	it.value().weight_scale = weight_scale;
@@ -355,7 +355,7 @@ PointMap::points_key_type PointMap::get_closest_point(ivec2_t const& point, bool
 static fvec2_t get_closest_point_to_segment(fvec2_t const& p_point, std::span<ivec2_t, 2> p_segment) {
 	fvec2_t p = p_point - fvec2_t { p_segment[0] };
 	fvec2_t n = fvec2_t { p_segment[1] } - fvec2_t { p_segment[0] };
-	int32_t l2 = n.length_squared();
+	int32_t l2 = n.length_squared().round<int32_t>();
 	if (l2 == 0) {
 		return fvec2_t { p_segment[0] }; // Both points are the same, just give any.
 	}

--- a/src/openvic-simulation/pop/Pop.cpp
+++ b/src/openvic-simulation/pop/Pop.cpp
@@ -249,7 +249,7 @@ void Pop::update_gamestate(
 		} else {
 			max_supported_regiments = (fixed_point_t::parse(size) / (
 				fixed_point_t::parse(military_defines.get_pop_size_per_regiment()) * pop_size_per_regiment_multiplier
-			)).to_int64_t() + 1;
+			)).floor<size_t>() + 1;
 		}
 	}
 }

--- a/src/openvic-simulation/pop/PopManager.cpp
+++ b/src/openvic-simulation/pop/PopManager.cpp
@@ -473,7 +473,7 @@ bool PopManager::load_pop_bases_into_vector(
 	}
 
 	if (culture != nullptr && religion != nullptr && size >= 1 && size <= std::numeric_limits<pop_size_t>::max()) {
-		vec.emplace_back(PopBase { type, *culture, *religion, size.to_int32_t(), militancy, consciousness, rebel_type });
+		vec.emplace_back(PopBase { type, *culture, *religion, size.floor<int32_t>(), militancy, consciousness, rebel_type });
 	} else {
 		spdlog::warn_s(
 			"Some pop arguments are invalid: culture = {}, religion = {}, size = {}",

--- a/src/openvic-simulation/testing/test_scripts/A_002_economy_tests.cpp
+++ b/src/openvic-simulation/testing/test_scripts/A_002_economy_tests.cpp
@@ -557,7 +557,7 @@ namespace OpenVic {
 											  .get_good_definition_manager()
 											  .get_good_definition_by_identifier(identifier)
 											  ->get_base_price();
-			memory::string base_price = memory::fmt::format("{:.1f}", base_price_fp.to_double());
+			memory::string base_price = memory::fmt::format("{:.1f}", base_price_fp);
 
 			// Perform req checks
 			pass_or_fail_req_with_actual_and_target_values(req_name, target_value, base_price);

--- a/src/openvic-simulation/utility/Math.hpp
+++ b/src/openvic-simulation/utility/Math.hpp
@@ -23,12 +23,9 @@ namespace OpenVic {
 	requires (!(std::integral<T> || std::floating_point<T>))
 	[[nodiscard]] inline constexpr T abs(T num);
 
-	constexpr int64_t round_to_int64(float num) {
-		return (num > 0.0f) ? (num + 0.5f) : (num - 0.5f);
-	}
-
-	constexpr int64_t round_to_int64(double num) {
-		return (num > 0.0) ? (num + 0.5) : (num - 0.5);
+	template<std::floating_point T>
+	constexpr int64_t round_to_int64(T num) {
+		return (num > T { 0 }) ? (num + (T { 1 } / 2)) : (num - (T { 1 } / 2));
 	}
 
 	constexpr uint64_t pow(uint64_t base, std::size_t exponent) {

--- a/tests/src/dataloader/NodeTools.cpp
+++ b/tests/src/dataloader/NodeTools.cpp
@@ -500,7 +500,7 @@ TEST_CASE("NodeTools expect colour functions", "[NodeTools][NodeTools-expect-fun
 					if (fp <= 1) {
 						fp *= 255;
 					}
-					check[index] = fp.to_int64_t();
+					check[index] = fp.truncate<colour_t::value_type>();
 				}
 			}
 		}

--- a/tests/src/types/Approx.hpp
+++ b/tests/src/types/Approx.hpp
@@ -13,6 +13,9 @@
 #include <snitch/snitch_string_utility.hpp>
 
 namespace OpenVic::testing {
+	template<typename From, typename To>
+	concept explicit_convertible_to = requires { static_cast<To>(std::declval<From>()); };
+
 	struct approx {
 		constexpr approx(double value)
 			: _epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100), //
@@ -26,7 +29,7 @@ namespace OpenVic::testing {
 			return approx;
 		}
 
-		template<std::convertible_to<double> T>
+		template<explicit_convertible_to<double> T>
 		explicit constexpr approx(T const& value) { // NOLINT(cppcoreguidelines-pro-type-member-init)
 			*this = static_cast<double>(value);
 		}
@@ -36,7 +39,7 @@ namespace OpenVic::testing {
 			return *this;
 		}
 
-		template<std::convertible_to<double> T>
+		template<explicit_convertible_to<double> T>
 		constexpr approx& epsilon(T const& psilon) {
 			_epsilon = static_cast<double>(psilon);
 			return *this;
@@ -47,7 +50,7 @@ namespace OpenVic::testing {
 			return *this;
 		}
 
-		template<std::convertible_to<double> T>
+		template<explicit_convertible_to<double> T>
 		constexpr approx& scale(T const& scale) {
 			_scale = static_cast<double>(scale);
 			return *this;
@@ -59,7 +62,8 @@ namespace OpenVic::testing {
 			return result;
 		}
 
-		template<std::convertible_to<double> T>
+		template<explicit_convertible_to<double> T>
+		requires not_same_as<T, approx>
 		constexpr bool operator==(T rhs) const {
 			return operator==(static_cast<double>(rhs));
 		}
@@ -69,7 +73,8 @@ namespace OpenVic::testing {
 			return OpenVic::abs(rhs - _value) < _epsilon * (_scale + std::max<double>(OpenVic::abs(rhs), OpenVic::abs(_value)));
 		}
 
-		template<std::convertible_to<double> T>
+		template<explicit_convertible_to<double> T>
+		requires not_same_as<T, approx>
 		constexpr std::partial_ordering operator<=>(T rhs) const {
 			return operator<=>(static_cast<double>(rhs));
 		}

--- a/tests/src/types/FixedPoint.cpp
+++ b/tests/src/types/FixedPoint.cpp
@@ -95,24 +95,28 @@ TEST_CASE("fixed_point_t Rounding methods", "[fixed_point_t][fixed_point_t-round
 
 	CONSTEXPR_CHECK(_2_55.floor() == 2);
 	CONSTEXPR_CHECK(_2_55.ceil() == 3);
-	CONSTEXPR_CHECK(_2_55.round_down_to_multiple(3) == 0);
-	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(5) == 5);
-	CONSTEXPR_CHECK(_2_55.round_down_to_multiple(fixed_point_t::_0_25) == 2.50_a);
-	CONSTEXPR_CHECK(_2_55.round_up_to_multiple(fixed_point_t::_1_50) == 3);
+	CONSTEXPR_CHECK(_2_55.round() == 3);
+	CONSTEXPR_CHECK((_2_55 - fixed_point_t::_0_10).round() == 2);
+	CONSTEXPR_CHECK(_2_55.truncate() == 2);
+	CONSTEXPR_CHECK(-_2_55.truncate() == -2);
+	CONSTEXPR_CHECK(_2_55.round<midpoint_rounding::AWAY_ZERO>(3) == 0);
+	CONSTEXPR_CHECK(_2_55.round<midpoint_rounding::TO_ZERO>(5) == 5);
+	CONSTEXPR_CHECK(_2_55.round<midpoint_rounding::AWAY_ZERO>(fixed_point_t::_0_25) == 2.50_a);
+	CONSTEXPR_CHECK(_2_55.round<midpoint_rounding::TO_ZERO>(fixed_point_t::_1_50) == 3);
 
-	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).to_int32_t_rounded() == 0);
-	CONSTEXPR_CHECK(fixed_point_t::_0_50.to_int32_t_rounded() == 1);
-	CONSTEXPR_CHECK((-fixed_point_t::_0_50).to_int32_t_rounded() == -1);
-	CONSTEXPR_CHECK(fixed_point_t::_1_50.to_int32_t_rounded() == 2);
-	CONSTEXPR_CHECK((-fixed_point_t::_1_50).to_int32_t_rounded() == -2);
-	CONSTEXPR_CHECK(_2_55.to_int32_t_rounded() == 3);
+	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).round<int32_t>() == 0);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50.round<int32_t>() == 1);
+	CONSTEXPR_CHECK((-fixed_point_t::_0_50).round<int32_t>() == -1);
+	CONSTEXPR_CHECK(fixed_point_t::_1_50.round<int32_t>() == 2);
+	CONSTEXPR_CHECK((-fixed_point_t::_1_50).round<int32_t>() == -2);
+	CONSTEXPR_CHECK(_2_55.round<int32_t>() == 3);
 
-	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).to_int64_t_rounded() == 0);
-	CONSTEXPR_CHECK(fixed_point_t::_0_50.to_int64_t_rounded() == 1);
-	CONSTEXPR_CHECK((-fixed_point_t::_0_50).to_int64_t_rounded() == -1);
-	CONSTEXPR_CHECK(fixed_point_t::_1_50.to_int64_t_rounded() == 2);
-	CONSTEXPR_CHECK((-fixed_point_t::_1_50).to_int64_t_rounded() == -2);
-	CONSTEXPR_CHECK(_2_55.to_int64_t_rounded() == 3);
+	CONSTEXPR_CHECK((fixed_point_t::_0_50 - fixed_point_t::epsilon).round<int64_t>() == 0);
+	CONSTEXPR_CHECK(fixed_point_t::_0_50.round<int64_t>() == 1);
+	CONSTEXPR_CHECK((-fixed_point_t::_0_50).round<int64_t>() == -1);
+	CONSTEXPR_CHECK(fixed_point_t::_1_50.round<int64_t>() == 2);
+	CONSTEXPR_CHECK((-fixed_point_t::_1_50).round<int64_t>() == -2);
+	CONSTEXPR_CHECK(_2_55.round<int64_t>() == 3);
 }
 
 TEST_CASE("fixed_point_t Parse methods", "[fixed_point_t][fixed_point_t-parse]") {

--- a/tests/src/types/Numeric.hpp
+++ b/tests/src/types/Numeric.hpp
@@ -12,7 +12,7 @@ namespace OpenVic::testing {
 	static constexpr double INACCURATE_EPSILON = static_cast<double>(std::numeric_limits<float>::epsilon()) * 1000;
 
 	inline double approx_value(fixed_point_t value, double compare) {
-		return std::abs(value.to_double() - compare);
+		return std::abs(static_cast<double>(value) - compare);
 	}
 
 	inline double approx_value(double value, double compare) {
@@ -22,6 +22,6 @@ namespace OpenVic::testing {
 
 namespace snitch {
 	[[nodiscard]] inline static constexpr bool append(snitch::small_string_span ss, OpenVic::fixed_point_t const& s) {
-		return append(ss, s.to_double());
+		return append(ss, static_cast<double>(s));
 	}
 }


### PR DESCRIPTION
This ensures that we'll never accidentally convert a fixed_point_t to an integer, implicit conversions are a common source for bugs, unintended fixed_point_t conversions can lose value information and so they should be implicit.

Add template type parameter to round_to_int64

Add fixed_point_t::floor<std::integral T>
Add fixed_point_t::ceil<std::integral T>
Add fixed_point_t::truncate
Add fixed_point_t::truncate<T>
Add fixed_point_t::round
Add fixed_point_t::round<T>
Add fixed_point floating point round methods with rounding preference

Remove fixed_point_t::round_down_to_multiple - Use round<round_preference::DOWN>
Remove fixed_point_t::round_up_to_multiple - Use round<round_preference::UP>
Remove fixed_point_t::to_int64_t - Use `static_cast<int64_t>(fp)`
Remove fixed_point_t::to_int64_t_rounded - Use round<int64_t>
Remove fixed_point_t::to_int32_t - Use `static_cast<int32_t>(fp)`
Remove fixed_point_t::to_int32_t_rounded - Use round<int32_t>
Remove fixed_point_t::to<T> - Use `static_cast<T>(fp)`
Remove fixed_point_t::to_float - Use `static_cast<float>(fp)`
Remove fixed_point_t::to_float_rounded - Use round<float>
Remove fixed_point_t::to_double - Use `static_cast<double>(fp)`
Remove fixed_point_t::to_double_rounded - Use round<double>