### PR TITLE
Apply clang-tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,19 +1,28 @@
 Checks:
   - -*
+  - bugprone-use-after-move
   - cppcoreguidelines-pro-type-member-init
+  - modernize-deprecated-headers
   - modernize-redundant-void-arg
   - modernize-use-bool-literals
   - modernize-use-default-member-init
   - modernize-use-nullptr
+  - performance-move-const-arg
   - readability-braces-around-statements
+  - readability-identifier-naming
+  - readability-operators-representation
   - readability-redundant-member-init
-HeaderFileExtensions: ['', h, hh, hpp, hxx, inc]
+HeaderFileExtensions: ["", h, hh, hpp, hxx, inc]
 ImplementationFileExtensions: [c, cc, cpp, cxx]
 HeaderFilterRegex: (extension/src/openvic-extension)/
 FormatStyle: file
 CheckOptions:
   cppcoreguidelines-pro-type-member-init.IgnoreArrays: true
   cppcoreguidelines-pro-type-member-init.UseAssignment: true
+  modernize-deprecated-headers.CheckHeaderFile: true
   modernize-use-bool-literals.IgnoreMacros: false
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
+  readability-identifier-naming.ParameterCase: lower_case
+  readability-operators-representation.BinaryOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="
+  readability-operators-representation.OverloadedOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,8 @@ repos:
             --fix,
             --quiet,
             --use-color,
-            -p=compile_commands.json,
+            -p=out/build,
             -extra-arg=-Wno-unknown-warning-option,
-            -checks=-modernize-use-bool-literals,
           ]
         types_or: [text]
         additional_dependencies: [clang-tidy==22.1.8]

--- a/src/openvic-simulation/economy/production/FactoryProducer.cpp
+++ b/src/openvic-simulation/economy/production/FactoryProducer.cpp
@@ -38,7 +38,7 @@ FactoryProducer::FactoryProducer(
 	days_without_input { new_days_without_input },
 	hiring_priority { new_hiring_priority },
 	profit_history_current { new_profit_history_current },
-	daily_profit_history { std::move(new_daily_profit_history) } {}
+	daily_profit_history { new_daily_profit_history } {}
 
 FactoryProducer::FactoryProducer(ProductionType const& new_production_type, fixed_point_t new_size_multiplier)
 	: FactoryProducer { new_production_type, new_size_multiplier, 0, 0, 0, {}, {}, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {} } {}

--- a/src/openvic-simulation/politics/BaseIssue.cpp
+++ b/src/openvic-simulation/politics/BaseIssue.cpp
@@ -11,5 +11,5 @@ BaseIssue::BaseIssue(
 	modifier_type_t new_type
 ) : Modifier { new_identifier, std::move(new_values), new_type },
 	HasColour { new_colour, false },
-	rules { std::move(new_rules) },
+	rules { new_rules },
 	is_jingoism { new_is_jingoism } {}

--- a/src/openvic-simulation/research/Technology.cpp
+++ b/src/openvic-simulation/research/Technology.cpp
@@ -35,7 +35,7 @@ Technology::Technology(
 	cost { new_cost },
 	index_in_area { new_index_in_area },
 	unciv_military { new_unciv_military },
-	unit_variant { std::move(new_unit_variant) },
+	unit_variant { new_unit_variant },
 	activated_units { std::move(new_activated_units) },
 	activated_buildings { std::move(new_activated_buildings) },
 	ai_chance { std::move(new_ai_chance) } {}

--- a/tests/src/core/error/ErrorSet.cpp
+++ b/tests/src/core/error/ErrorSet.cpp
@@ -30,7 +30,7 @@ TEST_CASE("ErrorSet Constructor methods", "[ErrorSet][ErrorSet-constructor]") {
 	CHECK(set_4[Error::BUG]);
 	CHECK_FALSE(set_4[Error::FAILED]);
 
-	ErrorSet set_5 = std::move(set_4);
+	ErrorSet set_5 = set_4;
 
 	CHECK(set_5.any());
 	CHECK(set_5[Error::BUG]);

--- a/tests/src/ecs/MultiSystemMixedStage.cpp
+++ b/tests/src/ecs/MultiSystemMixedStage.cpp
@@ -82,10 +82,10 @@ ECS_SYSTEM(MmsWriteDSerial)
 namespace {
 	// Common fixture: N entities each carrying Seed + all four writable components.
 	// Returns the created entity ids in insertion order.
-	std::vector<EntityID> seed_world(World& world, std::size_t N) {
+	std::vector<EntityID> seed_world(World& world, std::size_t n) {
 		std::vector<EntityID> ids;
-		ids.reserve(N);
-		for (std::size_t i = 0; i < N; ++i) {
+		ids.reserve(n);
+		for (std::size_t i = 0; i < n; ++i) {
 			ids.push_back(world.create_entity(
 				MmsSeed { static_cast<int64_t>(i + 1) },
 				MmsA {}, MmsB {}, MmsC {}, MmsD {}
@@ -214,10 +214,10 @@ TEST_CASE("Mixed stage with 2 SystemThreaded + 2 plain System<> all correct",
 // ============================================================================
 
 namespace {
-	int64_t run_mixed_and_digest(uint32_t worker_count, std::size_t N, int ticks) {
+	int64_t run_mixed_and_digest(uint32_t worker_count, std::size_t n, int ticks) {
 		World world;
 		world.set_ecs_worker_count(worker_count);
-		std::vector<EntityID> ids = seed_world(world, N);
+		std::vector<EntityID> ids = seed_world(world, n);
 
 		world.register_system<MmsWriteAThreaded>();
 		world.register_system<MmsWriteBThreaded>();


### PR DESCRIPTION
Fix .pre-commit-config.yaml clang-tidy hook arguments
Add checks to .clang-tidy:
- bugprone-use-after-move
- modernize-deprecated-headers
- performance-move-const-arg
- readability-identifier-naming
- readability-operators-representation