### PR TITLE
Fix width of strong typed integers

### DIFF
--- a/src/openvic-simulation/population/PopIdInProvince.hpp
+++ b/src/openvic-simulation/population/PopIdInProvince.hpp
@@ -5,14 +5,18 @@
 #include <fmt/base.h>
 #include <fmt/format.h>
 
+#include <type_safe/narrow_cast.hpp>
 #include <type_safe/strong_typedef.hpp>
 
 namespace OpenVic {
-	struct pop_id_in_province_t : type_safe::strong_typedef<pop_id_in_province_t, std::size_t>,
+	struct pop_id_in_province_t : type_safe::strong_typedef<pop_id_in_province_t, std::uint16_t>,
 		type_safe::strong_typedef_op::equality_comparison<pop_id_in_province_t>,
 		type_safe::strong_typedef_op::relational_comparison<pop_id_in_province_t>,
 		type_safe::strong_typedef_op::integer_arithmetic<pop_id_in_province_t> {
 		using strong_typedef::strong_typedef;
+
+		constexpr pop_id_in_province_t(const std::size_t i)
+			: pop_id_in_province_t(type_safe::narrow_cast<std::uint16_t>(i)) {} \
 
 		constexpr bool is_null() const { return type_safe::get(*this) == 0; }
     	constexpr bool operator!() const { return is_null(); }
@@ -23,8 +27,8 @@ namespace std {
 	struct hash<OpenVic::pop_id_in_province_t> : type_safe::hashable<OpenVic::pop_id_in_province_t> {};
 }
 template<>
-struct fmt::formatter<OpenVic::pop_id_in_province_t> : fmt::formatter<std::size_t> {
+struct fmt::formatter<OpenVic::pop_id_in_province_t> : fmt::formatter<std::uint16_t> {
 	fmt::format_context::iterator format(OpenVic::pop_id_in_province_t const& value, fmt::format_context& ctx) const {
-		return fmt::formatter<std::size_t>::format(type_safe::get(value), ctx);
+		return fmt::formatter<std::uint16_t>::format(type_safe::get(value), ctx);
 	}
 };

--- a/src/openvic-simulation/types/TypedIndices.hpp
+++ b/src/openvic-simulation/types/TypedIndices.hpp
@@ -6,6 +6,7 @@
 #include <fmt/base.h>
 #include <fmt/format.h>
 
+#include <type_safe/narrow_cast.hpp>
 #include <type_safe/strong_typedef.hpp>
 
 #define TYPED_INDEX_CUSTOM(name, base_type) \
@@ -15,6 +16,7 @@
 			type_safe::strong_typedef_op::relational_comparison<name>, \
 			type_safe::strong_typedef_op::integer_arithmetic<name> { \
 			using strong_typedef::strong_typedef; \
+			constexpr name(const std::size_t i) : name(type_safe::narrow_cast<base_type>(i)) {} \
 		}; \
 	} \
 	namespace std { \
@@ -27,7 +29,7 @@
 			return fmt::formatter<base_type>::format(type_safe::get(value), ctx); \
 		} \
 	};
-#define TYPED_INDEX(name) TYPED_INDEX_CUSTOM(name, std::size_t)
+#define TYPED_INDEX(name) TYPED_INDEX_CUSTOM(name, std::uint16_t)
 
 TYPED_INDEX(bookmark_index_t)
 TYPED_INDEX(building_type_index_t)


### PR DESCRIPTION
All of our indices fit within uint16_t. We want to avoid size_t as it is platform dependent and causes issues for macos in godot.