### PR TITLE
Refactor politics and leftovers to use reference_wrapper

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -260,32 +260,31 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 	SPDLOG_INFO("===== Ranking system test... =====");
 	if (game_manager.get_instance_manager()) {
 		const auto print_ranking_list = [ //
-		](std::string_view title, OpenVic::forwardable_span<CountryInstance* const> countries) -> void {
+		](std::string_view title, OpenVic::forwardable_span<const std::reference_wrapper<CountryInstance>> countries) -> void {
 			memory::string countries_str;
-			for (CountryInstance* country : countries) {
+			for (CountryInstance& country : countries) {
 				countries_str += fmt::format(
 					"\n\t{} - Total #{} ({}), Prestige #{} ({}), Industry #{} ({}), Military #{} ({})", //
-					*country, //
-					country->get_total_rank(), country->total_score.get_untracked().to_string(1), //
-					country->get_prestige_rank(), country->get_prestige_untracked().to_string(1),
-					country->get_industrial_rank(), country->get_industrial_power_untracked().to_string(1),
-					country->get_military_rank(), country->military_power.get_untracked().to_string(1)
+					country, //
+					country.get_total_rank(), country.total_score.get_untracked().to_string(1), //
+					country.get_prestige_rank(), country.get_prestige_untracked().to_string(1),
+					country.get_industrial_rank(), country.get_industrial_power_untracked().to_string(1),
+					country.get_military_rank(), country.military_power.get_untracked().to_string(1)
 				);
 			}
 			SPDLOG_INFO("{}:{}", title, countries_str);
 		};
 
-		CountryInstanceManager const& country_instance_manager =
-			game_manager.get_instance_manager()->get_country_instance_manager();
+		CountryInstanceManager const& country_instance_manager = game_manager.get_instance_manager()->get_country_instance_manager();
 
-		OpenVic::forwardable_span<CountryInstance* const> great_powers = country_instance_manager.get_great_powers();
+		OpenVic::forwardable_span<const std::reference_wrapper<CountryInstance>> great_powers = country_instance_manager.get_great_powers();
 		print_ranking_list("Great Powers", great_powers);
 		print_ranking_list("Secondary Powers", country_instance_manager.get_secondary_powers());
 		print_ranking_list("All countries", country_instance_manager.get_total_ranking());
 
 		SPDLOG_INFO("===== RGO test... =====");
 		for (size_t i = 0; i < std::min<size_t>(3, great_powers.size()); ++i) {
-			CountryInstance const& great_power = *great_powers[i];
+			CountryInstance const& great_power = great_powers[i];
 			ProvinceInstance const* const capital_province = great_power.get_capital();
 			if (capital_province == nullptr) {
 				spdlog::warn_s("{} has no capital ProvinceInstance set.", great_power);

--- a/src/openvic-simulation/core/template/Concepts.hpp
+++ b/src/openvic-simulation/core/template/Concepts.hpp
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <memory>
 #include <string_view>
-#include <type_traits>
 
 #include <type_safe/strong_typedef.hpp>
 

--- a/src/openvic-simulation/core/template/Functional.hpp
+++ b/src/openvic-simulation/core/template/Functional.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <functional>
+
+#include <concepts/type_traits.hpp>
+
+// bug fix for std::hash & std::equal_to to work with std::reference_wrapper
+namespace std {
+	template <typename T>
+	struct hash<std::reference_wrapper<T>> {
+		using BaseType = std::remove_cv_t<T>;
+
+		[[nodiscard]] size_t operator()(T const& val) const noexcept {
+			return std::hash<BaseType>{}(val);
+		}
+	};
+}
+
+// bug fix for concepts/type_traits.hpp to work with std::reference_wrapper
+namespace concepts {
+	namespace detail {
+		template<typename T>
+		constexpr bool _is_ref_wrapper = false;
+		
+		template<typename T>
+		constexpr bool _is_ref_wrapper<std::reference_wrapper<T>> = true;
+		
+		template<typename R, typename T, typename RQual, typename TQual>
+		concept _ref_wrap_common_reference_with = _is_ref_wrapper<R>
+			&& requires { typename std::common_reference_t<typename R::type&, TQual>; }
+			&& std::convertible_to<RQual, std::common_reference_t<typename R::type&, TQual>>;
+	}
+
+	template<typename R, typename T, template<typename> class RQual, template<typename> class TQual>
+	requires detail::_ref_wrap_common_reference_with<R, T, RQual<R>, TQual<T>>
+	&& (!detail::_ref_wrap_common_reference_with<T, R, TQual<T>, RQual<R>>)
+	struct basic_common_reference<R, T, RQual, TQual>
+	{
+		using type = std::common_reference_t<typename R::type&, TQual<T>>;
+	};
+
+	template<typename T, typename R, template<typename> class TQual, template<typename> class RQual>
+	requires detail::_ref_wrap_common_reference_with<R, T, RQual<R>, TQual<T>>
+	&& (!detail::_ref_wrap_common_reference_with<T, R, TQual<T>, RQual<R>>)
+	struct basic_common_reference<T, R, TQual, RQual>
+	{
+		using type = std::common_reference_t<typename R::type&, TQual<T>>;
+	};
+}

--- a/src/openvic-simulation/country/CountryDefinition.cpp
+++ b/src/openvic-simulation/country/CountryDefinition.cpp
@@ -159,7 +159,7 @@ node_callback_t CountryDefinitionManager::load_country_party(
 
 						return politics_manager.get_issue_manager().expect_party_policy_identifier(
 							[&party_policy_group, &policy](PartyPolicy const& party_policy) -> bool {
-								if (&party_policy.issue_group == &party_policy_group) {
+								if (&party_policy.group == &party_policy_group) {
 									policy = &party_policy;
 									return true;
 								}
@@ -168,7 +168,7 @@ node_callback_t CountryDefinitionManager::load_country_party(
 								spdlog::warn_s(
 									"Invalid party policy \"{}\", group is \"{}\" when \"{}\" was expected.",
 									party_policy,
-									party_policy.issue_group,
+									party_policy.group,
 									party_policy_group
 								);
 								return true;

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -61,43 +61,43 @@ static constexpr size_t DAYS_OF_BALANCE_HISTORY = 30;
 static constexpr colour_t ERROR_COLOUR = colour_t::from_integer(0xFF0000);
 
 CountryInstance::CountryInstance(
-	CountryDefinition const* new_country_definition,
-	SharedCountryValues* new_shared_country_values,
-	CountryInstanceDeps const* country_instance_deps
+	CountryDefinition const& new_country_definition,
+	SharedCountryValues& new_shared_country_values,
+	CountryInstanceDeps const& country_instance_deps
 ) : FlagStrings { "country" },
-	HasIndex { new_country_definition->index },
+	HasIndex { new_country_definition.index },
 	PopsAggregate {
-		country_instance_deps->stratas,
-		country_instance_deps->pop_types,
-		country_instance_deps->ideologies
+		country_instance_deps.stratas,
+		country_instance_deps.pop_types,
+		country_instance_deps.ideologies
 	},
 	/* Main attributes */
-	country_definition { *new_country_definition },
-	shared_country_values { *new_shared_country_values },
+	country_definition { new_country_definition },
+	shared_country_values { new_shared_country_values },
 
-	country_relations_manager { country_instance_deps->country_relations_manager },
-	game_rules_manager { country_instance_deps->game_rules_manager },
-	good_instance_manager { country_instance_deps->good_instance_manager },
-	market_instance { country_instance_deps->market_instance },
-	modifier_effect_cache { country_instance_deps->modifier_effect_cache },
-	unit_type_manager { country_instance_deps->unit_type_manager },
+	country_relations_manager { country_instance_deps.country_relations_manager },
+	game_rules_manager { country_instance_deps.game_rules_manager },
+	good_instance_manager { country_instance_deps.good_instance_manager },
+	market_instance { country_instance_deps.market_instance },
+	modifier_effect_cache { country_instance_deps.modifier_effect_cache },
+	unit_type_manager { country_instance_deps.unit_type_manager },
 	
-	fallback_date_for_never_completing_research { country_instance_deps->fallback_date_for_never_completing_research },
-	country_defines { country_instance_deps->country_defines },
-	diplomacy_defines { country_instance_deps->diplomacy_defines },
-	economy_defines { country_instance_deps->economy_defines },
-	military_defines { country_instance_deps->military_defines },
+	fallback_date_for_never_completing_research { country_instance_deps.fallback_date_for_never_completing_research },
+	country_defines { country_instance_deps.country_defines },
+	diplomacy_defines { country_instance_deps.diplomacy_defines },
+	economy_defines { country_instance_deps.economy_defines },
+	military_defines { country_instance_deps.military_defines },
 
 	colour { ERROR_COLOUR },
 
 	/* Production */
-	building_type_unlock_levels { country_instance_deps->building_types },
+	building_type_unlock_levels { country_instance_deps.building_types },
 
 	/* Budget */
 	balance_history{DAYS_OF_BALANCE_HISTORY},
-	taxable_income_by_pop_type { country_instance_deps->pop_types },
+	taxable_income_by_pop_type { country_instance_deps.pop_types },
 	effective_tax_rate_by_strata {
-		country_instance_deps->stratas,
+		country_instance_deps.stratas,
 		[this](Strata const& strata)->auto {
 			return [this,&strata](DependencyTracker& tracker)->fixed_point_t {
 				return tax_efficiency.get(tracker) * tax_rate_slider_value_by_strata.at(strata).get_value(tracker);
@@ -105,7 +105,7 @@ CountryInstance::CountryInstance(
 		}
 	},
 	administration_salary_base_by_pop_type{
-		country_instance_deps->pop_types,
+		country_instance_deps.pop_types,
 		[this](PopType const& pop_type)->auto {
 			return [this,&pop_type](DependencyTracker& tracker)->fixed_point_t {
 				return corruption_cost_multiplier.get(tracker)
@@ -115,7 +115,7 @@ CountryInstance::CountryInstance(
 		}
 	},
 	education_salary_base_by_pop_type{
-		country_instance_deps->pop_types,
+		country_instance_deps.pop_types,
 		[this](PopType const& pop_type)->auto {
 			return [this,&pop_type](DependencyTracker& tracker)->fixed_point_t {
 				return corruption_cost_multiplier.get(tracker)
@@ -125,7 +125,7 @@ CountryInstance::CountryInstance(
 		}
 	},
 	military_salary_base_by_pop_type{
-		country_instance_deps->pop_types,
+		country_instance_deps.pop_types,
 		[this](PopType const& pop_type)->auto {
 			return [this,&pop_type](DependencyTracker& tracker)->fixed_point_t {
 				return corruption_cost_multiplier.get(tracker)
@@ -135,7 +135,7 @@ CountryInstance::CountryInstance(
 		}
 	},
 	social_income_variant_base_by_pop_type{
-		country_instance_deps->pop_types,
+		country_instance_deps.pop_types,
 		[this](PopType const& pop_type)->auto {
 			return [this,&pop_type](DependencyTracker& tracker)->fixed_point_t {
 				return corruption_cost_multiplier.get(tracker)
@@ -144,26 +144,26 @@ CountryInstance::CountryInstance(
 			};
 		}
 	},
-	tax_rate_slider_value_by_strata { country_instance_deps->stratas },
+	tax_rate_slider_value_by_strata { country_instance_deps.stratas },
 
 	/* Technology */
-	technology_unlock_levels { country_instance_deps->technologies },
-	invention_unlock_levels { country_instance_deps->inventions },
+	technology_unlock_levels { country_instance_deps.technologies },
+	invention_unlock_levels { country_instance_deps.inventions },
 
 	/* Politics */
-	upper_house_proportion_by_ideology { country_instance_deps->ideologies },
-	reforms { country_instance_deps->reforms },
-	flag_overrides_by_government_type { country_instance_deps->government_types },
-	crime_unlock_levels { country_instance_deps->crimes },
+	upper_house_proportion_by_ideology { country_instance_deps.ideologies },
+	reforms { country_instance_deps.reforms },
+	flag_overrides_by_government_type { country_instance_deps.government_types },
+	crime_unlock_levels { country_instance_deps.crimes },
 
 	/* Trade */
-	goods_data { country_instance_deps->good_instances },
+	goods_data { country_instance_deps.good_instances },
 
 	/* Diplomacy */
 
 	/* Military */
-	regiment_type_unlock_levels { country_instance_deps->regiment_types },
-	ship_type_unlock_levels { country_instance_deps->ship_types },
+	regiment_type_unlock_levels { country_instance_deps.regiment_types },
+	ship_type_unlock_levels { country_instance_deps.ship_types },
 
 	/* DerivedState */
 	flag_government_type { [this](DependencyTracker& tracker)->GovernmentType const* {
@@ -247,7 +247,7 @@ CountryInstance::CountryInstance(
 	}
 
 	// army, navy and construction spending have minimums defined in EconomyDefines and always have an unmodified max (1.0).
-	EconomyDefines const& economy_defines = country_instance_deps->economy_defines;
+	EconomyDefines const& economy_defines = country_instance_deps.economy_defines;
 	army_spending_slider_value.set_bounds(economy_defines.get_minimum_army_spending_slider_value(), 1);
 	army_spending_slider_value.set_value(1);
 
@@ -274,7 +274,7 @@ CountryInstance::CountryInstance(
 	tariff_rate_slider_value.set_bounds(0, 0);
 	tariff_rate_slider_value.set_value(0);
 
-	update_parties_for_votes(new_country_definition);
+	update_parties_for_votes(&new_country_definition);
 
 	for (BuildingType const& building_type : building_type_unlock_levels.get_keys()) {
 		if (building_type.is_enabled_by_default) {
@@ -393,17 +393,17 @@ void CountryInstance::set_alliance_with(CountryInstance& country, bool alliance)
 }
 
 bool CountryInstance::is_at_war_with(CountryInstance const& country) const {
-	return war_enemies.contains(&country);
+	return war_enemies.contains(country);
 }
 
 void CountryInstance::set_at_war_with(CountryInstance& country, bool at_war) {
 	country_relations_manager.set_at_war_with(this, &country, at_war);
 	if (at_war) {
-		war_enemies.insert(&country);
-		country.war_enemies.insert(this);
+		war_enemies.emplace(country);
+		country.war_enemies.emplace(*this);
 	} else {
-		war_enemies.unordered_erase(&country);
-		country.war_enemies.unordered_erase(this);
+		war_enemies.unordered_erase(country);
+		country.war_enemies.unordered_erase(*this);
 	}
 }
 
@@ -639,7 +639,7 @@ bool CountryInstance::set_ruling_party(CountryParty const& new_ruling_party) {
 }
 
 bool CountryInstance::add_reform(Reform const& new_reform) {
-	ReformGroup const& reform_group = new_reform.get_reform_group();
+	ReformGroup const& reform_group = new_reform.group;
 	Reform const*& reform = reforms.at(reform_group);
 
 	if (reform != &new_reform) {
@@ -1211,7 +1211,7 @@ bool CountryInstance::can_research_tech(Technology const& technology, const Date
 
 	const Technology::area_index_t index_in_area = technology.index_in_area;
 
-	return index_in_area == 0 || is_technology_unlocked(*technology.area.get_technologies()[index_in_area - 1]);
+	return index_in_area == 0 || is_technology_unlocked(technology.area.get_technologies()[index_in_area - 1]);
 }
 
 void CountryInstance::start_research(Technology const& technology, const Date today) {
@@ -1233,7 +1233,7 @@ void CountryInstance::apply_foreign_investments(
 	fixed_point_map_t<CountryDefinition const*> const& investments, CountryInstanceManager const& country_instance_manager
 ) {
 	for (auto const& [country, money_invested] : investments) {
-		foreign_investments[&country_instance_manager.get_country_instance_by_definition(*country)] = money_invested;
+		foreign_investments[country_instance_manager.get_country_instance_by_definition(*country)] = money_invested;
 	}
 }
 
@@ -1320,8 +1320,9 @@ void CountryInstance::_update_production() {
 	industrial_power_from_states.clear();
 	industrial_power_from_investments.clear();
 
-	for (State const* state : states) {
-		const fixed_point_t state_industrial_power = state->get_industrial_power();
+	for (State const* state_ptr : states) {
+		State const& state = *state_ptr;
+		const fixed_point_t state_industrial_power = state.get_industrial_power();
 		if (state_industrial_power != 0) {
 			industrial_power += state_industrial_power;
 			industrial_power_from_states.emplace_back(state, state_industrial_power);
@@ -1329,7 +1330,7 @@ void CountryInstance::_update_production() {
 	}
 
 	for (auto const& [country, money_invested] : foreign_investments) {
-		if (country->exists()) {
+		if (country.get().exists()) {
 			const fixed_point_t investment_industrial_power = fixed_point_t::mul_div(
 				money_invested,
 				country_defines.get_country_investment_industrial_score_factor(),

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -154,10 +154,10 @@ namespace OpenVic {
 
 		/* Production */
 		OV_STATE_PROPERTY(fixed_point_t, industrial_power);
-		memory::vector<std::pair<State const*, fixed_point_t>> SPAN_PROPERTY(industrial_power_from_states);
-		memory::vector<std::pair<CountryInstance const*, fixed_point_t>> SPAN_PROPERTY(industrial_power_from_investments);
+		memory::vector<std::pair<std::reference_wrapper<const State>, fixed_point_t>> SPAN_PROPERTY(industrial_power_from_states);
+		memory::vector<std::pair<std::reference_wrapper<const CountryInstance>, fixed_point_t>> SPAN_PROPERTY(industrial_power_from_investments);
 		size_t PROPERTY(industrial_rank, 0);
-		fixed_point_map_t<CountryInstance const*> PROPERTY(foreign_investments);
+		fixed_point_map_t<std::reference_wrapper<const CountryInstance>> PROPERTY(foreign_investments);
 		OV_IFLATMAP_PROPERTY(BuildingType, building_level_t, building_type_unlock_levels);
 		// TODO - total amount of each good produced
 
@@ -345,7 +345,7 @@ namespace OpenVic {
 		// The last time this country lost a war, i.e. accepted a peace offer sent from their offer tab or the enemy's demand
 		// tab, even white peace. Used for the "has_recently_lost_war" condition (true if the date is less than 5 years ago).
 		Date PROPERTY(last_war_loss_date);
-		vector_ordered_set<CountryInstance const*> PROPERTY(war_enemies);
+		vector_ordered_set<std::reference_wrapper<const CountryInstance>> PROPERTY(war_enemies);
 		OV_STATE_PROPERTY(CountryInstance const*, sphere_owner, nullptr);
 		// TODO - colonial power, current wars
 
@@ -397,11 +397,10 @@ namespace OpenVic {
 		memory::vector<technology_unlock_level_t> SPAN_PROPERTY(unit_variant_unlock_levels);
 
 	public:
-		//pointers instead of references to allow construction via std::tuple
 		CountryInstance(
-			CountryDefinition const* new_country_definition,
-			SharedCountryValues* new_shared_country_values,
-			CountryInstanceDeps const* country_instance_deps
+			CountryDefinition const& new_country_definition,
+			SharedCountryValues& new_shared_country_values,
+			CountryInstanceDeps const& country_instance_deps
 		);
 		CountryInstance(CountryInstance const&) = delete;
 		CountryInstance& operator=(CountryInstance const&) = delete;

--- a/src/openvic-simulation/country/CountryInstanceManager.cpp
+++ b/src/openvic-simulation/country/CountryInstanceManager.cpp
@@ -1,5 +1,7 @@
 #include "CountryInstanceManager.hpp"
+
 #include <algorithm>
+#include <functional>
 
 #include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/defines/CountryDefines.hpp"
@@ -32,12 +34,12 @@ CountryInstanceManager::CountryInstanceManager(
 		new_country_definition_manager.get_country_definitions(),
 		[
 			this,
-			country_instance_deps_ptr=&country_instance_deps
+			&country_instance_deps
 		](CountryDefinition const& country_definition)->auto{
 			return std::make_tuple(
-				&country_definition,
-				&shared_country_values,
-				country_instance_deps_ptr
+				std::ref(country_definition),
+				std::ref(shared_country_values),
+				std::ref(country_instance_deps)
 			);
 		}
 	}
@@ -52,7 +54,7 @@ void CountryInstanceManager::update_rankings(const Date today) {
 
 	for (CountryInstance& country : get_country_instances()) {
 		if (country.exists()) {
-			total_ranking.push_back(&country);
+			total_ranking.emplace_back(country);
 		}
 	}
 
@@ -62,37 +64,37 @@ void CountryInstanceManager::update_rankings(const Date today) {
 
 	std::stable_sort(
 		total_ranking.begin(), total_ranking.end(),
-		[](CountryInstance* a, CountryInstance* b) -> bool {
-			const bool a_civilised = a->is_civilised();
-			const bool b_civilised = b->is_civilised();
-			return a_civilised != b_civilised ? a_civilised : a->total_score.get_untracked() > b->total_score.get_untracked();
+		[](CountryInstance& a, CountryInstance& b) -> bool {
+			const bool a_civilised = a.is_civilised();
+			const bool b_civilised = b.is_civilised();
+			return a_civilised != b_civilised ? a_civilised : a.total_score.get_untracked() > b.total_score.get_untracked();
 		}
 	);
 	std::stable_sort(
 		prestige_ranking.begin(), prestige_ranking.end(),
-		[](CountryInstance const* a, CountryInstance const* b) -> bool {
-			return a->get_prestige_untracked() > b->get_prestige_untracked();
+		[](CountryInstance const& a, CountryInstance const& b) -> bool {
+			return a.get_prestige_untracked() > b.get_prestige_untracked();
 		}
 	);
 	std::stable_sort(
 		industrial_power_ranking.begin(), industrial_power_ranking.end(),
-		[](CountryInstance const* a, CountryInstance const* b) -> bool {
-			return a->get_industrial_power_untracked() > b->get_industrial_power_untracked();
+		[](CountryInstance const& a, CountryInstance const& b) -> bool {
+			return a.get_industrial_power_untracked() > b.get_industrial_power_untracked();
 		}
 	);
 	std::stable_sort(
 		military_power_ranking.begin(), military_power_ranking.end(),
-		[](CountryInstance* a, CountryInstance* b) -> bool {
-			return a->military_power.get_untracked() > b->military_power.get_untracked();
+		[](CountryInstance& a, CountryInstance& b) -> bool {
+			return a.military_power.get_untracked() > b.military_power.get_untracked();
 		}
 	);
 
 	for (size_t index = 0; index < total_ranking.size(); ++index) {
 		const size_t rank = index + 1;
-		total_ranking[index]->total_rank = rank;
-		prestige_ranking[index]->prestige_rank = rank;
-		industrial_power_ranking[index]->industrial_rank = rank;
-		military_power_ranking[index]->military_rank = rank;
+		total_ranking[index].get().total_rank = rank;
+		prestige_ranking[index].get().prestige_rank = rank;
+		industrial_power_ranking[index].get().industrial_rank = rank;
+		military_power_ranking[index].get().military_rank = rank;
 	}
 
 	const size_t max_great_power_rank = country_defines.get_great_power_rank();
@@ -103,12 +105,12 @@ void CountryInstanceManager::update_rankings(const Date today) {
 	// Demote great powers who have been below the max great power rank for longer than the demotion grace period and
 	// remove them from the list. We don't just demote them all and clear the list as when rebuilding we'd need to look
 	// ahead for countries below the max great power rank but still within the demotion grace period.
-	std::erase_if(great_powers, [max_great_power_rank, today](CountryInstance* great_power) -> bool {
-		if (OV_likely(great_power->get_country_status() == COUNTRY_STATUS_GREAT_POWER)) {
+	std::erase_if(great_powers, [max_great_power_rank, today](CountryInstance& great_power) -> bool {
+		if (OV_likely(great_power.get_country_status() == COUNTRY_STATUS_GREAT_POWER)) {
 			if (OV_unlikely(
-				great_power->get_total_rank() > max_great_power_rank && great_power->get_lose_great_power_date() < today
+				great_power.get_total_rank() > max_great_power_rank && great_power.get_lose_great_power_date() < today
 			)) {
-				great_power->country_status = COUNTRY_STATUS_CIVILISED;
+				great_power.country_status = COUNTRY_STATUS_CIVILISED;
 				return true;
 			} else {
 				return false;
@@ -119,9 +121,9 @@ void CountryInstanceManager::update_rankings(const Date today) {
 
 	// Demote all secondary powers and clear the list. We will rebuilt the whole list from scratch, so there's no need to
 	// keep countries which are still above the max secondary power rank (they might become great powers instead anyway).
-	for (CountryInstance* secondary_power : secondary_powers) {
-		if (secondary_power->country_status == COUNTRY_STATUS_SECONDARY_POWER) {
-			secondary_power->country_status = COUNTRY_STATUS_CIVILISED;
+	for (CountryInstance& secondary_power : secondary_powers) {
+		if (secondary_power.country_status == COUNTRY_STATUS_SECONDARY_POWER) {
+			secondary_power.country_status = COUNTRY_STATUS_CIVILISED;
 		}
 	}
 	secondary_powers.clear();
@@ -133,41 +135,41 @@ void CountryInstanceManager::update_rankings(const Date today) {
 	const size_t max_power_index = std::clamp(max_secondary_power_rank, max_great_power_rank, total_ranking.size());
 
 	for (size_t index = 0; index < max_power_index; index++) {
-		CountryInstance* country = total_ranking[index];
+		CountryInstance& country = total_ranking[index];
 
-		if (!country->is_civilised()) {
+		if (!country.is_civilised()) {
 			// All further countries are civilised and so ineligible for great or secondary power status.
 			break;
 		}
 
-		if (country->is_great_power()) {
+		if (country.is_great_power()) {
 			// The country already has great power status and is in the great powers list.
 			continue;
 		}
 
-		if (great_powers.size() < max_great_power_rank && country->get_total_rank() <= max_great_power_rank) {
+		if (great_powers.size() < max_great_power_rank && country.get_total_rank() <= max_great_power_rank) {
 			// The country is eligible for great power status and there are still slots available,
 			// so it is promoted and added to the list.
-			country->country_status = COUNTRY_STATUS_GREAT_POWER;
+			country.country_status = COUNTRY_STATUS_GREAT_POWER;
 			great_powers.push_back(country);
-		} else if (country->get_total_rank() <= max_secondary_power_rank) {
+		} else if (country.get_total_rank() <= max_secondary_power_rank) {
 			// The country is eligible for secondary power status and so is promoted and added to the list.
-			country->country_status = COUNTRY_STATUS_SECONDARY_POWER;
-			secondary_powers.push_back(country);
+			country.country_status = COUNTRY_STATUS_SECONDARY_POWER;
+			secondary_powers.emplace_back(country);
 		}
 	}
 
 	// Sort the great powers list by total rank, as pre-existing great powers may have changed rank order and new great
 	// powers will have been added to the end of the list regardless of rank.
-	std::stable_sort(great_powers.begin(), great_powers.end(), [](CountryInstance const* a, CountryInstance const* b) -> bool {
-		return a->get_total_rank() < b->get_total_rank();
+	std::stable_sort(great_powers.begin(), great_powers.end(), [](CountryInstance const& a, CountryInstance const& b) -> bool {
+		return a.get_total_rank() < b.get_total_rank();
 	});
 
 	// Update the lose great power date for all great powers which are above the max great power rank.
 	const Date new_lose_great_power_date = today + lose_great_power_grace_days;
-	for (CountryInstance* great_power : great_powers) {
-		if (great_power->get_total_rank() <= max_great_power_rank) {
-			great_power->lose_great_power_date = new_lose_great_power_date;
+	for (CountryInstance& great_power : great_powers) {
+		if (great_power.get_total_rank() <= max_great_power_rank) {
+			great_power.lose_great_power_date = new_lose_great_power_date;
 		}
 	}
 }

--- a/src/openvic-simulation/country/CountryInstanceManager.hpp
+++ b/src/openvic-simulation/country/CountryInstanceManager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string_view>
 
 #include "openvic-simulation/country/CountryInstance.hpp"
@@ -32,13 +33,13 @@ namespace OpenVic {
 
 		OV_IFLATMAP_PROPERTY(CountryDefinition, CountryInstance, country_instance_by_definition);
 
-		memory::vector<CountryInstance*> SPAN_PROPERTY(great_powers);
-		memory::vector<CountryInstance*> SPAN_PROPERTY(secondary_powers);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(great_powers);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(secondary_powers);
 
-		memory::vector<CountryInstance*> SPAN_PROPERTY(total_ranking);
-		memory::vector<CountryInstance*> SPAN_PROPERTY(prestige_ranking);
-		memory::vector<CountryInstance*> SPAN_PROPERTY(industrial_power_ranking);
-		memory::vector<CountryInstance*> SPAN_PROPERTY(military_power_ranking);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(total_ranking);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(prestige_ranking);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(industrial_power_ranking);
+		memory::vector<std::reference_wrapper<CountryInstance>> SPAN_PROPERTY(military_power_ranking);
 
 		void update_rankings(const Date today);
 

--- a/src/openvic-simulation/economy/BuildingType.cpp
+++ b/src/openvic-simulation/economy/BuildingType.cpp
@@ -135,7 +135,7 @@ bool BuildingTypeManager::add_building_type(
 	if (ret) {
 		building_type_types.emplace(building_type_args.type);
 		if (province_building_index.has_value()) {
-			province_building_types.emplace_back(&building_types.back());
+			province_building_types.emplace_back(building_types.back());
 		}
 	}
 

--- a/src/openvic-simulation/economy/BuildingType.hpp
+++ b/src/openvic-simulation/economy/BuildingType.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <optional>
 
 #include "openvic-simulation/modifier/Modifier.hpp"
@@ -112,7 +113,7 @@ namespace OpenVic {
 	private:
 		IdentifierRegistry<BuildingType> IDENTIFIER_REGISTRY(building_type);
 		string_set_t PROPERTY(building_type_types);
-		memory::vector<BuildingType const*> SPAN_PROPERTY(province_building_types);
+		memory::vector<std::reference_wrapper<const BuildingType>> SPAN_PROPERTY(province_building_types);
 		BuildingType const* PROPERTY(infrastructure_building_type);
 		BuildingType const* PROPERTY(port_building_type);
 

--- a/src/openvic-simulation/economy/GoodDefinition.cpp
+++ b/src/openvic-simulation/economy/GoodDefinition.cpp
@@ -66,7 +66,7 @@ bool GoodDefinitionManager::add_good_definition(
 		identifier, colour, GoodDefinition::index_t { get_good_definition_count() }, category, base_price, is_available_from_start,
 		is_tradeable, is_money, has_overseas_penalty
 	)) {
-		category.good_definitions.push_back(&get_back_good_definition());
+		category.good_definitions.emplace_back(get_back_good_definition());
 		return true;
 	} else {
 		return false;

--- a/src/openvic-simulation/economy/GoodDefinition.hpp
+++ b/src/openvic-simulation/economy/GoodDefinition.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/types/HasIdentifier.hpp"
 #include "openvic-simulation/types/HasIndex.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
@@ -14,7 +16,7 @@ namespace OpenVic {
 		friend struct GoodDefinitionManager;
 
 	private:
-		memory::vector<GoodDefinition const*> SPAN_PROPERTY(good_definitions);
+		memory::vector<std::reference_wrapper<const GoodDefinition>> SPAN_PROPERTY(good_definitions);
 	public:
 		GoodCategory(std::string_view new_identifier);
 		GoodCategory(GoodCategory&&) = default;

--- a/src/openvic-simulation/history/CountryHistory.cpp
+++ b/src/openvic-simulation/history/CountryHistory.cpp
@@ -96,13 +96,14 @@ bool CountryHistoryMap::_load_history_entry(
 			std::string_view key,
 			ast::NodeCPtr value
 		) -> bool {
-			ReformGroup const* reform_group = issue_manager.get_reform_group_by_identifier(key);
-			if (reform_group != nullptr) {
-				return issue_manager.expect_reform_identifier([&entry, reform_group](Reform const& reform) -> bool {
-					if (&reform.get_reform_group() != reform_group) {
+			ReformGroup const* reform_group_ptr = issue_manager.get_reform_group_by_identifier(key);
+			if (reform_group_ptr != nullptr) {
+				ReformGroup const& reform_group = *reform_group_ptr;
+				return issue_manager.expect_reform_identifier([&entry, &reform_group](Reform const& reform) -> bool {
+					if (reform.group != reform_group) {
 						spdlog::warn_s(
 							"Listing {} as belonging to the reform group {} when it actually belongs to {} in history of {}",
-							reform, *reform_group, reform.get_reform_group(), entry.country
+							reform, reform_group, reform.group, entry.country
 						);
 					}
 					return set_callback_pointer(entry.reforms)(reform);

--- a/src/openvic-simulation/history/DiplomaticHistory.cpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.cpp
@@ -22,8 +22,8 @@ void DiplomaticHistoryManager::lock_diplomatic_history() {
 	locked = true;
 }
 
-memory::vector<WarHistory const*> DiplomaticHistoryManager::get_wars(Date date) const {
-	memory::vector<WarHistory const*> ret;
+memory::vector<std::reference_wrapper<const WarHistory>> DiplomaticHistoryManager::get_wars(Date date) const {
+	memory::vector<std::reference_wrapper<const WarHistory>> ret;
 	for (auto const& war : wars) {
 		Date start {};
 		for (auto const& wargoal : war.wargoals) {
@@ -32,7 +32,7 @@ memory::vector<WarHistory const*> DiplomaticHistoryManager::get_wars(Date date) 
 			}
 		}
 		if (start >= date) {
-			ret.push_back(&war);
+			ret.emplace_back(war);
 		}
 	}
 	return ret;

--- a/src/openvic-simulation/history/DiplomaticHistory.hpp
+++ b/src/openvic-simulation/history/DiplomaticHistory.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/dataloader/NodeTools.hpp"
 #include "openvic-simulation/history/diplomacy/AllianceHistory.hpp"
 #include "openvic-simulation/history/diplomacy/ReparationsHistory.hpp"
@@ -21,14 +23,14 @@ namespace OpenVic {
 		bool locked = false;
 
 		template<typename HistoryType>
-		static memory::vector<HistoryType const*> filter_by_date(
+		static memory::vector<std::reference_wrapper<const HistoryType>> filter_by_date(
 			std::span<const HistoryType> items,
 			const Date date
 		) {
-			memory::vector<HistoryType const*> ret;
-			for (auto const& item : items) {
+			memory::vector<std::reference_wrapper<const HistoryType>> ret;
+			for (HistoryType const& item : items) {
 				if (item.period.is_date_in_period(date)) {
-					ret.push_back(&item);
+					ret.emplace_back(item);
 				}
 			}
 			return ret;
@@ -43,18 +45,18 @@ namespace OpenVic {
 			return locked;
 		}
 
-		[[nodiscard]] memory::vector<AllianceHistory const*> get_alliances(Date date) const {
+		[[nodiscard]] memory::vector<std::reference_wrapper<const AllianceHistory>> get_alliances(Date date) const {
 			return filter_by_date<AllianceHistory>(alliances, date);
 		}
-		[[nodiscard]] memory::vector<ReparationsHistory const*> get_reparations(Date date) const {
+		[[nodiscard]] memory::vector<std::reference_wrapper<const ReparationsHistory>> get_reparations(Date date) const {
 			return filter_by_date<ReparationsHistory>(reparations, date);
 		}
-		[[nodiscard]] memory::vector<SubjectHistory const*> get_subjects(Date date) const{
+		[[nodiscard]] memory::vector<std::reference_wrapper<const SubjectHistory>> get_subjects(Date date) const{
 			return filter_by_date<SubjectHistory>(subjects, date);
 		}
 		/* Returns all wars that begin before date. NOTE: Some wargoals may be added or countries may join after date,
 		 * should be checked for by functions that use get_wars() */
-		[[nodiscard]] memory::vector<WarHistory const*> get_wars(Date date) const;
+		[[nodiscard]] memory::vector<std::reference_wrapper<const WarHistory>> get_wars(Date date) const;
 
 		bool load_diplomacy_history_file(CountryDefinitionManager const& country_definition_manager, ast::NodeCPtr root);
 		bool load_war_history_file(DefinitionManager const& definition_manager, ast::NodeCPtr root);

--- a/src/openvic-simulation/map/MapDefinition.cpp
+++ b/src/openvic-simulation/map/MapDefinition.cpp
@@ -1129,11 +1129,11 @@ bool MapDefinition::load_climate_file(ModifierManager const& modifier_manager, a
 				);
 			} else {
 				ret &= expect_list_reserve_length(*cur_climate, expect_province_definition_identifier(
-					[cur_climate, &identifier](ProvinceDefinition& province) {
+					[this, cur_climate, &identifier](ProvinceDefinition& province) {
 						if (province.climate != cur_climate) {
 							cur_climate->add_province(province);
 							if (province.climate != nullptr) {
-								Climate* old_climate = const_cast<Climate*>(province.climate);
+								Climate* old_climate = climates.get_item_by_identifier(province.climate->get_identifier());
 								old_climate->remove_province(province);
 								spdlog::warn_s(
 									"Province with id {} found in multiple climates: {} and {}",

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -1,5 +1,6 @@
 #include "MapInstance.hpp"
 
+#include <functional>
 #include <optional>
 #include <tuple>
 
@@ -21,12 +22,12 @@ MapInstance::MapInstance(
 	sea_pathing { new_map_definition, *this },
 	province_instance_by_definition(
 		new_map_definition.get_province_definitions(),
-		[
-			province_instance_deps_ptr=&province_instance_deps
-		](ProvinceDefinition const& province_definition) -> auto {
+		[&province_instance_deps](
+			ProvinceDefinition const& province_definition
+		) -> auto {
 			return std::make_tuple(
-				&province_definition,
-				province_instance_deps_ptr
+				std::ref(province_definition),
+				std::ref(province_instance_deps)
 			);
 		}
 	) { assert(new_map_definition.province_definitions_are_locked()); }

--- a/src/openvic-simulation/map/ProvinceDefinition.cpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.cpp
@@ -153,13 +153,13 @@ bool ProvinceDefinition::is_adjacent_to(ProvinceDefinition const& province) cons
 	);
 }
 
-memory::vector<ProvinceDefinition::adjacency_t const*> ProvinceDefinition::get_adjacencies_going_through(
+memory::vector<std::reference_wrapper<const ProvinceDefinition::adjacency_t>> ProvinceDefinition::get_adjacencies_going_through(
 	ProvinceDefinition const& province
 ) const {
-	memory::vector<adjacency_t const*> ret;
+	memory::vector<std::reference_wrapper<const adjacency_t>> ret;
 	for (adjacency_t const& adj : adjacencies) {
 		if (adj.get_through() != nullptr && *adj.get_through() == province) {
-			ret.push_back(&adj);
+			ret.emplace_back(adj);
 		}
 	}
 	return ret;

--- a/src/openvic-simulation/map/ProvinceDefinition.hpp
+++ b/src/openvic-simulation/map/ProvinceDefinition.hpp
@@ -151,7 +151,7 @@ namespace OpenVic {
 
 		adjacency_t const* get_adjacency_to(ProvinceDefinition const& province) const;
 		bool is_adjacent_to(ProvinceDefinition const& province) const;
-		memory::vector<adjacency_t const*> get_adjacencies_going_through(ProvinceDefinition const& province) const;
+		memory::vector<std::reference_wrapper<const adjacency_t>> get_adjacencies_going_through(ProvinceDefinition const& province) const;
 		bool has_adjacency_going_through(ProvinceDefinition const& province) const;
 
 		fvec2_t get_unit_position() const;

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -20,27 +20,27 @@
 using namespace OpenVic;
 
 ProvinceInstance::ProvinceInstance(
-	ProvinceDefinition const* new_province_definition,
-	ProvinceInstanceDeps const* province_instance_deps
-) : HasIdentifierAndColour { *new_province_definition },
-	HasIndex { new_province_definition->index },
+	ProvinceDefinition const& new_province_definition,
+	ProvinceInstanceDeps const& province_instance_deps
+) : HasIdentifierAndColour { new_province_definition },
+	HasIndex { new_province_definition.index },
 	FlagStrings { "province" },
 	PopsAggregate {
-		province_instance_deps->stratas,
-		province_instance_deps->pop_types,
-		province_instance_deps->ideologies
+		province_instance_deps.stratas,
+		province_instance_deps.pop_types,
+		province_instance_deps.ideologies
 	},
-	province_definition { *new_province_definition },
-	game_rules_manager { province_instance_deps->game_rules_manager },
-	terrain_type { new_province_definition->get_default_terrain_type() },
-	rgo { province_instance_deps->rgo_deps },
-	pops_cache_by_type { province_instance_deps->pop_types },
+	province_definition { new_province_definition },
+	game_rules_manager { province_instance_deps.game_rules_manager },
+	terrain_type { new_province_definition.get_default_terrain_type() },
+	rgo { province_instance_deps.rgo_deps },
+	pops_cache_by_type { province_instance_deps.pop_types },
 	_buildings(
-		new_province_definition->is_water()
+		new_province_definition.is_water()
 			? 0
-			: province_instance_deps->building_type_manager.get_province_building_types().size(),
-			[&province_instance_deps](const size_t i) -> BuildingInstance {
-				return *province_instance_deps->building_type_manager.get_province_building_types()[i];
+			: province_instance_deps.building_type_manager.get_province_building_types().size(),
+			[&province_instance_deps](const size_t i) -> BuildingType const& {
+				return province_instance_deps.building_type_manager.get_province_building_types()[i];
 			}
 	),
 	buildings(_buildings)

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -128,10 +128,9 @@ namespace OpenVic {
 	public:
 		ProvinceDefinition const& province_definition;
 
-		//pointers instead of references to allow construction via std::tuple
 		ProvinceInstance(
-			ProvinceDefinition const* new_province_definition,
-			ProvinceInstanceDeps const* province_instance_deps
+			ProvinceDefinition const& new_province_definition,
+			ProvinceInstanceDeps const& province_instance_deps
 		);
 		ProvinceInstance(ProvinceInstance const&) = delete;
 		ProvinceInstance& operator=(ProvinceInstance const&) = delete;

--- a/src/openvic-simulation/military/Wargoal.cpp
+++ b/src/openvic-simulation/military/Wargoal.cpp
@@ -1,5 +1,7 @@
 #include "Wargoal.hpp"
 
+#include <range/v3/algorithm/contains.hpp>
+
 #include <openvic-dataloader/v2script/Parser.hpp>
 
 #include "openvic-simulation/dataloader/NodeTools.hpp"
@@ -209,8 +211,11 @@ bool WargoalTypeManager::load_wargoal_file(ovdl::v2script::Parser const& parser)
 		expect_list(
 			expect_wargoal_type_identifier(
 				[this](WargoalType const& wargoal) -> bool {
-					if (std::find(peace_priorities.begin(), peace_priorities.end(), &wargoal) == peace_priorities.end()) {
-						peace_priorities.push_back(&wargoal);
+					if (!ranges::contains(
+						peace_priorities,
+						wargoal
+					)) {
+						peace_priorities.emplace_back(wargoal);
 					} else {
 						spdlog::warn_s("Wargoal {} is already in the peace priority list!", wargoal);
 					}

--- a/src/openvic-simulation/military/Wargoal.hpp
+++ b/src/openvic-simulation/military/Wargoal.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include <openvic-dataloader/v2script/Parser.hpp>
 
 #include "openvic-simulation/scripts/ConditionScript.hpp"
@@ -101,7 +103,7 @@ namespace OpenVic {
 	struct WargoalTypeManager {
 	private:
 		IdentifierRegistry<WargoalType> IDENTIFIER_REGISTRY(wargoal_type);
-		memory::vector<WargoalType const*> SPAN_PROPERTY(peace_priorities);
+		memory::vector<std::reference_wrapper<const WargoalType>> SPAN_PROPERTY(peace_priorities);
 
 	public:
 		bool add_wargoal_type(

--- a/src/openvic-simulation/misc/Event.cpp
+++ b/src/openvic-simulation/misc/Event.cpp
@@ -1,9 +1,11 @@
 #include "Event.hpp"
+
 #include <charconv>
 #include <system_error>
 
+#include <fmt/std.h>
+
 #include "openvic-simulation/dataloader/NodeTools.hpp"
-#include "openvic-simulation/politics/BaseIssue.hpp"
 #include "openvic-simulation/politics/IssueManager.hpp"
 #include "openvic-simulation/utility/Containers.hpp"
 
@@ -26,7 +28,7 @@ Event::Event(
 	std::string_view new_image, event_type_t new_type, bool new_triggered_only, bool new_major, bool new_fire_only_once,
 	bool new_allows_multiple_instances, bool new_news, std::string_view new_news_title, std::string_view new_news_desc_long,
 	std::string_view new_news_desc_medium, std::string_view new_news_desc_short, bool new_election,
-	BaseIssueGroup const* new_election_issue_group, ConditionScript&& new_trigger, ConditionalWeightTime&& new_mean_time_to_happen,
+	const issue_group_t new_election_issue_group, ConditionScript&& new_trigger, ConditionalWeightTime&& new_mean_time_to_happen,
 	EffectScript&& new_immediate, memory::vector<EventOption>&& new_options
 ) : HasIdentifier { new_identifier }, title { new_title }, description { new_description }, image { new_image },
 	type { new_type }, is_triggered_only { new_triggered_only }, is_major { new_major }, fire_only_once { new_fire_only_once },
@@ -59,7 +61,7 @@ bool EventManager::register_event(
 	std::string_view identifier, std::string_view title, std::string_view description, std::string_view image,
 	Event::event_type_t type, bool triggered_only, bool major, bool fire_only_once, bool allows_multiple_instances, bool news,
 	std::string_view news_title, std::string_view news_desc_long, std::string_view news_desc_medium,
-	std::string_view news_desc_short, bool election, BaseIssueGroup const* election_issue_group, ConditionScript&& trigger,
+	std::string_view news_desc_short, bool election, const issue_group_t election_issue_group, ConditionScript&& trigger,
 	ConditionalWeightTime&& mean_time_to_happen, EffectScript&& immediate, memory::vector<Event::EventOption>&& options
 ) {
 	if (identifier.empty()) {
@@ -76,13 +78,29 @@ bool EventManager::register_event(
 		spdlog::error_s("No options specified for event with ID {}", identifier);
 		return false;
 	}
-	if (election && election_issue_group == nullptr) {
+	if (election && std::holds_alternative<std::monostate>(election_issue_group)) {
 		spdlog::warn_s("Event with ID {} is an election event but has no issue group!", identifier);
-	} else if (!election && election_issue_group != nullptr) {
-		spdlog::warn_s(
-			"Event with ID {} is not an election event but has issue group {}!",
-			identifier, *election_issue_group
-		);
+	} else if (!election) {
+		std::visit([identifier](auto&& arg) {
+			using T = std::decay_t<decltype(arg)>; // Get the clean type
+			
+			if constexpr (std::is_same_v<T, std::reference_wrapper<const PartyPolicyGroup>>) {
+				spdlog::warn_s(
+					"Event with ID {} is not an election event but has party policy group {}!",
+					identifier, arg
+				);
+			} else if constexpr (std::is_same_v<T, std::reference_wrapper<const ReformGroup>>) {
+				spdlog::warn_s(
+					"Event with ID {} is not an election event but has reform group {}!",
+					identifier, arg
+				);
+			} else if constexpr (!std::is_same_v<T, std::monostate>){
+				spdlog::error_s(
+					"Event with ID {} is not an election event but has unknown issue group {}!",
+					identifier, arg
+				);
+			}
+		}, election_issue_group);
 	}
 	if (news) {
 		if (news_desc_long.empty() || news_desc_medium.empty() || news_desc_short.empty()) {
@@ -149,7 +167,7 @@ bool EventManager::load_event_file(IssueManager const& issue_manager, ast::NodeC
 				news_desc_short;
 			bool triggered_only = false, major = false, fire_only_once = false, allows_multiple_instances = false,
 				news = false, election = false;
-			BaseIssueGroup const* election_issue_group = nullptr;
+			issue_group_t election_issue_group;
 			ConditionScript trigger { initial_scope, COUNTRY, NO_SCOPE };
 			ConditionalWeightTime mean_time_to_happen { initial_scope, COUNTRY, NO_SCOPE };
 			EffectScript immediate;
@@ -175,7 +193,7 @@ bool EventManager::load_event_file(IssueManager const& issue_manager, ast::NodeC
 				"news_desc_medium", ZERO_OR_ONE, expect_identifier_or_string(assign_variable_callback(news_desc_medium)),
 				"news_desc_short", ZERO_OR_ONE, expect_identifier_or_string(assign_variable_callback(news_desc_short)),
 				"election", ZERO_OR_ONE, expect_bool(assign_variable_callback(election)),
-				"issue_group", ZERO_OR_ONE, issue_manager.expect_base_issue_group_identifier(assign_variable_callback_pointer(election_issue_group)),
+				"issue_group", ZERO_OR_ONE, issue_manager.expect_base_issue_group_identifier(assign_variable_callback(election_issue_group)),
 				"option", ONE_OR_MORE, [initial_scope](ast::NodeCPtr node) -> bool {
 					std::string_view name;
 					EffectScript effect;

--- a/src/openvic-simulation/misc/Event.hpp
+++ b/src/openvic-simulation/misc/Event.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "openvic-simulation/politics/IssueGroup.hpp"
 #include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/scripts/EffectScript.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
@@ -7,7 +8,6 @@
 #include "openvic-simulation/utility/Containers.hpp"
 
 namespace OpenVic {
-	struct BaseIssueGroup;
 	struct EventManager;
 	struct IssueManager;
 
@@ -46,7 +46,7 @@ namespace OpenVic {
 		memory::string PROPERTY(news_desc_short);
 
 		bool PROPERTY_CUSTOM_PREFIX(election, is);
-		BaseIssueGroup const* PROPERTY(election_issue_group);
+		issue_group_t PROPERTY(election_issue_group);
 
 		ConditionScript PROPERTY(trigger);
 		ConditionalWeightTime PROPERTY(mean_time_to_happen);
@@ -68,7 +68,7 @@ namespace OpenVic {
 			std::string_view new_image, event_type_t new_type, bool new_triggered_only, bool new_major,
 			bool new_fire_only_once, bool new_allows_multiple_instances, bool new_news, std::string_view new_news_title,
 			std::string_view new_news_desc_long, std::string_view new_news_desc_medium, std::string_view new_news_desc_short,
-			bool new_election, BaseIssueGroup const* new_election_issue_group, ConditionScript&& new_trigger,
+			bool new_election, const issue_group_t new_election_issue_group, ConditionScript&& new_trigger,
 			ConditionalWeightTime&& new_mean_time_to_happen, EffectScript&& new_immediate,
 			memory::vector<EventOption>&& new_options
 		);
@@ -98,7 +98,7 @@ namespace OpenVic {
 			std::string_view identifier, std::string_view title, std::string_view description, std::string_view image,
 			Event::event_type_t type, bool triggered_only, bool major, bool fire_only_once, bool allows_multiple_instances,
 			bool news, std::string_view news_title, std::string_view news_desc_long, std::string_view news_desc_medium,
-			std::string_view news_desc_short, bool election, BaseIssueGroup const* election_issue_group, ConditionScript&& trigger,
+			std::string_view news_desc_short, bool election, const issue_group_t election_issue_group, ConditionScript&& trigger,
 			ConditionalWeightTime&& mean_time_to_happen, EffectScript&& immediate, memory::vector<Event::EventOption>&& options
 		);
 

--- a/src/openvic-simulation/politics/BaseIssue.cpp
+++ b/src/openvic-simulation/politics/BaseIssue.cpp
@@ -6,12 +6,10 @@ BaseIssue::BaseIssue(
 	std::string_view new_identifier,
 	colour_t new_colour,
 	ModifierValue&& new_values,
-	BaseIssueGroup const& new_issue_group,
 	RuleSet&& new_rules,
 	bool new_is_jingoism,
 	modifier_type_t new_type
 ) : Modifier { new_identifier, std::move(new_values), new_type },
 	HasColour { new_colour, false },
-	issue_group { new_issue_group },
 	rules { std::move(new_rules) },
 	is_jingoism { new_is_jingoism } {}

--- a/src/openvic-simulation/politics/BaseIssue.hpp
+++ b/src/openvic-simulation/politics/BaseIssue.hpp
@@ -3,18 +3,14 @@
 #include "openvic-simulation/modifier/Modifier.hpp"
 #include "openvic-simulation/politics/RuleSet.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
-#include "openvic-simulation/utility/Getters.hpp"
 
 namespace OpenVic {
-	struct BaseIssueGroup;
-
 	struct BaseIssue : Modifier, public HasColour {
 	protected:
 		BaseIssue(
 			std::string_view new_identifier,
 			colour_t new_colour,
 			ModifierValue&& new_values,
-			BaseIssueGroup const& new_issue_group,
 			RuleSet&& new_rules,
 			bool new_is_jingoism,
 			modifier_type_t new_type
@@ -23,18 +19,5 @@ namespace OpenVic {
 	public:
 		const bool is_jingoism;
 		const RuleSet rules;
-
-		BaseIssueGroup const& issue_group;		
-	};
-
-	struct BaseIssueGroup : HasIdentifier {
-		friend struct IssueManager;
-
-	private:
-		memory::vector<BaseIssue const*> SPAN_PROPERTY(issues);
-
-	protected:
-		BaseIssueGroup(std::string_view new_identifier): HasIdentifier { new_identifier } {}
-		BaseIssueGroup(BaseIssueGroup&&) = default;
 	};
 }

--- a/src/openvic-simulation/politics/Government.cpp
+++ b/src/openvic-simulation/politics/Government.cpp
@@ -1,5 +1,7 @@
 #include "Government.hpp"
 
+#include <range/v3/algorithm/contains.hpp>
+
 #include "openvic-simulation/politics/Ideology.hpp"
 
 using namespace OpenVic;
@@ -8,7 +10,7 @@ using namespace OpenVic::NodeTools;
 GovernmentType::GovernmentType(
 	index_t new_index,
 	std::string_view new_identifier,
-	memory::vector<Ideology const*>&& new_ideologies,
+	memory::vector<std::reference_wrapper<const Ideology>>&& new_ideologies,
 	bool new_holds_elections,
 	bool new_can_appoint_ruling_party,
 	Timespan new_term_duration,
@@ -21,12 +23,15 @@ GovernmentType::GovernmentType(
 	term_duration { new_term_duration },
 	flag_type_identifier { new_flag_type_identifier } {}
 
-bool GovernmentType::is_ideology_compatible(Ideology const* ideology) const {
-	return std::find(ideologies.begin(), ideologies.end(), ideology) != ideologies.end();
+bool GovernmentType::is_ideology_compatible(Ideology const& ideology) const {
+	return ranges::contains(
+		ideologies,
+		ideology
+	);
 }
 
 bool GovernmentTypeManager::add_government_type(
-	std::string_view identifier, memory::vector<Ideology const*>&& ideologies, bool elections, bool appoint_ruling_party,
+	std::string_view identifier, memory::vector<std::reference_wrapper<const Ideology>>&& ideologies, bool elections, bool appoint_ruling_party,
 	Timespan term_duration, std::string_view flag_type
 ) {
 	spdlog::scope scope { fmt::format("government type {}", identifier) };
@@ -64,7 +69,7 @@ bool GovernmentTypeManager::load_government_types_file(IdeologyManager const& id
 	bool ret = expect_dictionary_reserve_length(
 		government_types,
 		[this, &ideology_manager](std::string_view government_type_identifier, ast::NodeCPtr government_type_value) -> bool {
-			memory::vector<Ideology const*> ideologies;
+			memory::vector<std::reference_wrapper<const Ideology>> ideologies;
 			bool elections = false, appoint_ruling_party = false;
 			Timespan term_duration = 0;
 			std::string_view flag_type_identifier;
@@ -87,29 +92,32 @@ bool GovernmentTypeManager::load_government_types_file(IdeologyManager const& id
 					if (reserved_keys.contains(key)) {
 						return true;
 					}
-					Ideology const* ideology = ideology_manager.get_ideology_by_identifier(key);
-					if (ideology == nullptr) {
+					Ideology const* ideology_ptr = ideology_manager.get_ideology_by_identifier(key);
+					if (ideology_ptr == nullptr) {
 						spdlog::error_s(
 							"When loading government type {}, specified ideology {} is invalid!",
 							government_type_identifier, key
 						);
 						return false;
 					}
-					return expect_bool([&ideologies, ideology, government_type_identifier](bool val) -> bool {
+					return expect_bool([&ideologies, &ideology = *ideology_ptr, government_type_identifier](bool val) -> bool {
 						if (val) {
-							if (std::find(ideologies.begin(), ideologies.end(), ideology) == ideologies.end()) {
-								ideologies.push_back(ideology);
+							if (!ranges::contains(
+								ideologies,
+								ideology
+							)) {
+								ideologies.emplace_back(ideology);
 								return true;
 							}
 							spdlog::error_s(
 								"Government type {} marked as supporting ideology {}",
-								government_type_identifier, *ideology
+								government_type_identifier, ideology
 							);
 							return false;
 						}
 						spdlog::error_s(
 							"Government type {} redundantly marked as not supporting ideology {} multiple times",
-							government_type_identifier, *ideology
+							government_type_identifier, ideology
 						);
 						return false;
 					})(value);

--- a/src/openvic-simulation/politics/Government.hpp
+++ b/src/openvic-simulation/politics/Government.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/HasIdentifier.hpp"
 #include "openvic-simulation/types/HasIndex.hpp"
@@ -13,7 +15,7 @@ namespace OpenVic {
 
 	struct GovernmentType : HasIndex<GovernmentType, government_type_index_t>, HasIdentifier {
 	private:
-		memory::vector<Ideology const*> SPAN_PROPERTY(ideologies);
+		memory::vector<std::reference_wrapper<const Ideology>> SPAN_PROPERTY(ideologies);
 		memory::string PROPERTY_CUSTOM_NAME(flag_type_identifier, get_flag_type);
 
 	public:
@@ -24,7 +26,7 @@ namespace OpenVic {
 		GovernmentType(
 			index_t new_index,
 			std::string_view new_identifier,
-			memory::vector<Ideology const*>&& new_ideologies,
+			memory::vector<std::reference_wrapper<const Ideology>>&& new_ideologies,
 			bool new_holds_elections,
 			bool new_can_appoint_ruling_party,
 			Timespan new_term_duration,
@@ -32,7 +34,7 @@ namespace OpenVic {
 		);
 		GovernmentType(GovernmentType&&) = default;
 
-		bool is_ideology_compatible(Ideology const* ideology) const;
+		bool is_ideology_compatible(Ideology const& ideology) const;
 	};
 
 	struct GovernmentTypeManager {
@@ -42,7 +44,7 @@ namespace OpenVic {
 
 	public:
 		bool add_government_type(
-			std::string_view identifier, memory::vector<Ideology const*>&& ideologies, bool elections, bool appoint_ruling_party,
+			std::string_view identifier, memory::vector<std::reference_wrapper<const Ideology>>&& ideologies, bool elections, bool appoint_ruling_party,
 			Timespan term_duration, std::string_view flag_type
 		);
 

--- a/src/openvic-simulation/politics/IssueGroup.hpp
+++ b/src/openvic-simulation/politics/IssueGroup.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <functional>
+#include <variant>
+
+namespace OpenVic {
+	struct PartyPolicyGroup;
+	struct ReformGroup;
+	using issue_group_t = std::variant<
+		std::monostate,
+		std::reference_wrapper<const PartyPolicyGroup>,
+		std::reference_wrapper<const ReformGroup>
+	>;
+}

--- a/src/openvic-simulation/politics/IssueManager.cpp
+++ b/src/openvic-simulation/politics/IssueManager.cpp
@@ -35,7 +35,7 @@ bool IssueManager::add_party_policy(
 		return false;
 	}
 
-	party_policy_group.issues.push_back(&get_back_party_policy());
+	party_policy_group.party_policies.emplace_back(get_back_party_policy());
 	return true;
 }
 
@@ -66,7 +66,7 @@ bool IssueManager::add_reform_group(
 		return false;
 	}
 
-	reform_type.reform_groups.push_back(&get_back_reform_group());
+	reform_type.reform_groups.emplace_back(get_back_reform_group());
 	return true;
 }
 
@@ -119,7 +119,7 @@ bool IssueManager::add_reform(
 		return false;
 	}
 
-	reform_group.issues.push_back(&get_back_reform());
+	reform_group.reforms.emplace_back(get_back_reform());
 	return true;
 }
 

--- a/src/openvic-simulation/politics/IssueManager.hpp
+++ b/src/openvic-simulation/politics/IssueManager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "openvic-simulation/politics/BaseIssue.hpp"
+#include "openvic-simulation/politics/IssueGroup.hpp"
 #include "openvic-simulation/politics/PartyPolicy.hpp"
 #include "openvic-simulation/politics/Reform.hpp"
 #include "openvic-simulation/types/IdentifierRegistry.hpp"
@@ -39,15 +40,21 @@ namespace OpenVic {
 			}
 			return issue;
 		}
-		constexpr BaseIssueGroup const* get_base_issue_group_by_identifier(std::string_view identifier) const {
-			BaseIssueGroup const* issue = get_party_policy_group_by_identifier(identifier);
-			if (issue == nullptr) {
-				issue = get_reform_group_by_identifier(identifier);
+		constexpr issue_group_t get_base_issue_group_by_identifier(std::string_view identifier) const {
+			PartyPolicyGroup const* const party_policy_group = get_party_policy_group_by_identifier(identifier);
+			if (party_policy_group != nullptr) {
+				return { *party_policy_group };
 			}
-			return issue;
+
+			ReformGroup const* const reform_group = get_reform_group_by_identifier(identifier);
+			if (reform_group != nullptr) {
+				return { *reform_group };
+			}
+
+			return {};
 		}
 		constexpr NodeTools::NodeCallback auto expect_base_issue_group_identifier(
-			NodeTools::Callback<BaseIssueGroup const&> auto callback, bool warn = false
+			NodeTools::Callback<issue_group_t> auto callback, bool warn = false
 		) const {
 			return NodeTools::expect_identifier(
 				[this, callback, warn](std::string_view identifier) -> bool {
@@ -58,15 +65,16 @@ namespace OpenVic {
 						);
 						return warn;
 					}
-					BaseIssueGroup const* item = get_base_issue_group_by_identifier(identifier);
-					if (item != nullptr) {
-						return callback(*item);
+					issue_group_t issue_group = get_base_issue_group_by_identifier(identifier);
+					if (std::holds_alternative<std::monostate>(issue_group)) {
+						spdlog::log_s(
+							warn ? spdlog::level::warn : spdlog::level::err,
+							"Invalid base issue group identifier: {}", identifier
+						);
+						return warn;
 					}
-					spdlog::log_s(
-						warn ? spdlog::level::warn : spdlog::level::err,
-						"Invalid base issue group identifier: {}", identifier
-					);
-					return warn;
+					
+					return callback(issue_group);
 				}
 			);
 		}

--- a/src/openvic-simulation/politics/PartyPolicy.hpp
+++ b/src/openvic-simulation/politics/PartyPolicy.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/politics/BaseIssue.hpp"
 #include "openvic-simulation/types/HasIndex.hpp"
 #include "openvic-simulation/types/TypedIndices.hpp"
@@ -8,24 +10,24 @@ namespace OpenVic {
 	struct PartyPolicy;
 
 	// PartyPolicy group (i.e. trade_policy)
-	struct PartyPolicyGroup : HasIndex<PartyPolicyGroup, party_policy_group_index_t>, BaseIssueGroup {
+	struct PartyPolicyGroup : HasIndex<PartyPolicyGroup, party_policy_group_index_t>, HasIdentifier {
 		friend struct IssueManager;
+	private:
+		memory::vector<std::reference_wrapper<const PartyPolicy>> SPAN_PROPERTY(party_policies);
 
 	public:
 		PartyPolicyGroup(
 			std::string_view new_identifier,
 			index_t new_index
-		) : HasIndex { new_index }, BaseIssueGroup { new_identifier } {}
+		) : HasIndex { new_index }, HasIdentifier { new_identifier } {}
 		PartyPolicyGroup(PartyPolicyGroup&&) = default;
-
-		std::span<PartyPolicy const* const> get_party_policies() const {
-			return { reinterpret_cast<PartyPolicy const* const*>(get_issues().data()), get_issues().size() };
-		}
 	};
 
 	// PartyPolicy (i.e. protectionism)
 	struct PartyPolicy : HasIndex<PartyPolicy, party_policy_index_t>, BaseIssue {
 	public:
+		PartyPolicyGroup const& group;
+
 		PartyPolicy(
 			index_t new_index,
 			std::string_view new_identifier,
@@ -39,11 +41,11 @@ namespace OpenVic {
 				new_identifier,
 				new_colour,
 				std::move(new_values),
-				new_issue_group,
 				std::move(new_rules),
 				new_is_jingoism,
 				modifier_type_t::PARTY_POLICY
-			} {}
+			},
+			group { new_issue_group } {}
 		PartyPolicy(PartyPolicy&&) = default;
 	};
 }

--- a/src/openvic-simulation/politics/Reform.cpp
+++ b/src/openvic-simulation/politics/Reform.cpp
@@ -11,7 +11,7 @@ ReformGroup::ReformGroup(
 	ReformType const& new_reform_type,
 	bool new_is_ordered,
 	bool new_is_administrative
-) : BaseIssueGroup { new_identifier },
+) : HasIdentifier { new_identifier },
 	HasIndex { new_index },
 	reform_type { new_reform_type },
 	is_ordered { new_is_ordered },
@@ -23,13 +23,14 @@ Reform::Reform(
 	size_t new_ordinal, fixed_point_t new_administrative_multiplier, RuleSet&& new_rules, tech_cost_t new_technology_cost,
 	ConditionScript&& new_allow, ConditionScript&& new_on_execute_trigger, EffectScript&& new_on_execute_effect
 ) : BaseIssue {
-		new_identifier, new_colour, std::move(new_values), new_reform_group, std::move(new_rules), false,
+		new_identifier, new_colour, std::move(new_values), std::move(new_rules), false,
 		modifier_type_t::REFORM
 	},
 	HasIndex { new_index },
 	ordinal { new_ordinal },
 	administrative_multiplier { new_administrative_multiplier },
 	technology_cost { new_technology_cost },
+	group { new_reform_group },
 	allow { std::move(new_allow) },
 	on_execute_trigger { std::move(new_on_execute_trigger) },
 	on_execute_effect { std::move(new_on_execute_effect) } {}

--- a/src/openvic-simulation/politics/Reform.hpp
+++ b/src/openvic-simulation/politics/Reform.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/politics/BaseIssue.hpp"
 #include "openvic-simulation/scripts/ConditionScript.hpp"
 #include "openvic-simulation/scripts/EffectScript.hpp"
@@ -16,7 +18,7 @@ namespace OpenVic {
 
 	private:
 		// in vanilla education, military and economic reforms are hardcoded to true and the rest to false
-		memory::vector<ReformGroup const*> SPAN_PROPERTY(reform_groups);
+		memory::vector<std::reference_wrapper<const ReformGroup>> SPAN_PROPERTY(reform_groups);
 
 	public:
 		const bool is_civilizing;
@@ -28,7 +30,11 @@ namespace OpenVic {
 	struct Reform;
 
 	// Reform group (i.e. slavery)
-	struct ReformGroup : HasIndex<ReformGroup, reform_group_index_t>, BaseIssueGroup {
+	struct ReformGroup : HasIndex<ReformGroup, reform_group_index_t>, HasIdentifier {
+		friend struct IssueManager;
+
+	private:
+		memory::vector<std::reference_wrapper<const Reform>> SPAN_PROPERTY(reforms);
 
 	public:
 		ReformType const& reform_type;
@@ -43,10 +49,6 @@ namespace OpenVic {
 			bool new_is_administrative
 		);
 		ReformGroup(ReformGroup&&) = default;
-
-		std::span<Reform const* const> get_reforms() const {
-			return { reinterpret_cast<Reform const* const*>(get_issues().data()), get_issues().size() };
-		}
 
 		constexpr bool is_civilizing() const {
 			return reform_type.is_civilizing;
@@ -70,6 +72,8 @@ namespace OpenVic {
 		const fixed_point_t administrative_multiplier;
 		const tech_cost_t technology_cost;
 
+		ReformGroup const& group;
+
 		Reform(
 			index_t new_index, std::string_view new_identifier,
 			colour_t new_colour, ModifierValue&& new_values, ReformGroup const& new_reform_group,
@@ -78,9 +82,5 @@ namespace OpenVic {
 			ConditionScript&& new_on_execute_trigger, EffectScript&& new_on_execute_effect
 		);
 		Reform(Reform&&) = default;
-
-		constexpr ReformGroup const& get_reform_group() const {
-			return static_cast<ReformGroup const&>(issue_group);
-		}
 	};
 }

--- a/src/openvic-simulation/population/Pop.cpp
+++ b/src/openvic-simulation/population/Pop.cpp
@@ -131,7 +131,7 @@ void Pop::setup_pop_test_values(IssueManager const& issue_manager) {
 		test_weight_ordered(supporter_equivalents_by_issue, issue, 3, 6);
 	}
 	for (Reform const& reform : issue_manager.get_reforms()) {
-		if (!reform.get_reform_group().is_civilizing()) {
+		if (!reform.group.is_civilizing()) {
 			test_weight_ordered(supporter_equivalents_by_issue, reform, 3, 6);
 		}
 	}

--- a/src/openvic-simulation/population/PopManager.cpp
+++ b/src/openvic-simulation/population/PopManager.cpp
@@ -197,7 +197,7 @@ bool PopManager::add_pop_type(
 
 	delayed_parse_nodes.emplace_back(rebel_units, equivalent, promote_to_node, issues_node);
 
-	strata->pop_types.push_back(&pop_types.back());
+	strata->pop_types.emplace_back(pop_types.back());
 
 	if (slave_sprite <= 0 && is_slave) {
 		/* Set slave sprite to that of the first is_slave pop type we find. */

--- a/src/openvic-simulation/population/PopType.hpp
+++ b/src/openvic-simulation/population/PopType.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "openvic-simulation/scripts/ConditionalWeight.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPointMap.hpp"
@@ -23,7 +25,7 @@ namespace OpenVic {
 		friend struct PopManager;
 
 	private:
-		memory::vector<PopType const*> SPAN_PROPERTY(pop_types);
+		memory::vector<std::reference_wrapper<const PopType>> SPAN_PROPERTY(pop_types);
 
 	public:
 		Strata(std::string_view new_identifier, index_t new_index);

--- a/src/openvic-simulation/research/Invention.cpp
+++ b/src/openvic-simulation/research/Invention.cpp
@@ -150,7 +150,7 @@ bool InventionManager::generate_invention_links(TechnologyManager& tech_manager)
 			if (tech == nullptr) {
 				continue;
 			}
-			tech->add_invention(&invention);
+			tech->add_invention(invention);
 		}
 
 		invention.raw_associated_tech_identifiers.clear();

--- a/src/openvic-simulation/research/Technology.cpp
+++ b/src/openvic-simulation/research/Technology.cpp
@@ -280,11 +280,11 @@ bool TechnologyManager::generate_technology_lists() {
 	}
 
 	for (TechnologyArea const& area : technology_areas.get_items()) {
-		const_cast<TechnologyFolder&>(area.folder).technology_areas.push_back(&area);
+		const_cast<TechnologyFolder&>(area.folder).technology_areas.emplace_back(area);
 	}
 
 	for (Technology const& tech : technologies.get_items()) {
-		const_cast<TechnologyArea&>(tech.area).technologies.push_back(&tech);
+		const_cast<TechnologyArea&>(tech.area).technologies.emplace_back(tech);
 	}
 
 	bool ret = true;

--- a/src/openvic-simulation/research/Technology.hpp
+++ b/src/openvic-simulation/research/Technology.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 
 #include "openvic-simulation/modifier/Modifier.hpp"
 #include "openvic-simulation/scripts/ConditionalWeight.hpp"
@@ -25,7 +26,7 @@ namespace OpenVic {
 		friend struct TechnologyManager;
 
 	private:
-		memory::vector<TechnologyArea const*> SPAN_PROPERTY(technology_areas);
+		memory::vector<std::reference_wrapper<const TechnologyArea>> SPAN_PROPERTY(technology_areas);
 
 	public:
 		TechnologyFolder(std::string_view new_identifier, index_t new_index);
@@ -36,7 +37,7 @@ namespace OpenVic {
 		friend struct TechnologyManager;
 
 	private:
-		memory::vector<Technology const*> SPAN_PROPERTY(technologies);
+		memory::vector<std::reference_wrapper<const Technology>> SPAN_PROPERTY(technologies);
 		size_t PROPERTY(tech_count, 0);
 
 	public:
@@ -56,7 +57,7 @@ namespace OpenVic {
 	private:
 		std::optional<unit_variant_t> PROPERTY(unit_variant);
 		ConditionalWeightFactorMul PROPERTY(ai_chance);
-		memory::vector<Invention const*> PROPERTY(inventions);
+		memory::vector<std::reference_wrapper<const Invention>> PROPERTY(inventions);
 
 		bool parse_scripts(DefinitionManager const& definition_manager);
 
@@ -85,8 +86,8 @@ namespace OpenVic {
 		);
 		Technology(Technology&&) = default;
 
-		void add_invention(Invention const* invention) {
-			inventions.push_back(invention);
+		void add_invention(Invention const& invention) {
+			inventions.emplace_back(invention);
 		}
 	};
 

--- a/src/openvic-simulation/types/HasIdentifier.hpp
+++ b/src/openvic-simulation/types/HasIdentifier.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <concepts>
 #include <cstddef>
 #include <string_view>
 #include <ostream>
@@ -8,6 +9,7 @@
 #include <fmt/base.h>
 
 #include "openvic-simulation/core/template/Concepts.hpp"
+#include "openvic-simulation/core/template/Functional.hpp" // IWYU pragma: keep: bug fix for std::reference_wrapper hash & equality
 #include "openvic-simulation/types/Colour.hpp"
 #include "openvic-simulation/utility/Getters.hpp"
 
@@ -31,10 +33,18 @@ namespace OpenVic {
 		HasIdentifier& operator=(HasIdentifier const&) = delete;
 		HasIdentifier& operator=(HasIdentifier&&) = delete;
 
-		template <std::derived_from<HasIdentifier> T>
+		template <std::derived_from<HasIdentifier> T, std::convertible_to<T const&> U>
 		requires (!has_index<T>)
-		friend bool operator==(T const& lhs, T const& rhs) {
-			return lhs.get_identifier() == rhs.get_identifier();
+		friend bool operator==(T const& lhs, U const& rhs) {
+			return lhs.get_identifier() == static_cast<T const&>(rhs).get_identifier();
+		}
+
+		template <typename T, typename U>
+		requires specialization_of<std::decay_t<T>, std::reference_wrapper>
+			&& std::derived_from<typename std::decay_t<T>::type, HasIdentifier>
+			&& equalable<typename std::decay_t<T>::type const&, U>
+		friend bool operator==(T const& lhs, U const& rhs) {
+			return lhs.get() == rhs;
 		}
 	};
 
@@ -108,6 +118,16 @@ namespace std {
 	requires (!OpenVic::has_index<T>)
 	struct hash<T> {
 		[[nodiscard]] std::size_t operator()(T const& obj) const noexcept {
+			return std::hash<std::string_view>{}(obj.get_identifier());
+		}
+	};
+}
+
+namespace std {
+	template<OpenVic::has_get_identifier T>
+	requires (!OpenVic::has_index<T>)
+	struct hash<std::remove_const<T>> {
+		[[nodiscard]] std::size_t operator()(std::remove_const_t<T> const& obj) const noexcept {
 			return std::hash<std::string_view>{}(obj.get_identifier());
 		}
 	};

--- a/src/openvic-simulation/types/HasIndex.hpp
+++ b/src/openvic-simulation/types/HasIndex.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include <type_safe/strong_typedef.hpp>
 
 #include "openvic-simulation/core/template/Concepts.hpp"
+#include "openvic-simulation/core/template/Functional.hpp" // IWYU pragma: keep: bug fix for std::reference_wrapper hash & equality
 
 namespace OpenVic {
-	template<typename TypeTag, derived_from_specialization_of<type_safe::strong_typedef> IndexT>
+	template<typename SelfT, derived_from_specialization_of<type_safe::strong_typedef> IndexT>
 	class HasIndex {
 	public:
 		using index_t = IndexT;
@@ -24,17 +26,18 @@ namespace OpenVic {
 		HasIndex& operator=(HasIndex const&) = delete;
 		HasIndex& operator=(HasIndex&&) = delete;
 
-		constexpr bool operator==(HasIndex const& rhs) const {
-			return index == rhs.index;
+		friend constexpr bool operator==(HasIndex const& lhs, HasIndex const& rhs) {
+			return lhs.index == rhs.index;
 		}
 	};
 }
 
 namespace std {
-	template<OpenVic::has_index T>
+	template<typename T>
+	requires OpenVic::derived_from_specialization_of<std::decay_t<T>, OpenVic::HasIndex>
 	struct hash<T> {
 		[[nodiscard]] std::size_t operator()(T const& obj) const noexcept {
-			return std::hash<typename T::index_t>{}(obj.index);
+			return std::hash<typename std::decay_t<T>::index_t>{}(obj.index);
 		}
 	};
 }

--- a/src/openvic-simulation/types/OrderedContainers.hpp
+++ b/src/openvic-simulation/types/OrderedContainers.hpp
@@ -16,18 +16,6 @@
 #include <foonathan/memory/default_allocator.hpp>
 #include <foonathan/memory/std_allocator.hpp>
 
-namespace std {
-	template<typename T>
-	struct equal_to<std::reference_wrapper<const T>> {
-		[[nodiscard]] bool operator()(
-			std::reference_wrapper<const T> const& lhs,
-			std::reference_wrapper<const T> const& rhs
-		) const noexcept {
-			return lhs.get() == rhs.get();
-		}
-	};
-}
-
 namespace OpenVic {
 	struct ordered_container_string_hash {
 		using is_transparent = void;
@@ -58,10 +46,6 @@ namespace OpenVic {
 	struct container_hash<char const*> : ordered_container_string_hash {};
 	template<typename T>
 	struct container_hash<T*> : std::hash<T const*> {};
-	template<typename T>
-	struct container_hash<std::reference_wrapper<T>> : std::hash<const T> {};
-	template<typename T>
-	struct container_hash<std::reference_wrapper<const T>> : std::hash<const T> {};
 
 	// Default: Use transparent equality
 	template<typename T>


### PR DESCRIPTION
Similar to #707 , #708, #709 & #710
This should be most of what those PRs didn't touch.

BaseIssueGroup is replaced with an std::variant. This avoid recasting and improves type safety.