### PR TITLE
Limit .gitignore of build directory to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ compile_commands.json
 src/openvic-simulation/testing/test_results/results.txt
 
 # Out-of-source build directory
-build/
+/build/
 
 # ccls
 .ccls-cache


### PR DESCRIPTION
- Waiting on OpenVicProject/OpenVic-Dataloader#109 and OpenVicProject/lexy-vdf#35

VSCode uses .gitignore to hide directories, without this change this includes `scripts/build`, making it impossible to open or search the directory inside VSCode.