### PR TITLE
Normalize action inputs and tighten required fields

### DIFF
--- a/.github/actions/openvic-sim-build/action.yml
+++ b/.github/actions/openvic-sim-build/action.yml
@@ -4,38 +4,28 @@ description: Setup and Build OpenVic-Simulation with the provided options
 inputs:
   identifier:
     description: Identifier of this build
-    type: string
+    required: true
   target:
-    description: Target type to build for
-    type: choice
-    options: [template_release, template_debug, editor]
+    description: Target type to build for (template_release, template_debug, editor)
+    required: true
   platform:
-    description: Platform to build for
-    type: choice
-    options: [windows, linux, macos]
+    description: Platform to build for (windows, linux, macos)
+    required: true
   arch:
-    description: Architecture to build for
-    type: choice
-    options: [x86_64, universal]
+    description: Architecture to build for (x86_32, x86_64, universal)
+    required: true
   scons-flags:
     description: Additional flags to send to SCons
-    required: false
     default: 'build_ovsim_benchmarks=yes'
-    type: string
   build-library:
     description: Whether to build the library file
-    default: true
-    type: boolean
+    default: 'true'
   cache-base-branch:
-    description: |
-      Branch to base the cache upon
-    required: false
+    description: Branch to base the cache upon
     default: 'master'
-    type: string
   disable-cache:
     description: Whether to disable the build cache
-    default: false
-    type: boolean
+    default: 'false'
 
 runs:
   using: composite

--- a/.github/actions/openvic-sim-release/action.yml
+++ b/.github/actions/openvic-sim-release/action.yml
@@ -5,45 +5,35 @@ inputs:
   tag-name:
     description: 'Name to assign to the tag (default: github.ref)'
     default: ${{ github.ref }}
-    type: string
   target-repo:
     description: Repository to publish this release to
     default: 'OpenVic-Simulation'
-    type: string
   to-ref:
     description: 'Tag/Commit to publish this release to (default: github.ref)'
     default: ${{ github.ref }}
-    type: string
   from-ref:
     description: Tag/Commit to source the release notes from
-    type: string
     required: true
   from-tag:
     description: 'Tag name being sourced from (default: from-ref)'
     default: ''
-    type: string
   nightly-release:
     description: Whether the release is a nightly build
-    type: boolean
-    default: false
+    default: 'false'
   snapshot-release:
     description: Whether the release is a snapshot release
-    type: boolean
-    default: false
+    default: 'false'
   latest:
     description: Latest
-    type: boolean
-    default: false
+    default: 'false'
   prerelease:
     description: Pre-release
-    type: boolean
     required: true
   src-token:
     description: Github token for source repository
     required: true
   target-token:
     description: Github token for target repository
-    required: false
     default: ''
 
 runs:


### PR DESCRIPTION
Make several inputs explicit/required and simplify types in GitHub Action metadata:
- Mark identifier, target, platform, arch as required
- Replace choice value with suggestions in description strings for target/platform/arch
- Expand arch suggestion to include x86_32
- Convert boolean inputs to string defaults ('true'/'false')
- Remove superfluous `required: false` input values