### PR TITLE
Add game rule for coastal production

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1809,8 +1809,10 @@ void CountryInstance::update_gamestate(const Date today, MapInstance& map_instan
 
 	Continent const* capital_continent = capital != nullptr ? capital->get_province_definition().get_continent() : nullptr;
 
+	coastal = false;
 	for (ProvinceInstance* province : owned_provinces) {
 		ProvinceDefinition const& province_definition = province->get_province_definition();
+		coastal |= province_definition.is_coastal();
 
 		if (province->get_controller() != this) {
 			occupied_provinces_proportion++;

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -128,6 +128,7 @@ namespace OpenVic {
 		bool PROPERTY_CUSTOM_PREFIX(releasable_vassal, is, true);
 		bool PROPERTY(owns_colonial_province, false);
 		bool PROPERTY(has_unowned_cores, false);
+		bool PROPERTY_CUSTOM_PREFIX(coastal, is, false);
 		fixed_point_t PROPERTY(owned_cores_controlled_proportion);
 		fixed_point_t PROPERTY(occupied_provinces_proportion);
 		size_t PROPERTY(port_count, 0);

--- a/src/openvic-simulation/economy/production/ProductionType.cpp
+++ b/src/openvic-simulation/economy/production/ProductionType.cpp
@@ -401,6 +401,20 @@ bool ProductionTypeManager::load_production_types_file(
 	return ret;
 }
 
+bool ProductionType::is_valid_for_artisan_in(ProvinceInstance& province) const{
+	if (template_type != template_type_t::ARTISAN) {
+		return false;
+	}
+	return !coastal || game_rules_manager.may_use_coastal_artisanal_production_types(province);
+}
+
+bool ProductionType::is_valid_for_factory_in(State& state) const{
+	if (template_type != template_type_t::FACTORY) {
+		return false;
+	}
+	return !coastal || game_rules_manager.may_use_coastal_factory_production_types(state);
+}
+
 bool ProductionTypeManager::parse_scripts(DefinitionManager const& definition_manager) {
 	bool ret = true;
 	for (ProductionType& production_type : production_types.get_items()) {

--- a/src/openvic-simulation/economy/production/ProductionType.hpp
+++ b/src/openvic-simulation/economy/production/ProductionType.hpp
@@ -17,6 +17,8 @@ namespace OpenVic {
 	struct PopManager;
 	struct PopType;
 	struct ProductionTypeManager;
+	struct ProvinceInstance;
+	struct State;
 
 	struct Job {
 		friend struct ProductionTypeManager;
@@ -90,6 +92,8 @@ namespace OpenVic {
 		}
 		bool get_is_farm_for_tech() const;
 		bool get_is_mine_for_non_tech() const;
+		bool is_valid_for_artisan_in(ProvinceInstance& province) const;
+		bool is_valid_for_factory_in(State& state) const;
 		ProductionType(ProductionType&&) = default;
 	};
 

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -58,7 +58,9 @@ void State::update_gamestate() {
 		pops_cache.clear();
 	}
 
+	coastal = false;
 	for (ProvinceInstance* const province : provinces) {
+		coastal |= province->get_province_definition().is_coastal();
 		add_pops_aggregate(*province);
 
 		for (auto const& [pop_type, province_pops_of_type] : province->get_pops_cache_by_type()) {

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -36,6 +36,7 @@ namespace OpenVic {
 		memory::vector<ProvinceInstance*> SPAN_PROPERTY(provinces);
 		colony_status_t PROPERTY(colony_status);
 		fixed_point_t PROPERTY(industrial_power);
+		bool PROPERTY_CUSTOM_PREFIX(coastal, is, false);
 
 		OV_IFLATMAP_PROPERTY(PopType, memory::vector<Pop*>, pops_cache_by_type);
 

--- a/src/openvic-simulation/misc/GameRulesManager.cpp
+++ b/src/openvic-simulation/misc/GameRulesManager.cpp
@@ -1,0 +1,43 @@
+#include "GameRulesManager.hpp"
+
+#include "openvic-simulation/country/CountryInstance.hpp"
+#include "openvic-simulation/map/ProvinceDefinition.hpp"
+#include "openvic-simulation/map/ProvinceInstance.hpp"
+#include "openvic-simulation/map/State.hpp"
+
+using namespace OpenVic;
+
+bool GameRulesManager::may_use_coastal_artisanal_production_types(ProvinceInstance const& province) const {
+	const bool is_coastal_province = province.get_province_definition().is_coastal();
+	using enum artisan_coastal_restriction_t;
+	switch (coastal_restriction_for_artisans) {
+		case Unrestricted:
+			return true;
+		case CountriesWithCoast: {
+			CountryInstance const* const country = province.get_country_to_report_economy();
+			return is_coastal_province || (country != nullptr && country->is_coastal());
+		}
+		case CoastalStates: {
+			State const* const state = province.get_state();
+			return is_coastal_province || (state != nullptr && state->is_coastal());
+		}
+		case CoastalProvinces:
+			return is_coastal_province;
+	}
+}
+
+bool GameRulesManager::may_use_coastal_factory_production_types(State const& state) const {
+	const bool is_coastal_state = state.is_coastal();
+	using enum factory_coastal_restriction_t;
+	switch (coastal_restriction_for_factories) {
+		case Unrestricted:
+			return true;
+		case CountriesWithCoast: {
+			CountryInstance const* const country = state.get_owner();
+			return is_coastal_state || (country != nullptr && country->is_coastal());
+		}
+		case CoastalStates: {
+			return is_coastal_state;
+		}
+	}
+}

--- a/src/openvic-simulation/misc/GameRulesManager.hpp
+++ b/src/openvic-simulation/misc/GameRulesManager.hpp
@@ -5,6 +5,9 @@
 #include "openvic-simulation/utility/Getters.hpp"
 
 namespace OpenVic {
+	struct ProvinceInstance;
+	struct State;
+
 	enum struct country_to_report_economy_t : uint8_t {
 		Owner,
 		Controller,
@@ -17,6 +20,19 @@ namespace OpenVic {
 		FactoryNeeds
 	};
 
+	enum struct artisan_coastal_restriction_t : uint8_t {
+		Unrestricted,
+		CountriesWithCoast,
+		CoastalStates,
+		CoastalProvinces
+	};
+
+	enum struct factory_coastal_restriction_t : uint8_t {
+		Unrestricted,
+		CountriesWithCoast,
+		CoastalStates
+	};
+
 	struct GameRulesManager {
 	private:
 		bool PROPERTY_RW(use_simple_farm_mine_logic, false);
@@ -25,10 +41,21 @@ namespace OpenVic {
 		bool PROPERTY_RW(prevent_negative_administration_efficiency, false);
 		demand_category PROPERTY_RW(artisanal_input_demand_category, demand_category::None);
 		country_to_report_economy_t PROPERTY_RW(country_to_report_economy, country_to_report_economy_t::Owner);
+		artisan_coastal_restriction_t PROPERTY_RW(
+			coastal_restriction_for_artisans,
+			artisan_coastal_restriction_t::CountriesWithCoast
+		);
+		factory_coastal_restriction_t PROPERTY_RW(
+			coastal_restriction_for_factories,
+			factory_coastal_restriction_t::CoastalStates
+		);
 
 	public:
 		constexpr bool get_use_optimal_pricing() const {
 			return use_exponential_price_changes;
 		}
+
+		bool may_use_coastal_artisanal_production_types(ProvinceInstance const& province) const;
+		bool may_use_coastal_factory_production_types(State const& state) const;
 	};
 }


### PR DESCRIPTION
Production types can be marked as coastal. In Victoria 2 this restricts them to countries with a coast.
This is rather arbitary and so I added the following options:
- Unrestricted, ignores the coastal requirement entirely.
- CountriesWithCoast, same as Victoria 2 artisans. Requires the country owns at least 1 coastal province.
- CoastalStates, same as Victoria 2 factories. Requires the province to be in a state with at least 1 coastal province.
- CoastalProvinces, for artisans only. Requires the pop to be in a coastal province. (Unavailable for factories as they are state buildings.)

Implementation of the requirement follows in #605 
Note Victoria 2 doesn't disable the production type if the coastal requirement is no longer met.
The restriction only applies when switching production type as artisan or building a new factory.