### PR TITLE
Optimise PopsAggregate by using IndexedFlatMaps

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -38,7 +38,6 @@ InstanceManager::InstanceManager(
 		new_definition_manager.get_define_manager().get_diplomacy_defines(),
 		new_definition_manager.get_define_manager().get_economy_defines(),
 		new_definition_manager.get_research_manager().get_invention_manager().get_inventions(),
-		new_definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
 		new_game_rules_manager,
 		good_instance_manager.get_good_instances(),
 		good_instance_manager,
@@ -46,6 +45,11 @@ InstanceManager::InstanceManager(
 		market_instance,
 		new_definition_manager.get_define_manager().get_military_defines(),
 		new_definition_manager.get_modifier_manager().get_modifier_effect_cache(),
+		{
+			new_definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
+			new_definition_manager.get_politics_manager().get_issue_manager().get_party_policies(),
+			new_definition_manager.get_politics_manager().get_issue_manager().get_reforms()
+		},
 		new_definition_manager.get_pop_manager().get_pop_types(),
 		new_definition_manager.get_politics_manager().get_issue_manager().get_reform_groups(),
 		new_definition_manager.get_military_manager().get_unit_type_manager().get_regiment_types(),
@@ -54,9 +58,15 @@ InstanceManager::InstanceManager(
 		new_definition_manager.get_research_manager().get_technology_manager().get_technologies(),
 		new_definition_manager.get_military_manager().get_unit_type_manager()
 	},
+	pops_aggregate_deps {
+		new_definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
+		new_definition_manager.get_politics_manager().get_issue_manager().get_party_policies(),
+		new_definition_manager.get_politics_manager().get_issue_manager().get_reforms()
+	},
 	pop_deps {
 		artisanal_producer_deps,
-		market_instance
+		market_instance,
+		pops_aggregate_deps
 	},
 	rgo_deps {
 		market_instance,
@@ -66,7 +76,7 @@ InstanceManager::InstanceManager(
 	province_instance_deps {
 		new_definition_manager.get_economy_manager().get_building_type_manager(),
 		new_game_rules_manager,
-		new_definition_manager.get_politics_manager().get_ideology_manager().get_ideologies(),
+		pops_aggregate_deps,
 		new_definition_manager.get_pop_manager().get_pop_types(),
 		rgo_deps,
 		new_definition_manager.get_pop_manager().get_stratas()
@@ -240,8 +250,6 @@ bool InstanceManager::load_bookmark(Bookmark const& new_bookmark) {
 	bool ret = map_instance.apply_history_to_provinces(
 		definition_manager.get_history_manager().get_province_manager(), today,
 		country_instance_manager,
-		// TODO - the following argument is for generating test pop attributes
-		definition_manager.get_politics_manager().get_issue_manager(),
 		definition_manager.get_define_manager().get_military_defines(),
 		pop_deps
 	);
@@ -254,9 +262,9 @@ bool InstanceManager::load_bookmark(Bookmark const& new_bookmark) {
 	ret &= map_instance.get_state_manager().generate_states(
 		definition_manager.get_map_definition(),
 		map_instance,
+		pops_aggregate_deps,
 		definition_manager.get_pop_manager().get_stratas(),
-		definition_manager.get_pop_manager().get_pop_types(),
-		definition_manager.get_politics_manager().get_ideology_manager().get_ideologies()
+		definition_manager.get_pop_manager().get_pop_types()
 	);
 
 	bool all_has_state = true;

--- a/src/openvic-simulation/InstanceManager.hpp
+++ b/src/openvic-simulation/InstanceManager.hpp
@@ -21,6 +21,7 @@
 #include "openvic-simulation/misc/SimulationClock.hpp"
 #include "openvic-simulation/politics/PoliticsInstanceManager.hpp"
 #include "openvic-simulation/population/PopDeps.hpp"
+#include "openvic-simulation/population/PopsAggregateDeps.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/FlagStrings.hpp"
 #include "openvic-simulation/utility/ThreadPool.hpp"
@@ -46,6 +47,7 @@ namespace OpenVic {
 		
 		ArtisanalProducerDeps artisanal_producer_deps;
 		CountryInstanceDeps country_instance_deps;
+		PopsAggregateDeps pops_aggregate_deps;
 		PopDeps pop_deps;
 		ResourceGatheringOperationDeps rgo_deps;
 		ProvinceInstanceDeps province_instance_deps;

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -39,6 +39,7 @@
 #include "openvic-simulation/politics/RuleSet.hpp"
 #include "openvic-simulation/population/Culture.hpp"
 #include "openvic-simulation/population/Pop.hpp"
+#include "openvic-simulation/population/PopsAggregateDeps.hpp"
 #include "openvic-simulation/population/PopType.hpp"
 #include "openvic-simulation/research/Invention.hpp"
 #include "openvic-simulation/research/Technology.hpp"
@@ -67,9 +68,9 @@ CountryInstance::CountryInstance(
 ) : FlagStrings { "country" },
 	HasIndex { new_country_definition.index },
 	PopsAggregate {
+		country_instance_deps.pops_aggregate_deps,
 		country_instance_deps.stratas,
-		country_instance_deps.pop_types,
-		country_instance_deps.ideologies
+		country_instance_deps.pop_types
 	},
 	/* Main attributes */
 	country_definition { new_country_definition },
@@ -151,8 +152,8 @@ CountryInstance::CountryInstance(
 	invention_unlock_levels { country_instance_deps.inventions },
 
 	/* Politics */
-	upper_house_proportion_by_ideology { country_instance_deps.ideologies },
-	reforms { country_instance_deps.reforms },
+	upper_house_proportion_by_ideology { country_instance_deps.pops_aggregate_deps.ideologies },
+	reforms { country_instance_deps.reform_groups },
 	flag_overrides_by_government_type { country_instance_deps.government_types },
 	crime_unlock_levels { country_instance_deps.crimes },
 

--- a/src/openvic-simulation/country/CountryInstanceDeps.hpp
+++ b/src/openvic-simulation/country/CountryInstanceDeps.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "openvic-simulation/core/portable/ForwardableSpan.hpp"
+#include "openvic-simulation/population/PopsAggregateDeps.hpp"
 #include "openvic-simulation/types/Date.hpp"
 #include "openvic-simulation/types/UnitBranchType.hpp"
-#include "openvic-simulation/core/portable/ForwardableSpan.hpp"
 
 namespace OpenVic {
 	struct BuildingType;
@@ -11,7 +12,6 @@ namespace OpenVic {
 	struct Crime;
 	struct DiplomacyDefines;
 	struct EconomyDefines;
-	struct Ideology;
 	struct Invention;
 	struct GameRulesManager;
 	struct GoodInstance;
@@ -35,7 +35,6 @@ namespace OpenVic {
 		DiplomacyDefines const& diplomacy_defines;
 		EconomyDefines const& economy_defines;
 		forwardable_span<const Invention> inventions;
-		forwardable_span<const Ideology> ideologies;
 		GameRulesManager const& game_rules_manager;
 		forwardable_span<const GoodInstance> good_instances;
 		GoodInstanceManager& good_instance_manager;
@@ -43,8 +42,9 @@ namespace OpenVic {
 		MarketInstance& market_instance;
 		MilitaryDefines const& military_defines;
 		ModifierEffectCache const& modifier_effect_cache;
+		const PopsAggregateDeps pops_aggregate_deps;
 		forwardable_span<const PopType> pop_types;
-		forwardable_span<const ReformGroup> reforms;
+		forwardable_span<const ReformGroup> reform_groups;
 		forwardable_span<const RegimentType> regiment_types;
 		forwardable_span<const ShipType> ship_types;
 		forwardable_span<const Strata> stratas;

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -84,7 +84,6 @@ bool MapInstance::apply_history_to_provinces(
 	ProvinceHistoryManager const& history_manager,
 	const Date date,
 	CountryInstanceManager& country_manager,
-	IssueManager const& issue_manager,
 	MilitaryDefines const& military_defines,
 	PopDeps const& pop_deps
 ) {
@@ -125,7 +124,7 @@ bool MapInstance::apply_history_to_provinces(
 						pop_history_entry->get_pops(),
 						pop_deps
 					);
-					province.setup_pop_test_values(issue_manager);
+					province.setup_pop_test_values();
 
 					//update pops so OOB can use up to date max_supported_regiments
 					province._update_pops(military_defines);

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -10,7 +10,6 @@
 
 namespace OpenVic {
 	struct BuildingTypeManager;
-	struct IssueManager;
 	struct MapDefinition;
 	struct MarketInstance;
 	struct MilitaryDefines;
@@ -78,7 +77,6 @@ namespace OpenVic {
 			ProvinceHistoryManager const& history_manager,
 			const Date date,
 			CountryInstanceManager& country_manager,
-			IssueManager const& issue_manager,
 			MilitaryDefines const& military_defines,
 			PopDeps const& pop_deps
 		);

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -1,5 +1,6 @@
 #include "ProvinceInstance.hpp"
 #include "ProvinceInstanceDeps.hpp"
+#include "population/PopsAggregateDeps.hpp"
 
 #include <type_traits>
 
@@ -26,9 +27,9 @@ ProvinceInstance::ProvinceInstance(
 	HasIndex { new_province_definition.index },
 	FlagStrings { "province" },
 	PopsAggregate {
+		province_instance_deps.pops_aggregate_deps,
 		province_instance_deps.stratas,
-		province_instance_deps.pop_types,
-		province_instance_deps.ideologies
+		province_instance_deps.pop_types
 	},
 	province_definition { new_province_definition },
 	game_rules_manager { province_instance_deps.game_rules_manager },
@@ -191,7 +192,6 @@ bool ProvinceInstance::add_pop_vec(
 			pops.emplace(
 				*this,
 				pop,
-				get_supporter_equivalents_by_ideology().get_keys(),
 				pop_deps,
 				++last_pop_id
 			);
@@ -527,9 +527,9 @@ void ProvinceInstance::initialise_rgo() {
 	rgo.initialise_rgo_size_multiplier();
 }
 
-void ProvinceInstance::setup_pop_test_values(IssueManager const& issue_manager) {
+void ProvinceInstance::setup_pop_test_values() {
 	for (Pop& pop : pops) {
-		pop.setup_pop_test_values(issue_manager);
+		pop.setup_pop_test_values();
 	}
 }
 

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -35,7 +35,6 @@ namespace OpenVic {
 	struct GoodDefinition;
 	struct Ideology;
 	struct InstanceManager;
-	struct IssueManager;
 	struct MapInstance;
 	struct MilitaryDefines;
 	struct PopDeps;
@@ -228,7 +227,7 @@ namespace OpenVic {
 
 		bool apply_history_to_province(ProvinceHistoryEntry const& entry, CountryInstanceManager& country_manager);
 
-		void setup_pop_test_values(IssueManager const& issue_manager);
+		void setup_pop_test_values();
 		memory::colony<Pop>& get_mutable_pops();
 	private:
 		template<typename T>

--- a/src/openvic-simulation/map/ProvinceInstanceDeps.hpp
+++ b/src/openvic-simulation/map/ProvinceInstanceDeps.hpp
@@ -5,7 +5,7 @@
 namespace OpenVic {
 	struct BuildingTypeManager;
 	struct GameRulesManager;
-	struct Ideology;
+	struct PopsAggregateDeps;
 	struct PopType;
 	struct ResourceGatheringOperationDeps;
 	struct Strata;
@@ -13,7 +13,7 @@ namespace OpenVic {
 	struct ProvinceInstanceDeps {
 		BuildingTypeManager const& building_type_manager;
 		GameRulesManager const& game_rules_manager;
-		forwardable_span<const Ideology> ideologies;
+		PopsAggregateDeps const& pops_aggregate_deps;
 		forwardable_span<const PopType> pop_types;
 		ResourceGatheringOperationDeps const& rgo_deps;
 		forwardable_span<const Strata> stratas;

--- a/src/openvic-simulation/map/State.cpp
+++ b/src/openvic-simulation/map/State.cpp
@@ -17,10 +17,14 @@ State::State(
 	ProvinceInstance* new_capital,
 	memory::vector<std::reference_wrapper<ProvinceInstance>>&& new_provinces,
 	colony_status_t new_colony_status,
+	PopsAggregateDeps const& pops_aggregate_deps,
 	forwardable_span<const Strata> strata_keys,
-	forwardable_span<const PopType> pop_type_keys,
-	forwardable_span<const Ideology> ideology_keys
-) : PopsAggregate { strata_keys, pop_type_keys, ideology_keys },
+	forwardable_span<const PopType> pop_type_keys
+) : PopsAggregate {
+		pops_aggregate_deps,
+		strata_keys,
+		pop_type_keys
+	},
 	state_set { new_state_set },
 	capital { new_capital },
 	provinces { std::move(new_provinces) },
@@ -131,9 +135,9 @@ void StateSet::update_gamestate() {
 
 bool StateManager::add_state_set(
 	MapInstance& map_instance, Region const& region,
+	PopsAggregateDeps const& pops_aggregate_deps,
 	forwardable_span<const Strata> strata_keys,
-	forwardable_span<const PopType> pop_type_keys,
-	forwardable_span<const Ideology> ideology_keys
+	forwardable_span<const PopType> pop_type_keys
 ) {
 	OV_ERR_FAIL_COND_V_MSG(region.is_meta, false, memory::fmt::format("Cannot use meta region \"{}\" as state template!", region));
 	OV_ERR_FAIL_COND_V_MSG(region.empty(), false, memory::fmt::format("Cannot use empty region \"{}\" as state template!", region));
@@ -174,7 +178,9 @@ bool StateManager::add_state_set(
 			/* TODO: capital province logic */
 			state_set, &capital,
 			std::move(provinces), capital.get_colony_status(),
-			strata_keys, pop_type_keys, ideology_keys
+			pops_aggregate_deps,
+			strata_keys,
+			pop_type_keys
 		);
 
 		for (ProvinceInstance& province : state.get_provinces()) {
@@ -188,9 +194,9 @@ bool StateManager::add_state_set(
 bool StateManager::generate_states(
 	MapDefinition const& map_definition,
 	MapInstance& map_instance,
+	PopsAggregateDeps const& pops_aggregate_deps,
 	forwardable_span<const Strata> strata_keys,
-	forwardable_span<const PopType> pop_type_keys,
-	forwardable_span<const Ideology> ideology_keys
+	forwardable_span<const PopType> pop_type_keys
 ) {
 	state_sets.clear();
 	state_sets.reserve(map_definition.get_region_count());
@@ -200,7 +206,13 @@ bool StateManager::generate_states(
 
 	for (Region const& region : map_definition.get_regions()) {
 		if (!region.is_meta) {
-			if (add_state_set(map_instance, region, strata_keys, pop_type_keys, ideology_keys)) {
+			if (add_state_set(
+				map_instance,
+				region,
+				pops_aggregate_deps,
+				strata_keys,
+				pop_type_keys
+			)) {
 				state_count += state_sets.back().get_state_count();
 			} else {
 				ret = false;

--- a/src/openvic-simulation/map/State.hpp
+++ b/src/openvic-simulation/map/State.hpp
@@ -17,9 +17,9 @@ namespace OpenVic {
 	struct CountryInstance;
 	struct CountryParty;
 	struct Culture;
-	struct Ideology;
 	struct MapDefinition;
 	struct Pop;
+	struct PopsAggregateDeps;
 	struct PopType;
 	struct ProvinceInstance;
 	struct Religion;
@@ -51,9 +51,9 @@ namespace OpenVic {
 			ProvinceInstance* new_capital,
 			memory::vector<std::reference_wrapper<ProvinceInstance>>&& new_provinces,
 			colony_status_t new_colony_status,
+			PopsAggregateDeps const& pops_aggregate_deps,
 			forwardable_span<const Strata> strata_keys,
-			forwardable_span<const PopType> pop_type_keys,
-			forwardable_span<const Ideology> ideology_keys
+			forwardable_span<const PopType> pop_type_keys
 		);
 		State(State&&) = delete;
 		State(State const&) = delete;
@@ -99,9 +99,9 @@ namespace OpenVic {
 
 		bool add_state_set(
 			MapInstance& map_instance, Region const& region,
+			PopsAggregateDeps const& pops_aggregate_deps,
 			forwardable_span<const Strata> strata_keys,
-			forwardable_span<const PopType> pop_type_keys,
-			forwardable_span<const Ideology> ideology_keys
+			forwardable_span<const PopType> pop_type_keys
 		);
 
 	public:
@@ -111,9 +111,9 @@ namespace OpenVic {
 		bool generate_states(
 			MapDefinition const& map_definition,
 			MapInstance& map_instance,
+			PopsAggregateDeps const& pops_aggregate_deps,
 			forwardable_span<const Strata> strata_keys,
-			forwardable_span<const PopType> pop_type_keys,
-			forwardable_span<const Ideology> ideology_keys
+			forwardable_span<const PopType> pop_type_keys
 		);
 
 		void reset();

--- a/src/openvic-simulation/population/Pop.cpp
+++ b/src/openvic-simulation/population/Pop.cpp
@@ -29,9 +29,11 @@
 #include "openvic-simulation/map/ProvinceInstance.hpp"
 #include "openvic-simulation/modifier/ModifierEffectCache.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
-#include "openvic-simulation/politics/IssueManager.hpp"
+#include "openvic-simulation/politics/PartyPolicy.hpp"
+#include "openvic-simulation/politics/Reform.hpp"
 #include "openvic-simulation/population/Culture.hpp"
 #include "openvic-simulation/population/PopNeedsMacro.hpp"
+#include "openvic-simulation/population/PopsAggregateDeps.hpp"
 #include "openvic-simulation/population/PopType.hpp"
 #include "openvic-simulation/population/PopValuesFromProvince.hpp"
 #include "openvic-simulation/population/Religion.hpp"
@@ -57,7 +59,6 @@ PopBase::PopBase(
 Pop::Pop(
 	ProvinceInstance& new_location,
 	PopBase const& pop_base,
-	decltype(supporter_equivalents_by_ideology)::keys_span_type ideology_keys,
 	PopDeps const& pop_deps,
 	const pop_id_in_province_t new_id_in_province
 ) : PopBase { pop_base },
@@ -71,7 +72,9 @@ Pop::Pop(
 			}
 			: std::optional<ArtisanalProducer> {}
 	},
-	supporter_equivalents_by_ideology { ideology_keys } {
+	supporter_equivalents_by_ideology { pop_deps.pops_aggregate_deps.ideologies },
+	supporter_equivalents_by_party_policy { pop_deps.pops_aggregate_deps.party_policies },
+	supporter_equivalents_by_reform { pop_deps.pops_aggregate_deps.reforms } {
 		reserve_needs_fulfilled_goods();
 	}
 
@@ -82,7 +85,7 @@ fixed_point_t Pop::get_unemployment_fraction() const {
 	return fp::from_fraction(get_unemployed(), size);
 }
 
-void Pop::setup_pop_test_values(IssueManager const& issue_manager) {
+void Pop::setup_pop_test_values() {
 	/* Returns +/- range% of size. */
 	const auto test_size = [this](int32_t range) -> pop_size_t {
 		return size * ((rand() % (2 * range + 1)) - range) / 100;
@@ -127,17 +130,20 @@ void Pop::setup_pop_test_values(IssueManager const& issue_manager) {
 		test_weight_indexed(supporter_equivalents_by_ideology, ideology, 1, 5);
 	}
 	supporter_equivalents_by_ideology.rescale(type_safe::get(size));
-
-	supporter_equivalents_by_issue.clear();
-	for (BaseIssue const& issue : issue_manager.get_party_policies()) {
-		test_weight_ordered(supporter_equivalents_by_issue, issue, 3, 6);
+	
+	supporter_equivalents_by_party_policy.fill(0);
+	for (PartyPolicy const& party_policy : supporter_equivalents_by_party_policy.get_keys()) {
+		test_weight_indexed(supporter_equivalents_by_party_policy, party_policy, 3, 6);
 	}
-	for (Reform const& reform : issue_manager.get_reforms()) {
+	supporter_equivalents_by_party_policy.rescale(type_safe::get(size));
+	
+	supporter_equivalents_by_reform.fill(0);
+	for (Reform const& reform : supporter_equivalents_by_reform.get_keys()) {
 		if (!reform.group.is_civilizing()) {
-			test_weight_ordered(supporter_equivalents_by_issue, reform, 3, 6);
+			test_weight_indexed(supporter_equivalents_by_reform, reform, 3, 6);
 		}
 	}
-	rescale_fixed_point_map(supporter_equivalents_by_issue, type_safe::get(size));
+	supporter_equivalents_by_reform.rescale(type_safe::get(size));
 
 	if (!vote_equivalents_by_party.empty()) {
 		for (auto& [party, value] : vote_equivalents_by_party) {
@@ -194,16 +200,6 @@ void Pop::update_location_based_attributes() {
 
 fixed_point_t Pop::get_supporter_equivalents_by_ideology(Ideology const& ideology) const {
 	return supporter_equivalents_by_ideology.at(ideology);
-}
-
-fixed_point_t Pop::get_supporter_equivalents_by_issue(BaseIssue const& issue) const {
-	const decltype(supporter_equivalents_by_issue)::const_iterator it = supporter_equivalents_by_issue.find(&issue);
-
-	if (it != supporter_equivalents_by_issue.end()) {
-		return it->second;
-	} else {
-		return 0;
-	}
 }
 
 fixed_point_t Pop::get_vote_equivalents_by_party(CountryParty const& party) const {

--- a/src/openvic-simulation/population/Pop.hpp
+++ b/src/openvic-simulation/population/Pop.hpp
@@ -18,22 +18,22 @@
 #include <type_safe/strong_typedef.hpp>
 
 namespace OpenVic {
-	struct BaseIssue;
 	struct BuyResult;
 	struct CountryInstance;
 	struct CountryParty;
 	struct Culture;
 	struct GoodDefinition;
 	struct Ideology;
-	struct IssueManager;
 	struct MarketInstance;
 	struct MilitaryDefines;
+	struct PartyPolicy;
 	struct PopDeps;
 	struct PopManager;
 	struct PopType;
 	struct PopValuesFromProvince;
 	struct ProvinceInstance;
 	struct RebelType;
+	struct Reform;
 	struct Religion;
 	struct SellResult;
 
@@ -125,13 +125,13 @@ namespace OpenVic {
 		// added together with automatic weighting based on their relative sizes. Similarly, the province, state and country
 		// equivalents of these distributions will have a total size equal to their total population size.
 		OV_IFLATMAP_PROPERTY(Ideology, fixed_point_t, supporter_equivalents_by_ideology);
-		fixed_point_map_t<BaseIssue const*> PROPERTY(supporter_equivalents_by_issue);
+		OV_IFLATMAP_PROPERTY(PartyPolicy, fixed_point_t, supporter_equivalents_by_party_policy);
+		OV_IFLATMAP_PROPERTY(Reform, fixed_point_t, supporter_equivalents_by_reform);
 		fixed_point_map_t<CountryParty const*> PROPERTY(vote_equivalents_by_party);
 	
 	public:
 		// The values returned by these functions are scaled by pop size, so they must be divided by pop size to get
 		// the support as a proportion of 1.0
-		fixed_point_t get_supporter_equivalents_by_issue(BaseIssue const& issue) const;
 		fixed_point_t get_vote_equivalents_by_party(CountryParty const& party) const;
 
 		static constexpr pop_size_t size_denominator = 200000;
@@ -202,7 +202,6 @@ namespace OpenVic {
 		Pop(
 			ProvinceInstance& new_location,
 			PopBase const& pop_base,
-			decltype(supporter_equivalents_by_ideology)::keys_span_type ideology_keys,
 			PopDeps const& pop_deps,
 			const pop_id_in_province_t new_id_in_province
 		);
@@ -211,7 +210,7 @@ namespace OpenVic {
 		Pop& operator=(Pop const&) = delete;
 		Pop& operator=(Pop&&) = delete;
 
-		void setup_pop_test_values(IssueManager const& issue_manager);
+		void setup_pop_test_values();
 		bool convert_to_equivalent();
 		void update_location_based_attributes();
 

--- a/src/openvic-simulation/population/PopDeps.hpp
+++ b/src/openvic-simulation/population/PopDeps.hpp
@@ -3,9 +3,11 @@
 namespace OpenVic {
 	struct ArtisanalProducerDeps;
 	struct MarketInstance;
+	struct PopsAggregateDeps;
 
 	struct PopDeps {
 		ArtisanalProducerDeps const& artisanal_producer_deps;
 		MarketInstance& market_instance;
+		PopsAggregateDeps const& pops_aggregate_deps;
 	};
 }

--- a/src/openvic-simulation/population/PopsAggregate.cpp
+++ b/src/openvic-simulation/population/PopsAggregate.cpp
@@ -5,7 +5,10 @@
 #include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/country/CountryInstance.hpp"
 #include "openvic-simulation/politics/Ideology.hpp"
+#include "openvic-simulation/politics/PartyPolicy.hpp" // IWYU pragma: keep for IndexedFlatMap
+#include "openvic-simulation/politics/Reform.hpp" // IWYU pragma: keep for IndexedFlatMap
 #include "openvic-simulation/population/Pop.hpp"
+#include "openvic-simulation/population/PopsAggregateDeps.hpp"
 #include "openvic-simulation/population/PopType.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/types/OrderedContainersMath.hpp"
@@ -14,9 +17,9 @@
 
 using namespace OpenVic;
 PopsAggregate::PopsAggregate(
+	PopsAggregateDeps const& pops_aggregate_deps,
 	decltype(population_by_strata)::keys_span_type strata_keys,
-	decltype(population_by_type)::keys_span_type pop_type_keys,
-	decltype(supporter_equivalents_by_ideology)::keys_span_type ideology_keys
+	decltype(population_by_type)::keys_span_type pop_type_keys
 ) : population_by_strata { strata_keys },
 	militancy_by_strata_running_total_raw { strata_keys },
 	life_needs_fulfilled_by_strata_running_total_raw { strata_keys },
@@ -28,7 +31,9 @@ PopsAggregate::PopsAggregate(
 	luxury_needs_fulfilled_by_strata { strata_keys },
 	population_by_type { pop_type_keys },
 	unemployed_pops_by_type { pop_type_keys },
-	supporter_equivalents_by_ideology { ideology_keys } {}
+	supporter_equivalents_by_ideology { pops_aggregate_deps.ideologies },
+	supporter_equivalents_by_party_policy { pops_aggregate_deps.party_policies },
+	supporter_equivalents_by_reform { pops_aggregate_deps.reforms } {}
 
 pop_sum_t PopsAggregate::get_population_by_type(PopType const& pop_type) const {
 	return population_by_type.at(pop_type);
@@ -38,15 +43,6 @@ pop_sum_t PopsAggregate::get_unemployed_pops_by_type(PopType const& pop_type) co
 }
 fixed_point_t PopsAggregate::get_supporter_equivalents_by_ideology(Ideology const& ideology) const {
 	return supporter_equivalents_by_ideology.at(ideology);
-}
-fixed_point_t PopsAggregate::get_supporter_equivalents_by_issue(BaseIssue const& issue) const {
-	const decltype(supporter_equivalents_by_issue)::const_iterator it = supporter_equivalents_by_issue.find(&issue);
-
-	if (it != supporter_equivalents_by_issue.end()) {
-		return it->second;
-	} else {
-		return 0;
-	}
 }
 fixed_point_t PopsAggregate::get_vote_equivalents_by_party(CountryParty const& party) const {
 	const decltype(vote_equivalents_by_party)::const_iterator it = vote_equivalents_by_party.find(&party);
@@ -114,7 +110,8 @@ void PopsAggregate::clear_pops_aggregate() {
 	population_by_type.fill(0);
 	unemployed_pops_by_type.fill(0);
 	supporter_equivalents_by_ideology.fill(fixed_point_t::_0);
-	supporter_equivalents_by_issue.clear();
+	supporter_equivalents_by_party_policy.fill(fixed_point_t::_0);
+	supporter_equivalents_by_reform.fill(fixed_point_t::_0);
 	vote_equivalents_by_party.clear();
 	population_by_culture.clear();
 	population_by_religion.clear();
@@ -150,7 +147,8 @@ void PopsAggregate::add_pops_aggregate(PopsAggregate& part) {
 	population_by_type += part.get_population_by_type();
 	unemployed_pops_by_type += part.get_unemployed_pops_by_type();
 	supporter_equivalents_by_ideology += part.get_supporter_equivalents_by_ideology();
-	supporter_equivalents_by_issue += part.get_supporter_equivalents_by_issue();
+	supporter_equivalents_by_party_policy += part.get_supporter_equivalents_by_party_policy();
+	supporter_equivalents_by_reform += part.get_supporter_equivalents_by_reform();
 	vote_equivalents_by_party += part.get_vote_equivalents_by_party();
 	population_by_culture += part.get_population_by_culture();
 	population_by_religion += part.get_population_by_religion();
@@ -186,7 +184,8 @@ void PopsAggregate::add_pops_aggregate(Pop const& pop) {
 	unemployed_pops_by_type.at(pop_type) += pop.get_unemployed();
 	// Pop ideology, issue and vote distributions are scaled to pop size so we can add them directly
 	supporter_equivalents_by_ideology += pop.get_supporter_equivalents_by_ideology();
-	supporter_equivalents_by_issue += pop.get_supporter_equivalents_by_issue();
+	supporter_equivalents_by_party_policy += pop.get_supporter_equivalents_by_party_policy();
+	supporter_equivalents_by_reform += pop.get_supporter_equivalents_by_reform();
 	vote_equivalents_by_party += pop.get_vote_equivalents_by_party();
 	population_by_culture[&pop.culture] += pop_size;
 	population_by_religion[&pop.religion] += pop_size;

--- a/src/openvic-simulation/population/PopsAggregate.hpp
+++ b/src/openvic-simulation/population/PopsAggregate.hpp
@@ -11,14 +11,16 @@
 #include <boost/int128/detail/int128_imp.hpp>
 
 namespace OpenVic {
-	struct BaseIssue;
 	struct CountryDefinition;
 	struct CountryInstance;
 	struct CountryParty;
 	struct Culture;
 	struct Ideology;
+	struct PartyPolicy;
 	struct Pop;
+	struct PopsAggregateDeps;
 	struct PopType;
+	struct Reform;
 	struct Religion;
 	struct Strata;
 
@@ -50,16 +52,17 @@ namespace OpenVic {
 		OV_IFLATMAP_PROPERTY(PopType, pop_sum_t, population_by_type);
 		OV_IFLATMAP_PROPERTY(PopType, pop_sum_t, unemployed_pops_by_type);
 		OV_IFLATMAP_PROPERTY(Ideology, fixed_point_t, supporter_equivalents_by_ideology);
-		fixed_point_map_t<BaseIssue const*> PROPERTY(supporter_equivalents_by_issue);
+		OV_IFLATMAP_PROPERTY(PartyPolicy, fixed_point_t, supporter_equivalents_by_party_policy);
+		OV_IFLATMAP_PROPERTY(Reform, fixed_point_t, supporter_equivalents_by_reform);
 		fixed_point_map_t<CountryParty const*> PROPERTY(vote_equivalents_by_party);
 		ordered_map<Culture const*, pop_sum_t> PROPERTY(population_by_culture);
 		ordered_map<Religion const*, pop_sum_t> PROPERTY(population_by_religion);
 
 	protected:
 		PopsAggregate(
+			PopsAggregateDeps const& pops_aggregate_deps,
 			decltype(population_by_strata)::keys_span_type strata_keys,
-			decltype(population_by_type)::keys_span_type pop_type_keys,
-			decltype(supporter_equivalents_by_ideology)::keys_span_type ideology_keys
+			decltype(population_by_type)::keys_span_type pop_type_keys
 		);
 
 		void clear_pops_aggregate();
@@ -71,8 +74,6 @@ namespace OpenVic {
 	public:
 		// The values returned by these functions are scaled by population size, so they must be divided by population size
 		// to get the support as a proportion of 1.0
-		fixed_point_t get_supporter_equivalents_by_issue(Ideology const& ideology) const;
-		fixed_point_t get_supporter_equivalents_by_issue(BaseIssue const& issue) const;
 		fixed_point_t get_vote_equivalents_by_party(CountryParty const& party) const;
 		pop_sum_t get_population_by_culture(Culture const& culture) const;
 		pop_sum_t get_population_by_religion(Religion const& religion) const;

--- a/src/openvic-simulation/population/PopsAggregateDeps.hpp
+++ b/src/openvic-simulation/population/PopsAggregateDeps.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "openvic-simulation/core/portable/ForwardableSpan.hpp"
+
+namespace OpenVic {
+	struct Ideology;
+	struct PartyPolicy;
+	struct Reform;
+
+	struct PopsAggregateDeps {
+		forwardable_span<const Ideology> ideologies;
+		forwardable_span<const PartyPolicy> party_policies;
+		forwardable_span<const Reform> reforms;
+	};
+}


### PR DESCRIPTION
IndexedFlatMap is much faster than fixed_point_map_t as that uses hash-based lookups whilst the former uses indexing.
Since this code is called every gamestate update, it is a hot-path and thus performance matters here.

Note breaks godot, I'll fix that later.