### PR TITLE
Fix perf test timing

### DIFF
--- a/src/headless/main.cpp
+++ b/src/headless/main.cpp
@@ -326,7 +326,7 @@ static bool run_headless(fs::path const& root, memory::vector<memory::string>& m
 		size_t ticks_passed = 0;
 		test_duration_t min_tick_duration = test_duration_t::max(), //
 			max_tick_duration = test_duration_t::min(), //
-			total_tick_duration;
+			total_tick_duration {};
 		const test_time_point_t start_time = testing_clock_t::now();
 		while (++ticks_passed < TICK_COUNT) {
 			const test_time_point_t tick_start = testing_clock_t::now();


### PR DESCRIPTION
For example `[2026-05-19 13:06:18.563] [info] Ran 10 / 10 ticks, total time 457989300ns at 45798930ns per tick, tick time only 2125402126320ns at 212540212632ns per tick. Tick lengths ranged from 46314900ns to 55808300ns.`

Total time > tick time only, which doesn't make sense.
It's due to total_tick_duration never being properly initialised.