### PR TITLE
Paralellise update gamestate & modifiers

### DIFF
--- a/src/openvic-simulation/InstanceManager.cpp
+++ b/src/openvic-simulation/InstanceManager.cpp
@@ -5,6 +5,7 @@
 #include "openvic-simulation/misc/GameAction.hpp"
 #include "openvic-simulation/types/TypedSpan.hpp"
 #include "openvic-simulation/utility/Logger.hpp"
+#include "openvic-simulation/utility/ThreadDeps.hpp"
 
 using namespace OpenVic;
 
@@ -168,8 +169,8 @@ void InstanceManager::update_gamestate() {
 	update_modifier_sums();
 
 	// Update gamestate...
-	map_instance.update_gamestate(*this);
-	country_instance_manager.update_gamestate(today, map_instance);
+	map_instance.update_gamestate();
+	country_instance_manager.update_gamestate_after_map(today);
 	unit_instance_manager.update_gamestate();
 
 	gamestate_updated();
@@ -234,12 +235,19 @@ bool InstanceManager::setup() {
 	}
 
 	thread_pool.initialise_threadpool(
-		game_rules_manager,
-		good_instance_manager,
-		definition_manager.get_modifier_manager().get_modifier_effect_cache(),
-		definition_manager.get_define_manager().get_pops_defines(),
-		definition_manager.get_economy_manager().get_production_type_manager(),
-		strata_index_t(definition_manager.get_pop_manager().get_strata_count()),
+		ThreadDeps{
+			game_rules_manager,
+			good_instance_manager,
+			map_instance,
+			definition_manager.get_define_manager().get_military_defines(),
+			definition_manager.get_modifier_manager().get_modifier_effect_cache(),
+			definition_manager.get_define_manager().get_pops_defines(),
+			definition_manager.get_economy_manager().get_production_type_manager(),
+			definition_manager.get_modifier_manager().get_static_modifier_cache(),
+			country_index_t(definition_manager.get_country_definition_manager().get_country_definition_count()),
+			good_index_t(definition_manager.get_economy_manager().get_good_definition_manager().get_good_definition_count()),
+			strata_index_t(definition_manager.get_pop_manager().get_strata_count())
+		},
 		good_instance_manager.get_good_instances(),
 		country_instance_manager.get_country_instances(),
 		map_instance.get_province_instances()
@@ -305,8 +313,8 @@ bool InstanceManager::load_bookmark(Bookmark const& new_bookmark) {
 	OV_ERR_FAIL_COND_V_MSG(!all_has_state, false, "At least one land province has no state");
 
 	update_modifier_sums();
-	map_instance.initialise_for_new_game(*this);
-	country_instance_manager.update_gamestate(today, map_instance);
+	map_instance.initialise_for_new_game();
+	country_instance_manager.update_gamestate_after_map(today);
 	market_instance.execute_orders();
 
 	return ret;
@@ -359,12 +367,9 @@ void InstanceManager::update_modifier_sums() {
 	// full copy of all the modifiers affecting them in their modifier sum, but provinces only having their directly/locally
 	// applied modifiers in their modifier sum, hence requiring owner country modifier effect values to be looked up when
 	// determining the value of a global effect on the province.
-	country_instance_manager.update_modifier_sums(
-		today, definition_manager.get_modifier_manager().get_static_modifier_cache()
-	);
-	map_instance.update_modifier_sums(
-		today, definition_manager.get_modifier_manager().get_static_modifier_cache()
-	);
+	country_instance_manager.update_modifier_sums_before_map();
+	map_instance.update_modifier_sums(today);
+	country_instance_manager.update_modifier_sums_after_map();
 }
 
 bool InstanceManager::queue_game_action(game_action_t&& game_action) {

--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -1782,7 +1782,7 @@ static constexpr Modifier const& get_country_status_static_effect(
 	}
 }
 
-void CountryInstance::update_modifier_sum(Date today, StaticModifierCache const& static_modifier_cache) {
+void CountryInstance::update_modifier_sum_before_map(Date today, StaticModifierCache const& static_modifier_cache) {
 	// Update sum of national modifiers
 	modifier_sum.clear();
 
@@ -1856,19 +1856,23 @@ void CountryInstance::update_modifier_sum(Date today, StaticModifierCache const&
 	// TODO - calculate stats for each unit type (locked and unlocked)
 }
 
-void CountryInstance::make_room_for_province_modifier_sum(ModifierSum const& province_modifier_sum) {
-	modifier_sum.make_room_for(province_modifier_sum);
+void CountryInstance::update_modifier_sum_after_map(Date today) {
+	for (ProvinceInstance const* const province_ptr : controlled_provinces) {
+		if (OV_likely(province_ptr != nullptr)) {
+			modifier_sum.add_modifier_sum(province_ptr->get_modifier_sum());
+		}
+	}
 }
 
-void CountryInstance::contribute_province_modifier_sum(ModifierSum const& province_modifier_sum) {
-	modifier_sum.add_modifier_sum(province_modifier_sum);
+void CountryInstance::make_room_for_province_modifier_sum(ModifierSum const& province_modifier_sum) {
+	modifier_sum.make_room_for(province_modifier_sum);
 }
 
 fixed_point_t CountryInstance::get_modifier_effect_value(ModifierEffect const& effect) const {
 	return modifier_sum.get_modifier_effect_value(effect);
 }
 
-void CountryInstance::update_gamestate(const Date today, MapInstance& map_instance) {
+void CountryInstance::update_gamestate_after_map(const Date today) {
 	if (is_civilised()) {
 		civilisation_progress = 0;
 	} else {
@@ -1932,14 +1936,14 @@ void CountryInstance::update_gamestate(const Date today, MapInstance& map_instan
 		province->set_connected_to_capital(false);
 		province->set_is_overseas(province_definition.get_continent() != capital_continent);
 
-		for (ProvinceDefinition::adjacency_t const& adjacency : province_definition.get_adjacencies()) {
-			// TODO - should we limit based on adjacency type? Straits and impassable still work in game,
-			// and water provinces don't have an owner so they'll get caught by the later checks anyway.
-			CountryInstance* neighbour = map_instance.get_province_instance_by_definition(adjacency.get_to()).get_owner();
-			if (neighbour != nullptr && neighbour != this) {
-				neighbouring_countries.insert(neighbour);
-			}
-		}
+		// for (ProvinceDefinition::adjacency_t const& adjacency : province_definition.get_adjacencies()) {
+		// 	// TODO - should we limit based on adjacency type? Straits and impassable still work in game,
+		// 	// and water provinces don't have an owner so they'll get caught by the later checks anyway.
+		// 	CountryInstance* neighbour = map_instance.get_province_instance_by_definition(adjacency.get_to()).get_owner();
+		// 	if (neighbour != nullptr && neighbour != this) {
+		// 		neighbouring_countries.insert(neighbour);
+		// 	}
+		// }
 	}
 
 	if (occupied_provinces_proportion != 0) {
@@ -1949,21 +1953,21 @@ void CountryInstance::update_gamestate(const Date today, MapInstance& map_instan
 
 	if (capital != nullptr) {
 		capital->set_connected_to_capital(true);
-		memory::vector<std::reference_wrapper<const ProvinceInstance>> province_checklist { *capital };
+		// memory::vector<std::reference_wrapper<const ProvinceInstance>> province_checklist { *capital };
 
-		for (size_t index = 0; index < province_checklist.size(); ++index) {
-			ProvinceInstance const& province = province_checklist[index];
+		// for (size_t index = 0; index < province_checklist.size(); ++index) {
+		// 	ProvinceInstance const& province = province_checklist[index];
 
-			for (ProvinceDefinition::adjacency_t const& adjacency : province.province_definition.get_adjacencies()) {
-				ProvinceInstance& adjacent_province = map_instance.get_province_instance_by_definition(adjacency.get_to());
+		// 	for (ProvinceDefinition::adjacency_t const& adjacency : province.province_definition.get_adjacencies()) {
+		// 		ProvinceInstance& adjacent_province = map_instance.get_province_instance_by_definition(adjacency.get_to());
 
-				if (adjacent_province.get_owner() == this && !adjacent_province.get_connected_to_capital()) {
-					adjacent_province.set_connected_to_capital(true);
-					adjacent_province.set_is_overseas(false);
-					province_checklist.emplace_back(adjacent_province);
-				}
-			}
-		}
+		// 		if (adjacent_province.get_owner() == this && !adjacent_province.get_connected_to_capital()) {
+		// 			adjacent_province.set_connected_to_capital(true);
+		// 			adjacent_province.set_is_overseas(false);
+		// 			province_checklist.emplace_back(adjacent_province);
+		// 		}
+		// 	}
+		// }
 	}
 
 	// Order of updates might need to be changed/functions split up to account for dependencies

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -685,9 +685,9 @@ namespace OpenVic {
 		bool update_rule_set();
 
 	public:
-		void update_modifier_sum(Date today, StaticModifierCache const& static_modifier_cache);
+		void update_modifier_sum_before_map(Date today, StaticModifierCache const& static_modifier_cache);
+		void update_modifier_sum_after_map(Date today);
 		void make_room_for_province_modifier_sum(ModifierSum const& province_modifier_sum);
-		void contribute_province_modifier_sum(ModifierSum const& province_modifier_sum);
 		fixed_point_t get_modifier_effect_value(ModifierEffect const& effect) const;
 		constexpr void for_each_contributing_modifier(
 			ModifierEffect const& effect, ContributingModifierCallback auto callback
@@ -695,7 +695,7 @@ namespace OpenVic {
 			return modifier_sum.for_each_contributing_modifier(effect, std::move(callback));
 		}
 
-		void update_gamestate(const Date today, MapInstance& map_instance);
+		void update_gamestate_after_map(const Date today);
 		void country_tick_before_map(
 			TypedSpan<good_index_t, char> reusable_goods_mask,
 			forwardable_span<

--- a/src/openvic-simulation/country/CountryInstanceManager.cpp
+++ b/src/openvic-simulation/country/CountryInstanceManager.cpp
@@ -292,16 +292,16 @@ bool CountryInstanceManager::apply_history_to_countries(InstanceManager& instanc
 	return ret;
 }
 
-void CountryInstanceManager::update_modifier_sums(const Date today, StaticModifierCache const& static_modifier_cache) {
-	for (CountryInstance& country : country_instances) {
-		country.update_modifier_sum(today, static_modifier_cache);
-	}
+void CountryInstanceManager::update_modifier_sums_before_map() {
+	thread_pool.process(work_t::COUNTRY_UPDATE_MODIFIER_SUMS_BEFORE_MAP);
 }
 
-void CountryInstanceManager::update_gamestate(const Date today, MapInstance& map_instance) {
-	for (CountryInstance& country : country_instances) {
-		country.update_gamestate(today, map_instance);
-	}
+void CountryInstanceManager::update_modifier_sums_after_map() {
+	thread_pool.process(work_t::COUNTRY_UPDATE_MODIFIER_SUMS_AFTER_MAP);
+}
+
+void CountryInstanceManager::update_gamestate_after_map(const Date today) {
+	thread_pool.process(work_t::COUNTRY_UPDATE_GAMESTATE_AFTER_MAP);
 
 	// TODO - work out how to have ranking effects applied (e.g. static modifiers) applied at game start
 	// we can't just move update_rankings to the top of this function as it will choose initial GPs based on
@@ -311,10 +311,10 @@ void CountryInstanceManager::update_gamestate(const Date today, MapInstance& map
 }
 
 void CountryInstanceManager::country_manager_tick_before_map() {
-	thread_pool.process_country_ticks_before_map();
+	thread_pool.process(work_t::COUNTRY_TICK_BEFORE_MAP);
 }
 
 void CountryInstanceManager::country_manager_tick_after_map() {
-	thread_pool.process_country_ticks_after_map();
+	thread_pool.process(work_t::COUNTRY_TICK_AFTER_MAP);
 	shared_country_values.update_costs();
 }

--- a/src/openvic-simulation/country/CountryInstanceManager.hpp
+++ b/src/openvic-simulation/country/CountryInstanceManager.hpp
@@ -18,10 +18,8 @@ namespace OpenVic {
 	struct CountryHistoryManager;
 	struct GoodInstanceManager;
 	struct InstanceManager;
-	struct MapInstance;
 	struct PopsDefines;
 	struct PopType;
-	struct StaticModifierCache;
 	struct ThreadPool;
 
 	struct CountryInstanceManager {
@@ -71,8 +69,9 @@ namespace OpenVic {
 
 		bool apply_history_to_countries(InstanceManager& instance_manager);
 
-		void update_modifier_sums(const Date today, StaticModifierCache const& static_modifier_cache);
-		void update_gamestate(const Date today, MapInstance& map_instance);
+		void update_modifier_sums_before_map();
+		void update_modifier_sums_after_map();
+		void update_gamestate_after_map(const Date today);
 		void country_manager_tick_before_map();
 		void country_manager_tick_after_map();
 	};

--- a/src/openvic-simulation/economy/trading/MarketInstance.cpp
+++ b/src/openvic-simulation/economy/trading/MarketInstance.cpp
@@ -78,7 +78,7 @@ void MarketInstance::place_market_sell_order(MarketSellOrder&& market_sell_order
 }
 
 void MarketInstance::execute_orders() {
-	thread_pool.process_good_execute_orders();
+	thread_pool.process(work_t::GOOD_EXECUTE_ORDERS);
 }
 
 void MarketInstance::record_price_history() {

--- a/src/openvic-simulation/map/MapInstance.cpp
+++ b/src/openvic-simulation/map/MapInstance.cpp
@@ -145,23 +145,17 @@ bool MapInstance::apply_history_to_provinces(
 	return ret;
 }
 
-void MapInstance::update_modifier_sums(const Date today, StaticModifierCache const& static_modifier_cache) {
-	for (ProvinceInstance& province : get_province_instances()) {
-		province.update_modifier_sum(today, static_modifier_cache);
-	}
-
-	for (ProvinceInstance& province : get_province_instances()) {
-		province.update_country_modifier_sum();
-	}
+void MapInstance::update_modifier_sums(const Date today) {
+	thread_pool.process(work_t::PROVINCE_UPDATE_MODIFIER_SUMS);
 }
 
-void MapInstance::update_gamestate(InstanceManager const& instance_manager) {
+void MapInstance::update_gamestate() {
 	highest_province_population = 0;
 	total_map_population = 0;
 
-	for (ProvinceInstance& province : get_province_instances()) {
-		province.update_gamestate(instance_manager);
+	thread_pool.process(work_t::PROVINCE_UPDATE_GAMESTATE);
 
+	for (ProvinceInstance& province : get_province_instances()) {
 		// Update population stats
 		const pop_sum_t province_population = province.get_total_population();
 		if (highest_province_population < province_population) {
@@ -174,13 +168,13 @@ void MapInstance::update_gamestate(InstanceManager const& instance_manager) {
 }
 
 void MapInstance::map_tick() {
-	thread_pool.process_province_ticks();
+	thread_pool.process(work_t::PROVINCE_TICK);
 	//state tick
 	//after province tick as province tick sets pop employment to 0
 	//state tick will update pop employment via factories
 }
 
-void MapInstance::initialise_for_new_game(InstanceManager const& instance_manager) {
-	update_gamestate(instance_manager);
-	thread_pool.process_province_initialise_for_new_game();
+void MapInstance::initialise_for_new_game() {
+	update_gamestate();
+	thread_pool.process(work_t::PROVINCE_INITIALISE_FOR_NEW_GAME);
 }

--- a/src/openvic-simulation/map/MapInstance.hpp
+++ b/src/openvic-simulation/map/MapInstance.hpp
@@ -85,9 +85,9 @@ namespace OpenVic {
 			TypedSpan<reform_index_t, const Reform> reforms
 		);
 
-		void update_modifier_sums(const Date today, StaticModifierCache const& static_modifier_cache);
-		void update_gamestate(InstanceManager const& instance_manager);
+		void update_modifier_sums(const Date today);
+		void update_gamestate();
 		void map_tick();
-		void initialise_for_new_game(InstanceManager const& instance_manager);
+		void initialise_for_new_game();
 	};
 }

--- a/src/openvic-simulation/map/ProvinceInstance.cpp
+++ b/src/openvic-simulation/map/ProvinceInstance.cpp
@@ -4,18 +4,26 @@
 
 #include <type_traits>
 
-#include "openvic-simulation/country/CountryDefinition.hpp"
 #include "openvic-simulation/country/CountryInstance.hpp"
+#include "openvic-simulation/country/CountryInstanceManager.hpp"
 #include "openvic-simulation/defines/MilitaryDefines.hpp"
-#include "openvic-simulation/DefinitionManager.hpp"
 #include "openvic-simulation/economy/BuildingInstance.hpp"
 #include "openvic-simulation/economy/BuildingType.hpp"
 #include "openvic-simulation/economy/production/Employee.hpp"
 #include "openvic-simulation/economy/production/ProductionType.hpp"
-#include "openvic-simulation/InstanceManager.hpp"
+#include "openvic-simulation/history/ProvinceHistory.hpp"
+#include "openvic-simulation/map/Crime.hpp"
+#include "openvic-simulation/map/MapInstance.hpp"
 #include "openvic-simulation/map/ProvinceDefinition.hpp"
+#include "openvic-simulation/map/Region.hpp"
+#include "openvic-simulation/map/TerrainType.hpp"
+#include "openvic-simulation/military/UnitInstanceGroup.hpp"
+#include "openvic-simulation/military/UnitType.hpp"
 #include "openvic-simulation/misc/GameRulesManager.hpp"
 #include "openvic-simulation/modifier/StaticModifierCache.hpp"
+#include "openvic-simulation/politics/Reform.hpp"
+#include "openvic-simulation/population/PopType.hpp"
+#include "openvic-simulation/population/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/ConstructorTags.hpp"
 #include "openvic-simulation/types/TypedIndices.hpp"
 
@@ -42,6 +50,8 @@ ProvinceInstance::ProvinceInstance(
 			}
 	}
 {
+	adjacencies.reserve(new_province_definition.get_adjacencies().size());
+	adjacent_nonempty_land_provinces.reserve(new_province_definition.get_adjacencies().size());
 	modifier_sum.set_this_source(this);
 	rgo.setup_location_ptr(*this);
 }
@@ -233,7 +243,7 @@ void ProvinceInstance::_update_pops(MilitaryDefines const& military_defines) {
 	normalise_pops_aggregate();
 }
 
-void ProvinceInstance::update_modifier_sum(Date today, StaticModifierCache const& static_modifier_cache) {
+void ProvinceInstance::update_modifier_sum(const Date today, StaticModifierCache const& static_modifier_cache) {
 	// Update sum of direct province modifiers
 	modifier_sum.clear();
 
@@ -288,9 +298,17 @@ void ProvinceInstance::update_modifier_sum(Date today, StaticModifierCache const
 	}
 }
 
-void ProvinceInstance::update_country_modifier_sum() {
-	if (controller != nullptr) {
-		controller->contribute_province_modifier_sum(modifier_sum);
+void ProvinceInstance::update_adjecencies() {
+	has_empty_adjacent_province = false;
+	// We assume there are no duplicate province adjacencies, so each adjacency.get_to() is unique in the loop below
+	adjacent_nonempty_land_provinces.clear();
+	for (const std::reference_wrapper<const ProvinceInstance> adjacency_wrapper : get_adjacencies()) {
+		ProvinceInstance const& adjacency = adjacency_wrapper.get();
+		if (adjacency.is_empty()) {
+			has_empty_adjacent_province = true;
+		} else if (!adjacency.province_definition.is_water()) {
+			adjacent_nonempty_land_provinces.emplace_back(adjacency);
+		}
 	}
 }
 
@@ -332,23 +350,8 @@ bool ProvinceInstance::convert_rgo_worker_pops_to_equivalent(
 	return is_valid_operation;
 }
 
-void ProvinceInstance::update_gamestate(InstanceManager const& instance_manager) {
-	has_empty_adjacent_province = false;
-	// We assume there are no duplicate province adjacencies, so each adjacency.get_to() is unique in the loop below
-	adjacent_nonempty_land_provinces.clear();
-
-	MapInstance const& map_instance = instance_manager.get_map_instance();
-	for (ProvinceDefinition::adjacency_t const& adjacency : province_definition.get_adjacencies()) {
-		ProvinceDefinition const& adjacent_to_definition = adjacency.get_to();
-		ProvinceInstance const& adjacent_to_instance = map_instance.get_province_instance_by_definition(adjacent_to_definition);
-
-		if (adjacent_to_instance.is_empty()) {
-			has_empty_adjacent_province = true;
-		} else if (!adjacent_to_definition.is_water()) {
-			adjacent_nonempty_land_provinces.emplace_back(adjacent_to_instance);
-		}
-	}
-
+void ProvinceInstance::update_gamestate(const Date today, MilitaryDefines const& military_defines) {
+	update_adjecencies();
 	land_regiment_count = 0;
 	for (ArmyInstance const& army : armies) {
 		land_regiment_count += army.get_unit_count();
@@ -363,12 +366,10 @@ void ProvinceInstance::update_gamestate(InstanceManager const& instance_manager)
 		occupation_duration = 0;
 	}
 
-	const Date today = instance_manager.get_today();
-
 	for (BuildingInstance& building : buildings) {
 		building.update_gamestate(today);
 	}
-	_update_pops(instance_manager.definition_manager.get_define_manager().get_military_defines());
+	_update_pops(military_defines);
 }
 
 void ProvinceInstance::province_tick(
@@ -504,6 +505,7 @@ bool ProvinceInstance::apply_history_to_province(ProvinceHistoryEntry const& ent
 
 void ProvinceInstance::initialise_for_new_game(
 	const Date today,
+	MapInstance const& map_instance,
 	PopValuesFromProvince& reusable_pop_values,
 	RandomU32& random_number_generator,
 	TypedSpan<good_index_t, char> reusable_goods_mask,
@@ -512,6 +514,12 @@ void ProvinceInstance::initialise_for_new_game(
 		VECTORS_FOR_PROVINCE_TICK
 	> reusable_vectors
 ) {
+	for (ProvinceDefinition::adjacency_t const& adjacency : province_definition.get_adjacencies()) {
+		ProvinceDefinition const& adjacent_to_definition = adjacency.get_to();
+		ProvinceInstance const& adjacent_to_instance = map_instance.get_province_instance_by_definition(adjacent_to_definition);
+		adjacencies.emplace_back(adjacent_to_instance);
+	}
+	update_adjecencies();		
 	initialise_rgo();
 	province_tick(
 		today,

--- a/src/openvic-simulation/map/ProvinceInstance.hpp
+++ b/src/openvic-simulation/map/ProvinceInstance.hpp
@@ -95,6 +95,7 @@ namespace OpenVic {
 		bool PROPERTY_RW(connected_to_capital, false);
 		bool PROPERTY_RW(is_overseas, false);
 		bool PROPERTY(has_empty_adjacent_province, false);
+		memory::vector<std::reference_wrapper<const ProvinceInstance>> SPAN_PROPERTY(adjacencies);
 		memory::vector<std::reference_wrapper<const ProvinceInstance>> SPAN_PROPERTY(adjacent_nonempty_land_provinces);
 		Crime const* PROPERTY_RW(crime, nullptr);
 		ResourceGatheringOperation PROPERTY(rgo);
@@ -123,6 +124,7 @@ namespace OpenVic {
 			ProductionType const& production_type
 		);
 		void initialise_rgo();
+		void update_adjecencies();
 
 		memory::FixedVector<
 			memory::vector<std::reference_wrapper<Pop>>,
@@ -188,9 +190,8 @@ namespace OpenVic {
 			PopDeps const& pop_deps
 		);
 		size_t get_pop_count() const;
+		void update_modifier_sum(const Date today, StaticModifierCache const& static_modifier_cache);
 
-		void update_modifier_sum(Date today, StaticModifierCache const& static_modifier_cache);
-		void update_country_modifier_sum();
 		fixed_point_t get_modifier_effect_value(ModifierEffect const& effect) const;
 
 		void for_each_contributing_modifier(ModifierEffect const& effect, ContributingModifierCallback auto callback) const {
@@ -205,7 +206,7 @@ namespace OpenVic {
 				get_owner_modifier_sum().for_each_contributing_modifier(effect, std::move(callback));
 			}
 		}
-		void update_gamestate(InstanceManager const& instance_manager);
+		void update_gamestate(const Date today, MilitaryDefines const& military_defines);
 		static constexpr size_t VECTORS_FOR_PROVINCE_TICK = std::max(
 			ResourceGatheringOperation::VECTORS_FOR_RGO_TICK,
 			Pop::VECTORS_FOR_POP_TICK
@@ -222,6 +223,7 @@ namespace OpenVic {
 		);
 		void initialise_for_new_game(
 			const Date today,
+			MapInstance const& map_instance,
 			PopValuesFromProvince& reusable_pop_values,
 			RandomU32& random_number_generator,
 			TypedSpan<good_index_t, char> reusable_goods_mask,

--- a/src/openvic-simulation/utility/ThreadDeps.hpp
+++ b/src/openvic-simulation/utility/ThreadDeps.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "openvic-simulation/types/TypedIndices.hpp"
+
+namespace OpenVic {
+	struct GameRulesManager;
+	struct GoodInstanceManager;
+	struct MapInstance;
+	struct MilitaryDefines;
+	struct ModifierEffectCache;
+	struct PopsDefines;
+	struct ProductionTypeManager;
+	struct StaticModifierCache;
+	
+	struct ThreadDeps {
+		GameRulesManager const& game_rules_manager;
+		GoodInstanceManager const& good_instance_manager;
+		MapInstance const& map_instance;
+		MilitaryDefines const& military_defines;
+		ModifierEffectCache const& modifier_effect_cache;
+		PopsDefines const& pop_defines;
+		ProductionTypeManager const& production_type_manager;
+		StaticModifierCache const& static_modifier_cache;
+		country_index_t country_count;
+		good_index_t good_count;
+		strata_index_t strata_count;
+	};
+}

--- a/src/openvic-simulation/utility/ThreadPool.cpp
+++ b/src/openvic-simulation/utility/ThreadPool.cpp
@@ -1,4 +1,5 @@
 #include "ThreadPool.hpp"
+#include "ThreadDeps.hpp"
 
 #include <array>
 #include <cstddef>
@@ -10,6 +11,7 @@
 #include "openvic-simulation/economy/GoodInstance.hpp"
 #include "openvic-simulation/economy/trading/GoodMarket.hpp"
 #include "openvic-simulation/map/ProvinceInstance.hpp"
+#include "openvic-simulation/population/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
 #include "openvic-simulation/types/TypedIndices.hpp"
 #include "openvic-simulation/types/TypedSpan.hpp"
@@ -18,20 +20,13 @@ using namespace OpenVic;
 
 void ThreadPool::loop_until_cancelled(
 	work_t& work_type,
-	GameRulesManager const& game_rules_manager,
-	GoodInstanceManager const& good_instance_manager,
-	ModifierEffectCache const& modifier_effect_cache,
-	PopsDefines const& pop_defines,
-	ProductionTypeManager const& production_type_manager,
-	forwardable_span<const CountryInstance> country_keys,
-	const good_index_t good_count,
-	const strata_index_t strata_count,
+	const ThreadDeps deps,
 	forwardable_span<WorkBundle> work_bundles
 ) {
-	memory::FixedVector<char, good_index_t> reusable_goods_mask { good_count, {} };
+	memory::FixedVector<char, good_index_t> reusable_goods_mask { deps.good_count, {} };
 
-	memory::FixedVector<fixed_point_t, country_index_t> reusable_country_map_0 { country_index_t(country_keys.size()), fixed_point_t::_0 };
-	memory::FixedVector<fixed_point_t, country_index_t> reusable_country_map_1 { country_index_t(country_keys.size()), fixed_point_t::_0 };
+	memory::FixedVector<fixed_point_t, country_index_t> reusable_country_map_0 { deps.country_count, fixed_point_t::_0 };
+	memory::FixedVector<fixed_point_t, country_index_t> reusable_country_map_1 { deps.country_count, fixed_point_t::_0 };
 
 	static constexpr std::size_t VECTOR_COUNT = std::max(
 		GoodMarket::VECTORS_FOR_EXECUTE_ORDERS,
@@ -44,12 +39,12 @@ void ThreadPool::loop_until_cancelled(
 	std::span<memory::vector<fixed_point_t>, VECTOR_COUNT> reusable_vectors_span = std::span(reusable_vectors);
 	memory::vector<good_index_t> reusable_good_index_vector;
 	PopValuesFromProvince reusable_pop_values {
-		game_rules_manager,
-		good_instance_manager,
-		modifier_effect_cache,
-		production_type_manager,
-		pop_defines,
-		strata_count
+		deps.game_rules_manager,
+		deps.good_instance_manager,
+		deps.modifier_effect_cache,
+		deps.production_type_manager,
+		deps.pop_defines,
+		deps.strata_count
 	};
 
 	while (!is_cancellation_requested) {
@@ -70,11 +65,11 @@ void ThreadPool::loop_until_cancelled(
 			work_type = work_t::NONE;
 		}
 
-		switch (work_type_copy) {
-			case work_t::NONE:
-				break;
-			case work_t::GOOD_EXECUTE_ORDERS:
-				for (WorkBundle& work_bundle : work_bundles) {
+		for (WorkBundle& work_bundle : work_bundles) {
+			switch (work_type_copy) {
+				case work_t::NONE:
+					break;
+				case work_t::GOOD_EXECUTE_ORDERS:
 					for (GoodMarket& good : work_bundle.goods_chunk) {
 						good.execute_orders(
 							reusable_country_map_0,
@@ -82,10 +77,8 @@ void ThreadPool::loop_until_cancelled(
 							reusable_vectors_span.first<GoodMarket::VECTORS_FOR_EXECUTE_ORDERS>()
 						);
 					}
-				}
-				break;
-			case work_t::PROVINCE_TICK:
-				for (WorkBundle& work_bundle : work_bundles) {
+					break;
+				case work_t::PROVINCE_TICK:
 					for (ProvinceInstance& province : work_bundle.provinces_chunk) {
 						province.province_tick(
 							current_date,
@@ -95,23 +88,20 @@ void ThreadPool::loop_until_cancelled(
 							reusable_vectors_span.first<ProvinceInstance::VECTORS_FOR_PROVINCE_TICK>()
 						);
 					}
-				}
-				break;
-			case work_t::PROVINCE_INITIALISE_FOR_NEW_GAME:
-				for (WorkBundle& work_bundle : work_bundles) {
+					break;
+				case work_t::PROVINCE_INITIALISE_FOR_NEW_GAME:
 					for (ProvinceInstance& province : work_bundle.provinces_chunk) {
 						province.initialise_for_new_game(
 							current_date,
+							deps.map_instance,
 							reusable_pop_values,
 							work_bundle.random_number_generator,
 							reusable_goods_mask,
 							reusable_vectors_span.first<ProvinceInstance::VECTORS_FOR_PROVINCE_TICK>()
 						);
 					}
-				}
-				break;
-			case work_t::COUNTRY_TICK_BEFORE_MAP:
-				for (WorkBundle& work_bundle : work_bundles) {
+					break;
+				case work_t::COUNTRY_TICK_BEFORE_MAP:
 					for (CountryInstance& country : work_bundle.countries_chunk) {
 						country.country_tick_before_map(
 							reusable_goods_mask,
@@ -119,15 +109,47 @@ void ThreadPool::loop_until_cancelled(
 							reusable_good_index_vector
 						);
 					}
-				}
-				break;
-			case work_t::COUNTRY_TICK_AFTER_MAP:
-				for (WorkBundle& work_bundle : work_bundles) {
+					break;
+				case work_t::COUNTRY_TICK_AFTER_MAP:
 					for (CountryInstance& country : work_bundle.countries_chunk) {
 						country.country_tick_after_map(current_date);
 					}
-				}
-				break;
+					break;
+				case work_t::PROVINCE_UPDATE_GAMESTATE:
+					for (ProvinceInstance& province : work_bundle.provinces_chunk) {
+						province.update_gamestate(
+							current_date,
+							deps.military_defines
+						);
+					}
+					break;
+				case work_t::COUNTRY_UPDATE_GAMESTATE_AFTER_MAP:
+					for (CountryInstance& country : work_bundle.countries_chunk) {
+						country.update_gamestate_after_map(current_date);
+					}
+					break;
+				case work_t::PROVINCE_UPDATE_MODIFIER_SUMS:
+					for (ProvinceInstance& province : work_bundle.provinces_chunk) {
+						province.update_modifier_sum(
+							current_date,
+							deps.static_modifier_cache
+						);
+					}
+					break;
+				case work_t::COUNTRY_UPDATE_MODIFIER_SUMS_BEFORE_MAP:
+					for (CountryInstance& country : work_bundle.countries_chunk) {
+						country.update_modifier_sum_before_map(
+							current_date,
+							deps.static_modifier_cache
+						);
+					}
+					break;
+				case work_t::COUNTRY_UPDATE_MODIFIER_SUMS_AFTER_MAP:
+					for (CountryInstance& country : work_bundle.countries_chunk) {
+						country.update_modifier_sum_after_map(current_date);
+					}
+					break;
+			}
 		}
 
 		{
@@ -139,7 +161,7 @@ void ThreadPool::loop_until_cancelled(
 	}
 }
 
-void ThreadPool::process_work(const work_t work_type) {
+void ThreadPool::process(const work_t work_type) {
 	{
 		std::unique_lock<std::mutex> thread_lock { thread_mutex };
 		if (is_cancellation_requested) {
@@ -184,12 +206,7 @@ ThreadPool::~ThreadPool() {
 }
 
 void ThreadPool::initialise_threadpool(
-	GameRulesManager const& game_rules_manager,
-	GoodInstanceManager const& good_instance_manager,
-	ModifierEffectCache const& modifier_effect_cache,
-	PopsDefines const& pop_defines,
-	ProductionTypeManager const& production_type_manager,
-	const strata_index_t strata_count,
+	ThreadDeps const& deps,
 	forwardable_span<GoodInstance> goods,
 	forwardable_span<CountryInstance> countries,
 	forwardable_span<ProvinceInstance> provinces
@@ -261,27 +278,13 @@ void ThreadPool::initialise_threadpool(
 			[
 				this,
 				&work_for_thread = work_per_thread[i],
-				&game_rules_manager,
-				&good_instance_manager,
-				&modifier_effect_cache,
-				&pop_defines,
-				&production_type_manager,
-				countries,
-				good_count = good_index_t(goods.size()),
-				strata_count,
+				deps,
 				work_bundles_begin,
 				work_bundles_end
 			]() -> void {
 				loop_until_cancelled(
 					work_for_thread,
-					game_rules_manager,
-					good_instance_manager,
-					modifier_effect_cache,
-					pop_defines,
-					production_type_manager,
-					countries,
-					good_count,
-					strata_count,
+					deps,
 					std::span<WorkBundle>{ work_bundles_begin, work_bundles_end }
 				);
 			}
@@ -289,24 +292,4 @@ void ThreadPool::initialise_threadpool(
 
 		work_bundles_begin = work_bundles_end;
 	}
-}
-
-void ThreadPool::process_good_execute_orders() {
-	process_work(work_t::GOOD_EXECUTE_ORDERS);
-}
-
-void ThreadPool::process_province_ticks() {
-	process_work(work_t::PROVINCE_TICK);
-}
-
-void ThreadPool::process_province_initialise_for_new_game() {
-	process_work(work_t::PROVINCE_INITIALISE_FOR_NEW_GAME);
-}
-
-void ThreadPool::process_country_ticks_before_map() {
-	process_work(work_t::COUNTRY_TICK_BEFORE_MAP);
-}
-
-void ThreadPool::process_country_ticks_after_map(){
-	process_work(work_t::COUNTRY_TICK_AFTER_MAP);
 }

--- a/src/openvic-simulation/utility/ThreadPool.hpp
+++ b/src/openvic-simulation/utility/ThreadPool.hpp
@@ -7,24 +7,17 @@
 #include <mutex>
 #include <thread>
 
-#include "openvic-simulation/population/PopValuesFromProvince.hpp"
 #include "openvic-simulation/core/memory/Vector.hpp"
 #include "openvic-simulation/core/portable/ForwardableSpan.hpp"
 #include "openvic-simulation/core/random/RandomGenerator.hpp"
 #include "openvic-simulation/population/PopValuesFromProvince.hpp"
 #include "openvic-simulation/types/Date.hpp"
-#include "openvic-simulation/types/TypedIndices.hpp"
 
 namespace OpenVic {
-	struct GameRulesManager;
-	struct GoodDefinition;
-	struct GoodInstanceManager;
 	struct CountryInstance;
 	struct GoodInstance;
-	struct ModifierEffectCache;
-	struct PopsDefines;
-	struct ProductionTypeManager;
-	struct Strata;
+	struct ProvinceInstance;
+	struct ThreadDeps;
 	
 	//bundle work so they always have the same rng regardless of hardware concurrency
 	struct WorkBundle {
@@ -47,18 +40,23 @@ namespace OpenVic {
 			provinces_chunk { new_provinces_chunk }
 			{}
 	};
+	
+	enum struct work_t : uint8_t {
+		NONE,
+		GOOD_EXECUTE_ORDERS,
+		PROVINCE_INITIALISE_FOR_NEW_GAME,
+		PROVINCE_TICK,
+		COUNTRY_TICK_BEFORE_MAP,
+		COUNTRY_TICK_AFTER_MAP,
+		PROVINCE_UPDATE_GAMESTATE,
+		COUNTRY_UPDATE_GAMESTATE_AFTER_MAP,
+		PROVINCE_UPDATE_MODIFIER_SUMS,
+		COUNTRY_UPDATE_MODIFIER_SUMS_BEFORE_MAP,
+		COUNTRY_UPDATE_MODIFIER_SUMS_AFTER_MAP
+	};
 
 	struct ThreadPool {
 	private:
-		enum struct work_t : uint8_t {
-			NONE,
-			GOOD_EXECUTE_ORDERS,
-			PROVINCE_INITIALISE_FOR_NEW_GAME,
-			PROVINCE_TICK,
-			COUNTRY_TICK_BEFORE_MAP,
-			COUNTRY_TICK_AFTER_MAP
-		};
-
 		constexpr static std::size_t WORK_BUNDLE_COUNT = 32;
 		std::array<WorkBundle, WORK_BUNDLE_COUNT> all_work_bundles;
 		memory::vector<std::thread> threads;
@@ -71,39 +69,21 @@ namespace OpenVic {
 
 		void loop_until_cancelled(
 			work_t& work_type,
-			GameRulesManager const& game_rules_manager,
-			GoodInstanceManager const& good_instance_manager,
-			ModifierEffectCache const& modifier_effect_cache,
-			PopsDefines const& pop_defines,
-			ProductionTypeManager const& production_type_manager,
-			forwardable_span<const CountryInstance> country_keys,
-			const good_index_t good_count,
-			const strata_index_t strata_count,
+			const ThreadDeps deps,
 			forwardable_span<WorkBundle> work_bundles
 		);
 		void await_completion();
-		void process_work(const work_t work_type);
 
 	public:
 		ThreadPool(Date const& new_current_date);
 		~ThreadPool();
 
 		void initialise_threadpool(
-			GameRulesManager const& game_rules_manager,
-			GoodInstanceManager const& good_instance_manager,
-			ModifierEffectCache const& modifier_effect_cache,
-			PopsDefines const& pop_defines,
-			ProductionTypeManager const& production_type_manager,
-			const strata_index_t strata_count,
+			ThreadDeps const& deps,
 			forwardable_span<GoodInstance> goods,
 			forwardable_span<CountryInstance> countries,
 			forwardable_span<ProvinceInstance> provinces
 		);
-
-		void process_good_execute_orders();
-		void process_province_ticks();
-		void process_province_initialise_for_new_game();
-		void process_country_ticks_before_map();
-		void process_country_ticks_after_map();
+		void process(const work_t work_type);
 	};
 }


### PR DESCRIPTION
Stacked on top of #739 

Note updating adjecencies inside the country is commented out.
This really should've never been placed there as recalculating it is expensive and can't be multithreaded easily.
Also the outcome rarely changes. It can only change when provinces change owner or our capital changes province.