### PR TITLE
Use spin mutex for goods and countries

### DIFF
--- a/src/openvic-simulation/country/CountryInstance.cpp
+++ b/src/openvic-simulation/country/CountryInstance.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <mutex>
 
 #include <type_safe/strong_typedef.hpp>
 
@@ -2407,11 +2408,11 @@ void CountryInstance::country_tick_after_map(const Date today) {
 }
 
 CountryInstance::good_data_t::good_data_t()
-	: mutex { memory::make_unique<std::mutex>() }
+	: mutex { memory::make_unique<spin_mutex>() }
 	{ }
 
 void CountryInstance::good_data_t::clear_daily_recorded_data() {
-	const std::lock_guard<std::mutex> lock_guard { *mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *mutex };
 	stockpile_change_yesterday
 		= quantity_traded_yesterday
 		= money_traded_yesterday
@@ -2431,24 +2432,24 @@ void CountryInstance::good_data_t::clear_daily_recorded_data() {
 }
 
 void CountryInstance::report_pop_income_tax(PopType const& pop_type, const fixed_point_t gross_income, const fixed_point_t paid_as_tax) {
-	const std::lock_guard<std::mutex> lock_guard { taxable_income_mutex };
+	const std::lock_guard<spin_mutex> lock_guard { taxable_income_mutex };
 	taxable_income_by_pop_type.at(pop_type) += gross_income;
 	cash_stockpile += paid_as_tax;
 }
 
 void CountryInstance::report_pop_need_consumption(PopType const& pop_type, const good_index_t good_index, const fixed_point_t quantity) {
 	good_data_t& good_data = goods_data.at_index(good_index);
-	const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 	good_data.need_consumption_per_pop_type[&pop_type] += quantity;
 }
 void CountryInstance::report_pop_need_demand(PopType const& pop_type, const good_index_t good_index, const fixed_point_t quantity) {
 	good_data_t& good_data = goods_data.at_index(good_index);
-	const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 	good_data.pop_demand += quantity;
 }
 void CountryInstance::report_input_consumption(ProductionType const& production_type, const good_index_t good_index, const fixed_point_t quantity) {
 	good_data_t& good_data = goods_data.at_index(good_index);
-	const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 	good_data.input_consumption_per_production_type[&production_type] += quantity;
 }
 void CountryInstance::report_input_demand(ProductionType const& production_type, const good_index_t good_index, const fixed_point_t quantity) {
@@ -2458,7 +2459,7 @@ void CountryInstance::report_input_demand(ProductionType const& production_type,
 		switch (game_rules_manager.get_artisanal_input_demand_category()) {
 			case demand_category::FactoryNeeds: break;
 			case demand_category::PopNeeds: {
-				const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+				const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 				good_data.pop_demand += quantity;
 				return;
 			}
@@ -2466,12 +2467,12 @@ void CountryInstance::report_input_demand(ProductionType const& production_type,
 		}
 	}
 
-	const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 	good_data.factory_demand += quantity;
 }
 void CountryInstance::report_output(ProductionType const& production_type, const fixed_point_t quantity) {
 	good_data_t& good_data = get_good_data(production_type.output_good);
-	const std::lock_guard<std::mutex> lock_guard { *good_data.mutex };
+	const std::lock_guard<spin_mutex> lock_guard { *good_data.mutex };
 	good_data.production_per_production_type[&production_type] += quantity;
 }
 

--- a/src/openvic-simulation/country/CountryInstance.hpp
+++ b/src/openvic-simulation/country/CountryInstance.hpp
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <functional>
-#include <mutex>
 #include <utility>
 
 #include <fmt/base.h>
 
 #include "openvic-simulation/core/memory/SmartPtr.hpp"
 #include "openvic-simulation/core/memory/Vector.hpp"
+#include "openvic-simulation/core/thread/SpinMutex.hpp"
 #include "openvic-simulation/diplomacy/CountryRelation.hpp"
 #include "openvic-simulation/economy/BuildingLevel.hpp"
 #include "openvic-simulation/economy/BuildingRestrictionCategory.hpp"
@@ -168,7 +168,7 @@ namespace OpenVic {
 		ValueHistory<fixed_point_t> PROPERTY(balance_history);
 		OV_STATE_PROPERTY(fixed_point_t, gold_income);
 		atomic_fixed_point_t PROPERTY(cash_stockpile);
-		std::mutex taxable_income_mutex;
+		spin_mutex taxable_income_mutex;
 		OV_IFLATMAP_PROPERTY(PopType, fixed_point_t, taxable_income_by_pop_type);
 		OV_STATE_PROPERTY(fixed_point_t, tax_efficiency);
 		IndexedFlatMap<Strata, DerivedState<fixed_point_t>> PROPERTY(effective_tax_rate_by_strata);
@@ -304,7 +304,7 @@ namespace OpenVic {
 
 		/* Trade */
 		struct good_data_t {
-			memory::unique_ptr<std::mutex> mutex;
+			memory::unique_ptr<spin_mutex> mutex;
 			fixed_point_t stockpile_amount;
 			fixed_point_t stockpile_change_yesterday; // positive if we gained, negative if we lost
 			fixed_point_t quantity_traded_yesterday; // positive if we bought, negative if we sold

--- a/src/openvic-simulation/economy/trading/GoodMarket.cpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.cpp
@@ -1,5 +1,7 @@
 #include "GoodMarket.hpp"
+
 #include <algorithm>
+#include <mutex>
 
 #include "openvic-simulation/economy/GoodDefinition.hpp"
 #include "openvic-simulation/economy/trading/BuyUpToOrder.hpp"
@@ -56,12 +58,12 @@ void GoodMarket::update_next_price_limits() {
 }
 
 void GoodMarket::add_buy_up_to_order(GoodBuyUpToOrder&& buy_up_to_order) {
-	const std::lock_guard<std::mutex> lock_guard { buy_lock };
+	const std::lock_guard<spin_mutex> lock_guard { buy_lock };
 	buy_up_to_orders.push_back(std::move(buy_up_to_order));
 }
 
 void GoodMarket::add_market_sell_order(GoodMarketSellOrder&& market_sell_order) {
-	const std::lock_guard<std::mutex> lock_guard { sell_lock };
+	const std::lock_guard<spin_mutex> lock_guard { sell_lock };
 	market_sell_orders.push_back(std::move(market_sell_order));
 }
 

--- a/src/openvic-simulation/economy/trading/GoodMarket.hpp
+++ b/src/openvic-simulation/economy/trading/GoodMarket.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <mutex>
 #include <span>
 
 #include "openvic-simulation/core/memory/Vector.hpp"
+#include "openvic-simulation/core/thread/SpinMutex.hpp"
 #include "openvic-simulation/economy/trading/BuyUpToOrder.hpp"
 #include "openvic-simulation/economy/trading/MarketSellOrder.hpp"
 #include "openvic-simulation/types/fixed_point/FixedPoint.hpp"
@@ -19,8 +19,8 @@ namespace OpenVic {
 	struct GoodMarket {
 	private:
 		static constexpr int32_t exponential_price_change_shift = 7;
-		std::mutex buy_lock;
-		std::mutex sell_lock;
+		spin_mutex buy_lock;
+		spin_mutex sell_lock;
 		GameRulesManager const& game_rules_manager;
 		fixed_point_t absolute_maximum_price;
 		fixed_point_t absolute_minimum_price;


### PR DESCRIPTION
Due to parallel processing all sorts of actors (RGOs, artisans, pops, countries, etc) place their orders on the market concurrently.
This requires a mutex to coordinate. As the action inside the lock is minor, the lock is quickly released. Spin waiting seems to be faster in this case.

`[2026-05-20 22:53:21.616] [info] Ran 1000 / 1000 ticks, total time 55887416600ns at 55887416ns per tick, tick time only 55885235600ns at 55885235ns per tick. Tick lengths ranged from 44021500ns to 516810600ns.`